### PR TITLE
Measure code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = nylas

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 python:
   - "2.7"
-install: "python setup.py install"
+install:
+  - "python setup.py install"
+  - "travis_retry pip install codecov"
 script: "python setup.py test"
+after_success:
+  - "codecov"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Nylas REST API Python bindings ![Travis build status](https://travis-ci.org/nylas/nylas-python.svg?branch=master)
+# Nylas REST API Python bindings ![Travis build status](https://travis-ci.org/nylas/nylas-python.svg?branch=master) [![Code Coverage](https://codecov.io/gh/nylas/nylas-python/branch/master/graph/badge.svg)](https://codecov.io/gh/nylas/nylas-python)
+
 
 Python bindings for the Nylas REST API. https://www.nylas.com/docs
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = '--junitxml ./tests/output tests/'
+        self.pytest_args = '--cov --junitxml ./tests/output tests/'
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -56,7 +56,7 @@ def main():
             "pyasn1",
         ],
         dependency_links=[],
-        tests_require=["pytest", "coverage", "responses", "httpretty"],
+        tests_require=["pytest", "pytest-cov", "responses", "httpretty"],
         cmdclass={'test': PyTest},
         author="Nylas Team",
         author_email="support@nylas.com",


### PR DESCRIPTION
This change will make Travis CI generate code coverage information for every build, and upload it to [Codecov](https://codecov.io). It also adds a badge to the README, so that it's easy to see the current coverage percentage of the codebase.