### PR TITLE
Fix Event.as_json to prevent mutation of `Event`

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -408,9 +408,13 @@ class Event(NylasAPIObject):
     def as_json(self):
         dct = NylasAPIObject.as_json(self)
         # Filter some parameters we got from the API
-        if 'when' in dct:
-            if 'object' in dct['when']:
-                del dct['when']['object']
+        if dct.get('when'):
+            # Currently, the event (self) and the dict (dct) share the same
+            # reference to the `'when'` dict.  We need to clone the dict so
+            # that when we remove the object key, the original event's
+            # `'when'` reference is unmodified.
+            dct['when'] = dct['when'].copy()
+            dct['when'].pop('object', None)
 
         return dct
 


### PR DESCRIPTION
Currently, If I try to get an `Event` as json, then the event will thereafter have the `event.when['object']` removed.  e.g.

```py
event = client.events.find(event_id)
print(event.when['object'])
json_event = event.as_json()
print(event.when['object'])  # KeyError!  Snap!
```

* Also, I decided to use `dict.pop(key, None)` instead of `if key in d: del d[key]` because it looks nicer (IMHO)
* and `if d.get(key)` rather than `if key in d` since the first one will work as we expect if `d[key] == None` whereas the latter won't.