### PR TITLE
Pass list of arguments to pytest.main()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = '--cov --junitxml ./tests/output tests/'
+        self.pytest_args = ['--cov', '--junitxml', './tests/output', 'tests/']
 
     def finalize_options(self):
         TestCommand.finalize_options(self)


### PR DESCRIPTION
Passing a string to pytest.main() is deprecated