### PR TITLE
Add hosted OAuth example

### DIFF
--- a/examples-new/hosted-oauth/README.md
+++ b/examples-new/hosted-oauth/README.md
@@ -81,5 +81,4 @@ Finally, run the example project like this:
 python server.py
 ```
 
-Once the server is running, visit `http://127.0.0.1:5000/` in your browser
-to test it out!
+Once the server is running, visit the ngrok URL in your browser to test it out!

--- a/examples-new/hosted-oauth/README.md
+++ b/examples-new/hosted-oauth/README.md
@@ -1,0 +1,85 @@
+# Example: Hosted OAuth
+
+This is an example project that demonstrates how to connect to Nylas via
+OAuth. [OAuth](https://oauth.net/) is a standard protocol to allow two
+websites to securely communicate with each other.
+
+This example uses the [Flask](http://flask.pocoo.org/) web framework to make
+a small website, and uses the [Flask-Dance](http://flask-dance.rtfd.org/)
+extension to handle the tricky bits of implementing the OAuth protocol.
+Once the OAuth communication is in place, this example website will contact
+the Nylas API to learn some basic information about the current user,
+such as the user's name and email address. It will display that information
+on the page, just to prove that it can fetch it correctly.
+
+In order to successfully run this example, you need to do the following things:
+
+## Get an API ID & API Secret from Nylas
+
+To do this, make a [Nylas Developer](https://developer.nylas.com/) account.
+You should see your API ID and API Secret on the dashboard, once you've logged
+in on the [Nylas Developer](https://developer.nylas.com/) website.
+
+## Update the `config.json` File
+
+Open the `config.json` file in this directory, and replace the example
+API ID and API Secret with the real values that you got from the Nylas
+Developer dashboard. You'll also need to replace the example secret key with
+any random string of letters and numbers: a keyboard mash will do.
+
+## Set Up HTTPS
+
+The OAuth protocol requires that all communication occur via the secure HTTPS
+connections, rather than insecure HTTP connections. There are several ways
+to set up HTTPS on your computer, but perhaps the simplest is to use
+[ngrok](https://ngrok.com), a tool that lets you create a secure tunnel
+from the ngrok website to your computer. Install it from the website, and
+then run the following command:
+
+```
+ngrok http 5000
+```
+
+Notice that ngrok will show you two "forwarding" URLs, which may look something
+like `http://ed90abe7.ngrok.io` and `https://ed90abe7.ngrok.io`. (The hash
+subdomain will be different for you.) You'll be using the second URL, which
+starts with `https`.
+
+Alternatively, you can set the `OAUTHLIB_INSECURE_TRANSPORT` environment
+variable in your shell, to disable the HTTPS check. That way, you'll be
+able to use `localhost` to refer to your app, instead of an ngrok URL.
+However, be aware that you won't be able to do this when you deploy
+your app to production, so it's usually a better idea to set up HTTPS properly.
+
+## Set the Nylas Callback URL
+
+Once you have a HTTPS URL that points to your computer, you'll need to tell
+Nylas about it. On the [Nylas Developer](https://developer.nylas.com) console,
+click on the "Settings" button, and then select the "Callbacks" tab.
+Paste your HTTPS URL into text field, and add `/login/nylas/authorized`
+after it. For example, if your HTTPS URL is `https://ad172180.ngrok.io`, then
+you would put `https://ad172180.ngrok.io/login/nylas/authorized` into
+the text field in the "Callbacks" tab.
+
+Then click the "Done" button to save.
+
+## Install the Dependencies
+
+This project depends on a few third-party Python modules, like Flask.
+These dependencies are listed in the `requirements.txt` file in this directory.
+To install them, use the `pip` tool, like this:
+
+```
+pip install -r requirements.txt
+```
+
+## Run the Example
+
+Finally, run the example project like this:
+
+```
+python server.py
+```
+
+Once the server is running, visit `http://127.0.0.1:5000/` in your browser
+to test it out!

--- a/examples-new/hosted-oauth/README.md
+++ b/examples-new/hosted-oauth/README.md
@@ -1,12 +1,12 @@
 # Example: Hosted OAuth
 
 This is an example project that demonstrates how to connect to Nylas via
-OAuth. [OAuth](https://oauth.net/) is a standard protocol to allow two
-websites to securely communicate with each other.
+OAuth, using [Nylas' hosted OAuth flow](https://docs.nylas.com/reference#oauth).
 
 This example uses the [Flask](http://flask.pocoo.org/) web framework to make
 a small website, and uses the [Flask-Dance](http://flask-dance.rtfd.org/)
-extension to handle the tricky bits of implementing the OAuth protocol.
+extension to handle the tricky bits of implementing the
+[OAuth protocol](https://oauth.net/).
 Once the OAuth communication is in place, this example website will contact
 the Nylas API to learn some basic information about the current user,
 such as the user's name and email address. It will display that information

--- a/examples-new/hosted-oauth/config.json
+++ b/examples-new/hosted-oauth/config.json
@@ -1,0 +1,5 @@
+{
+  "SECRET_KEY": "replace me with a random string",
+  "NYLAS_OAUTH_API_ID": "replace me with the API ID from Nylas",
+  "NYLAS_OAUTH_API_SECRET": "replace me with the API Secret from Nylas"
+}

--- a/examples-new/hosted-oauth/requirements.txt
+++ b/examples-new/hosted-oauth/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=0.11
+Flask-Dance>=0.11.0

--- a/examples-new/hosted-oauth/server.py
+++ b/examples-new/hosted-oauth/server.py
@@ -65,10 +65,12 @@ def index():
     # If the user has already connected to Nylas via OAuth,
     # `nylas.authorized` will be True. Otherwise, it will be False.
     if not nylas.authorized:
-        # OAuth requires HTTPS. Check for insecure HTTP, so the template
-        # can display a handy warning if necessary.
-        oauth_ok = request.is_secure or os.environ.get("OAUTHLIB_INSECURE_TRANSPORT")
-        return render_template("before_authorized.html", oauth_ok=oauth_ok)
+        # OAuth requires HTTPS. The template will display a handy warning,
+        # unless we've overridden the check.
+        return render_template(
+            "before_authorized.html",
+            insecure_override=os.environ.get("OAUTHLIB_INSECURE_TRANSPORT"),
+        )
 
     # If we've gotten to this point, then the user has already connected
     # to Nylas via OAuth. Let's set up the SDK client with the OAuth token:

--- a/examples-new/hosted-oauth/server.py
+++ b/examples-new/hosted-oauth/server.py
@@ -1,0 +1,88 @@
+# Imports from the Python standard library
+from __future__ import print_function
+import os
+import sys
+import textwrap
+
+# Imports from third-party modules that this project depends on
+try:
+    from flask import Flask, request, render_template
+    from flask_dance.contrib.nylas import make_nylas_blueprint, nylas
+except ImportError:
+    message = textwrap.dedent("""
+        You need to install the dependencies for this project.
+        To do so, run this command:
+
+            pip install -r requirements.txt
+    """)
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from nylas import APIClient
+except ImportError:
+    message = textwrap.dedent("""
+        You need to install the Nylas SDK for this project.
+        To do so, run this command:
+
+            pip install nylas
+    """)
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+# This example uses Flask, a micro web framework written in Python.
+# For more information, check out the documentation: http://flask.pocoo.org
+# Create a Flask app, and load the configuration file.
+app = Flask(__name__)
+app.config.from_json('config.json')
+
+# Check for dummy configuration values.
+# If you are building your own application based on this example,
+# you can remove this check from your code.
+cfg_needs_replacing = [
+    key  for key, value in app.config.items()
+    if isinstance(value, str) and value.startswith("replace me")
+]
+if cfg_needs_replacing:
+    message = textwrap.dedent("""
+        This example will only work if you replace the fake configuration
+        values in `config.json` with real configuration values.
+        The following config values need to be replaced:
+        {keys}
+        Consult the README.md file in this directory for more information.
+    """).format(keys=", ".join(cfg_needs_replacing))
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+# Use Flask-Dance to automatically set up the OAuth endpoints for Nylas.
+# For more information, check out the documentation: http://flask-dance.rtfd.org
+nylas_bp = make_nylas_blueprint()
+app.register_blueprint(nylas_bp, url_prefix="/login")
+
+# Define what Flask should do when someone visits the root URL of this website.
+@app.route("/")
+def index():
+    # If the user has already connected to Nylas via OAuth,
+    # `nylas.authorized` will be True. Otherwise, it will be False.
+    if not nylas.authorized:
+        # OAuth requires HTTPS. Check for insecure HTTP, so the template
+        # can display a handy warning if necessary.
+        oauth_ok = request.is_secure or os.environ.get("OAUTHLIB_INSECURE_TRANSPORT")
+        return render_template("before_authorized.html", oauth_ok=oauth_ok)
+
+    # If we've gotten to this point, then the user has already connected
+    # to Nylas via OAuth. Let's set up the SDK client with the OAuth token:
+    client = APIClient(
+        app_id=app.config["NYLAS_OAUTH_API_ID"],
+        app_secret=app.config["NYLAS_OAUTH_API_SECRET"],
+        access_token=nylas.access_token,
+    )
+
+    # We'll use the Nylas client to fetch information from Nylas
+    # about the current user, and pass that to the template.
+    account = client.account
+    return render_template("after_authorized.html", account=account)
+
+# When this file is executed, run the Flask web server.
+if __name__ == "__main__":
+    app.run()

--- a/examples-new/hosted-oauth/templates/after_authorized.html
+++ b/examples-new/hosted-oauth/templates/after_authorized.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block body %}
+<h1>Nylas Hosted OAuth Example</h1>
+<p>You've successfully connected to Nylas via hosted OAuth! Here's some
+   information that I got from the Nylas API, to prove it:</p>
+
+<table>
+  {% for key, value in account.items() %}
+  <tr>
+    <th>{{ key }}</th>
+    <td>{{ value }}</td>
+  </tr>
+  {% endfor %}
+</table>
+
+<p>If you want to test this OAuth flow again, clear your browser cookies
+   or open a new browser in incognito mode.</p>
+{% endblock %}

--- a/examples-new/hosted-oauth/templates/base.html
+++ b/examples-new/hosted-oauth/templates/base.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Nylas Hosted OAuth Example</title>
+    <style type="text/css">
+      .warning {
+        border: 2px solid red;
+        padding: 0 1em;
+      }
+    </style>
+  </head>
+  <body>
+    {% block body %}{% endblock %}
+  </body>
+</html>

--- a/examples-new/hosted-oauth/templates/base.html
+++ b/examples-new/hosted-oauth/templates/base.html
@@ -8,6 +8,9 @@
         border: 2px solid red;
         padding: 0 1em;
       }
+      .hide {
+        display: none;
+      }
     </style>
   </head>
   <body>

--- a/examples-new/hosted-oauth/templates/before_authorized.html
+++ b/examples-new/hosted-oauth/templates/before_authorized.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block body %}
+<h1>Nylas Hosted OAuth Example</h1>
+
+{% if not oauth_ok %}
+<div class="warning">
+  <h2>Warning</h2>
+  <p>OAuth requires HTTPS, and this page is loaded via insecure HTTP.
+    If you try to connect to Nylas like this, it will fail.
+    To fix this problem, serve this website over HTTPS.
+  </p>
+  <p>Since this is just an example, you can disable this requirement by
+    setting the <code>OAUTHLIB_INSECURE_TRANSPORT</code> environment
+    variable to <code>1</code> before running this example again.
+    However, you will <em>not</em> be able to do this when running
+    in production.
+  </p>
+</div>
+{% endif %}
+
+<p>Thanks for giving Nylas a try! Next, you need to click this link
+   to connect to Nylas via hosted OAuth.</p>
+<a href="{{ url_for("nylas.login") }}">Connect to Nylas</a>
+{% endblock %}

--- a/examples-new/hosted-oauth/templates/before_authorized.html
+++ b/examples-new/hosted-oauth/templates/before_authorized.html
@@ -2,8 +2,8 @@
 {% block body %}
 <h1>Nylas Hosted OAuth Example</h1>
 
-{% if not oauth_ok %}
-<div class="warning">
+{% if not insecure_override %}
+<div class="warning hide">
   <h2>Warning</h2>
   <p>OAuth requires HTTPS, and this page is loaded via insecure HTTP.
     If you try to connect to Nylas like this, it will fail.
@@ -21,4 +21,11 @@
 <p>Thanks for giving Nylas a try! Next, you need to click this link
    to connect to Nylas via hosted OAuth.</p>
 <a href="{{ url_for("nylas.login") }}">Connect to Nylas</a>
+
+<script type="text/javascript">
+  if (location.protocol === "http:") {
+    var el = document.querySelector(".warning.hide");
+    el.className = "warning";
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
This example uses Flask and Flask-Dance to demonstrate how to connect to Nylas via OAuth. In order to make this example easier to set up, I added Nylas support to [Flask-Dance](http://flask-dance.rtfd.org/).