### PR TITLE
Turn API_URL into a fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,19 @@ import pytest
 import responses
 from nylas import APIClient
 
-API_URL = 'http://localhost:2222'
+
+@pytest.fixture
+def api_url():
+    return 'http://localhost:2222'
 
 
 @pytest.fixture
-def api_client():
-    return APIClient(None, None, None, API_URL)
+def api_client(api_url):
+    return APIClient(None, None, None, api_url)
 
 
 @pytest.fixture
-def mock_account():
+def mock_account(api_url):
     response_body = json.dumps([
         {
             "account_id": "4dl0ni6vxomazo73r5ozdo16j",
@@ -24,14 +27,14 @@ def mock_account():
             "provider": "gmail"
         }
     ])
-    responses.add(responses.GET, API_URL + '/n?limit=1&offset=0',
+    responses.add(responses.GET, api_url + '/n?limit=1&offset=0',
                   content_type='application/json', status=200,
                   body=response_body, match_querystring=True)
 
 
 @pytest.fixture
-def mock_save_draft():
-    save_endpoint = re.compile(API_URL + '/drafts/')
+def mock_save_draft(api_url):
+    save_endpoint = re.compile(api_url + '/drafts/')
     response_body = json.dumps({
         "id": "4dl0ni6vxomazo73r5oydo16k",
         "version": "4dw0ni6txomazo33r5ozdo16j"
@@ -39,5 +42,3 @@ def mock_save_draft():
     responses.add(responses.POST, save_endpoint,
                   content_type='application/json', status=200,
                   body=response_body, match_querystring=True)
-
-

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1,12 +1,11 @@
 import json
 import pytest
 import responses
-from conftest import API_URL
 from nylas.client.errors import InvalidRequestError
 
 
 @pytest.fixture
-def mock_draft_saved_response():
+def mock_draft_saved_response(api_url):
     response_body = json.dumps(
         {
             "bcc": [],
@@ -36,13 +35,13 @@ def mock_draft_saved_response():
             "version": 0
         })
 
-    responses.add(responses.POST, API_URL + '/drafts/',
+    responses.add(responses.POST, api_url + '/drafts/',
                   content_type='application/json', status=200,
                   body=response_body, match_querystring=True)
 
 
 @pytest.fixture
-def mock_draft_updated_response():
+def mock_draft_updated_response(api_url):
     body = {
             "bcc": [],
             "body": "",
@@ -71,18 +70,18 @@ def mock_draft_updated_response():
             "version": 0
         }
 
-    responses.add(responses.PUT, API_URL + '/drafts/2h111aefv8pzwzfykrn7hercj',
+    responses.add(responses.PUT, api_url + '/drafts/2h111aefv8pzwzfykrn7hercj',
                   content_type='application/json', status=200,
                   body=json.dumps(body), match_querystring=True)
 
     body['subject'] = 'Update #2'
-    responses.add(responses.PUT, API_URL + '/drafts/2h111aefv8pzwzfykrn7hercj?random_query=true&param2=param',
+    responses.add(responses.PUT, api_url + '/drafts/2h111aefv8pzwzfykrn7hercj?random_query=true&param2=param',
                   content_type='application/json', status=200,
                   body=json.dumps(body), match_querystring=True)
 
 
 @pytest.fixture
-def mock_draft_sent_response():
+def mock_draft_sent_response(api_url):
     body = {
             "bcc": [],
             "body": "",
@@ -121,7 +120,7 @@ def mock_draft_sent_response():
         return values.pop()
 
     responses.add_callback(
-            responses.POST, API_URL + '/send/',
+            responses.POST, api_url + '/send/',
             callback=callback,
             content_type='application/json')
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,11 +3,9 @@ import pytest
 import responses
 import httpretty
 from httpretty import Response
-from conftest import API_URL
 from nylas.client.errors import InvalidRequestError
 
 
-url = API_URL + '/events/'
 body = {
     "busy": True,
     "calendar_id": "94rssh7bd3rmsxsp19kiocxze",
@@ -31,21 +29,21 @@ body = {
 
 
 @pytest.fixture
-def mock_event_create_response():
+def mock_event_create_response(api_url):
     values = [Response(status=200, body=json.dumps(body)),
               Response(status=400, body='')]
 
-    httpretty.register_uri(httpretty.POST, API_URL + '/events/', responses=values)
+    httpretty.register_uri(httpretty.POST, api_url + '/events/', responses=values)
     put_values = [Response(status=200,
                            body=json.dumps({'title': 'loaded from JSON',
                                             'ignored': 'ignored'}))]
-    httpretty.register_uri(httpretty.PUT, API_URL + '/events/cv4ei7syx10uvsxbs21ccsezf',
+    httpretty.register_uri(httpretty.PUT, api_url + '/events/cv4ei7syx10uvsxbs21ccsezf',
                            responses=put_values)
 
 
 @pytest.fixture
-def mock_event_create_notify_response():
-    httpretty.register_uri(httpretty.POST, API_URL + '/events/?notify_participants=true&other_param=1',
+def mock_event_create_notify_response(api_url):
+    httpretty.register_uri(httpretty.POST, api_url + '/events/?notify_participants=true&other_param=1',
                            body=json.dumps(body), status=200)
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,11 +3,10 @@ import pytest
 import responses
 import httpretty
 from httpretty import Response
-from conftest import API_URL
 from nylas.client.errors import InvalidRequestError, FileUploadError
 
 
-def test_file_upload(api_client):
+def test_file_upload(api_client, api_url):
     httpretty.enable()
     body = [{
         "content_type": "text/plain",
@@ -19,8 +18,8 @@ def test_file_upload(api_client):
     }]
 
     values = [Response(status=200, body=json.dumps(body))]
-    httpretty.register_uri(httpretty.POST, API_URL + '/files/', responses=values)
-    httpretty.register_uri(httpretty.GET, API_URL + '/files/3qfe4k3siosfjtjpfdnon8zbn/download',
+    httpretty.register_uri(httpretty.POST, api_url + '/files/', responses=values)
+    httpretty.register_uri(httpretty.GET, api_url + '/files/3qfe4k3siosfjtjpfdnon8zbn/download',
                            body='test body')
 
     myfile = api_client.files.create()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -4,11 +4,9 @@ import random
 import responses
 import httpretty
 from httpretty import Response
-from conftest import API_URL
 from nylas.client.errors import InvalidRequestError
 
 
-url = API_URL + '/events/'
 default_body = {
     "busy": True,
     "calendar_id": "94rssh7bd3rmsxsp19kiocxze",
@@ -34,13 +32,13 @@ body = [default_body for i in range(1, 51)]
 body2 = [default_body for i in range(1, 23)]
 
 
-def test_no_filter(api_client):
+def test_no_filter(api_client, api_url):
     httpretty.enable()
 
     # httpretty kind of sucks and strips & parameters from the URL
     values = [Response(status=200, body=json.dumps(body)),
               Response(status=200, body=json.dumps(body2))]
-    httpretty.register_uri(httpretty.GET, API_URL + '/events', responses=values)
+    httpretty.register_uri(httpretty.GET, api_url + '/events', responses=values)
 
     events = api_client.events.all()
     assert len(events) == 72
@@ -49,11 +47,11 @@ def test_no_filter(api_client):
     httpretty.disable()
 
 
-def test_two_filters(api_client):
+def test_two_filters(api_client, api_url):
     httpretty.enable()
 
     values2 = [Response(status=200, body='[]')]
-    httpretty.register_uri(httpretty.GET, API_URL + '/events?param1=a&param2=b', responses=values2)
+    httpretty.register_uri(httpretty.GET, api_url + '/events?param1=a&param2=b', responses=values2)
     events = api_client.events.where(param1='a', param2='b').all()
     assert len(events) == 0
     qs = httpretty.last_request().querystring
@@ -61,11 +59,11 @@ def test_two_filters(api_client):
     assert qs['param2'][0] == 'b'
     httpretty.disable()
 
-def test_no_offset(api_client):
+def test_no_offset(api_client, api_url):
     httpretty.enable()
 
     values = [Response(status=200, body='[]')]
-    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas', responses=values)
+    httpretty.register_uri(httpretty.GET, api_url + '/events?in=Nylas', responses=values)
     events = api_client.events.where({'in': 'Nylas'}).items()
     for event in events:
       pass
@@ -74,11 +72,11 @@ def test_no_offset(api_client):
     assert qs['offset'][0] == '0'
     httpretty.disable()
 
-def test_zero_offset(api_client):
+def test_zero_offset(api_client, api_url):
     httpretty.enable()
 
     values = [Response(status=200, body='[]')]
-    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas&offset=0', responses=values)
+    httpretty.register_uri(httpretty.GET, api_url + '/events?in=Nylas&offset=0', responses=values)
     events = api_client.events.where({'in': 'Nylas', 'offset': 0}).items()
     for event in events:
       pass
@@ -87,12 +85,12 @@ def test_zero_offset(api_client):
     assert qs['offset'][0] == '0'
     httpretty.disable()
 
-def test_non_zero_offset(api_client):
+def test_non_zero_offset(api_client, api_url):
     httpretty.enable()
 
     offset = random.randint(1,1000)
     values = [Response(status=200, body='[]')]
-    httpretty.register_uri(httpretty.GET, API_URL + '/events?in=Nylas&offset=' +
+    httpretty.register_uri(httpretty.GET, api_url + '/events?in=Nylas&offset=' +
                            str(offset), responses=values)
     events = api_client.events.where({'in': 'Nylas', 'offset': offset}).items()
     for event in events:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,11 +1,10 @@
 import json
 import pytest
 import responses
-from conftest import API_URL
 from nylas.client.errors import InvalidRequestError
 
 @pytest.fixture
-def mock_thread_search_response():
+def mock_thread_search_response(api_url):
     response_body = json.dumps(
         [
             {
@@ -45,13 +44,13 @@ def mock_thread_search_response():
         ])
 
     responses.add(responses.GET,
-            API_URL + '/threads/search?q=Helena',
+            api_url + '/threads/search?q=Helena',
             body=response_body, status=200,
             content_type='application/json',
             match_querystring=True)
 
 @pytest.fixture
-def mock_message_search_response():
+def mock_message_search_response(api_url):
     response_body = json.dumps(
         [
             {
@@ -125,7 +124,7 @@ def mock_message_search_response():
         ])
 
     responses.add(responses.GET,
-            API_URL + '/messages/search?q=Pinot',
+            api_url + '/messages/search?q=Pinot',
             body=response_body, status=200,
             content_type='application/json',
             match_querystring=True)


### PR DESCRIPTION
So that we don't have to import from `conftest.py`, which is not supposed to be importable.