### PR TITLE
Updated client.py to support url lib error in Py3

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -1,7 +1,10 @@
 import sys
 import requests
 import json
-from urllib import urlencode
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
 from os import environ
 from base64 import b64encode
 from six.moves.urllib.parse import urlencode


### PR DESCRIPTION
Python3 has moved the urlparse into a submodule, fixing that.