### PR TITLE
Fixed setup.py version import bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import setup, find_packages
 sys.path.append('inbox/')
-from _version import __VERSION__
+from inbox._version import __VERSION__
 
 
 def main():


### PR DESCRIPTION
Before changing this, `pip install nylas` would throw the following error:

Collecting nylas
  Downloading nylas-0.2.7.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/0v/n_kwg1kd41z153jfhcgktbrw0000gn/T/pip-build-s1YBGZ/nylas/setup.py", line 6, in <module>
        from _version import __VERSION__
    ImportError: cannot import name __VERSION__
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0v/n_kwg1kd41z153jfhcgktbrw0000gn/T/pip-build-s1YBGZ/nylas