### PR TITLE
Fixes a bug in using offset parameter queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ We have a three-step process for releasing a new version of the Python SDK. Reme
    Run the tests:
    
    ```shell
-   PYTHONPATH=/your-sdk-path python tests/oauth.py
-   PYTHONPATH=/your-sdk-path python tests/system.py
+   PYTHONPATH=/your-sdk-path py.test tests/oauth.py
+   PYTHONPATH=/your-sdk-path py.test tests/system.py
    ```
    
 3. Finally, you can create a new release by doing:

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -20,7 +20,7 @@ class RestfulModelCollection(object):
         return self.items()
 
     def items(self):
-        offset = 0
+        offset = self.filters['offset']
         while True:
             items = self._get_model_collection(offset, CHUNK_SIZE)
             if not items:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import random
 import responses
 import httpretty
 from httpretty import Response
@@ -59,3 +60,45 @@ def test_two_filters(api_client):
     assert qs['param1'][0] == 'a'
     assert qs['param2'][0] == 'b'
     httpretty.disable()
+
+def test_no_offset(api_client):
+    httpretty.enable()
+
+    values = [Response(status=200, body='[]')]
+    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas', responses=values)
+    events = api_client.events.where({'in': 'Nylas'}).items()
+    for event in events:
+      pass
+    qs = httpretty.last_request().querystring
+    assert qs['in'][0] == 'Nylas'
+    assert qs['offset'][0] == '0'
+    httpretty.disable()
+
+def test_zero_offset(api_client):
+    httpretty.enable()
+
+    values = [Response(status=200, body='[]')]
+    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas&offset=0', responses=values)
+    events = api_client.events.where({'in': 'Nylas', 'offset': 0}).items()
+    for event in events:
+      pass
+    qs = httpretty.last_request().querystring
+    assert qs['in'][0] == 'Nylas'
+    assert qs['offset'][0] == '0'
+    httpretty.disable()
+
+def test_non_zero_offset(api_client):
+    httpretty.enable()
+
+    offset = random.randint(1,1000)
+    values = [Response(status=200, body='[]')]
+    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas&offset=' +
+                           str(offset), responses=values)
+    events = api_client.events.where({'in': 'Nylas', 'offset': offset}).items()
+    for event in events:
+      pass
+    qs = httpretty.last_request().querystring
+    assert qs['in'][0] == 'Nylas'
+    assert qs['offset'][0] == str(offset)
+    httpretty.disable()
+


### PR DESCRIPTION
Offset is always set to 0 by default. This handles the case where an explicit offset is provided and the **items()** method is called on a Restful Collection.

```
from nylas import APIClient

client = APIClient(None, None, "XXXXX")

for thread in client.threads.where({"in": "Nylas", "limit": 1, "offset": 0}).items():
  print(thread.id)
```

- Verified providing no offset param, and explicitly setting offset to 0 produce the same result.
- Verified that any other offset value result in the corresponding message with correct offset.