### PR TITLE
Refactor how client validates responses

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -14,6 +14,10 @@ from nylas.client.restful_models import (
     Label, Draft
 )
 from nylas.client.errors import APIClientError, ConnectionError, STATUS_MAP
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
 
 DEBUG = environ.get('NYLAS_CLIENT_DEBUG')
 API_SERVER = "https://api.nylas.com"
@@ -40,7 +44,7 @@ def _validate(response):
     try:
         data = response.json()
         json_content = True
-    except json.JSONDecodeError:
+    except JSONDecodeError:
         data = response.content
         json_content = False
 

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -13,64 +13,57 @@ from nylas.client.restful_models import (
     Account, APIAccount, SingletonAccount, Folder,
     Label, Draft
 )
-from nylas.client.errors import (
-    APIClientError, ConnectionError, NotAuthorizedError,
-    InvalidRequestError, NotFoundError, MethodNotSupportedError,
-    ServerError, ServiceUnavailableError, ConflictError,
-    SendingQuotaExceededError, ServerTimeoutError, MessageRejectedError
-)
+from nylas.client.errors import APIClientError, ConnectionError, STATUS_MAP
 
 DEBUG = environ.get('NYLAS_CLIENT_DEBUG')
 API_SERVER = "https://api.nylas.com"
 
 
 def _validate(response):
-    status_code_to_exc = {400: InvalidRequestError,
-                          401: NotAuthorizedError,
-                          402: MessageRejectedError,
-                          403: NotAuthorizedError,
-                          404: NotFoundError,
-                          405: MethodNotSupportedError,
-                          409: ConflictError,
-                          429: SendingQuotaExceededError,
-                          500: ServerError,
-                          503: ServiceUnavailableError,
-                          504: ServerTimeoutError}
-    request = response.request
-    url = request.url
-    status_code = response.status_code
-    data = request.body
-
     if DEBUG:  # pragma: no cover
-        print("{} {} ({}) => {}: {}".format(request.method, url, data,
-                                            status_code, response.text))
+        print("{method} {url} ({body}) => {status}: {text}".format(
+            method=response.request.method,
+            url=response.request.url,
+            data=response.request.body,
+            status=response.status_code,
+            text=response.text,
+        ))
+
+    if response.ok:
+        return response
+
+    # The rest of this function is logic for raising the correct exception
+    # from the `nylas.client.errors` module. In the future, it may be worth changing
+    # this function to just call `response.raise_for_status()`.
+    # http://docs.python-requests.org/en/master/api/#requests.Response.raise_for_status
 
     try:
-        data = json.loads(data) if data else None
-    except (ValueError, TypeError):
-        pass
+        data = response.json()
+        json_content = True
+    except json.JSONDecodeError:
+        data = response.content
+        json_content = False
 
-    if status_code == 200:
-        return response
-    elif status_code in status_code_to_exc:
-        cls = status_code_to_exc[status_code]
-        try:
-            response = json.loads(response.text)
-            kwargs = dict(url=url, status_code=status_code,
-                          data=data)
+    kwargs = {
+        "url": response.request.url,
+        "status_code": response.status_code,
+        "data": data,
+    }
 
-            for key in ['message', 'server_error']:
-                if key in response:
-                    kwargs[key] = response[key]
-
+    if response.status_code in STATUS_MAP:
+        cls = STATUS_MAP[response.status_code]
+        if json_content:
+            if "message" in data:
+                kwargs["message"] = data["message"]
+            if "server_error" in data:
+                kwargs["server_error"] = data["server_error"]
             raise cls(**kwargs)
-
-        except (ValueError, TypeError):
-            raise cls(url=url, status_code=status_code,
-                      data=data, message="Malformed")
+        else:
+            kwargs["message"] = "Malformed"
+            raise cls(**kwargs)
     else:
-        raise APIClientError(url=url, status_code=status_code,
-                             data=data, message="Unknown status code.")
+        kwargs["message"] = "Unknown status code."
+        raise APIClientError(**kwargs)
 
 
 def nylas_excepted(func):

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -68,3 +68,18 @@ class ServerTimeoutError(APIClientError):
 
 class FileUploadError(APIClientError):
     pass
+
+
+STATUS_MAP = {
+    400: InvalidRequestError,
+    401: NotAuthorizedError,
+    402: MessageRejectedError,
+    403: NotAuthorizedError,
+    404: NotFoundError,
+    405: MethodNotSupportedError,
+    409: ConflictError,
+    429: SendingQuotaExceededError,
+    500: ServerError,
+    503: ServiceUnavailableError,
+    504: ServerTimeoutError,
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -184,20 +184,16 @@ def test_call_resource_method(mocked_responses, api_client, api_url):
         Contact, 1, "remove_duplicates", {}
     )
     assert isinstance(contact, Contact)
-<<<<<<< HEAD
     assert len(mocked_responses.calls) == 1
-=======
-    assert len(responses.calls) == 1
 
 
-@responses.activate
-def test_201_response(api_client, api_url):
+def test_201_response(mocked_responses, api_client, api_url):
     contact_data = {
         "id": 1,
         "name": "first",
         "email": "first@example.com",
     }
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         api_url + "/contacts/",
         content_type='application/json',
@@ -207,5 +203,29 @@ def test_201_response(api_client, api_url):
     )
     contact = api_client.contacts.create()
     contact.save()
-    assert len(responses.calls) == 1
->>>>>>> Refactor how client validates responses
+    assert len(mocked_responses.calls) == 1
+
+
+def test_301_response(mocked_responses, api_client, api_url):
+    contact_data = {
+        "id": 1,
+        "name": "first",
+        "email": "first@example.com",
+    }
+    mocked_responses.add(
+        responses.GET,
+        api_url + "/contacts/first",
+        status=301,
+        headers={"Location": api_url + "/contacts/1"}
+    )
+    mocked_responses.add(
+        responses.GET,
+        api_url + "/contacts/1",
+        content_type='application/json',
+        status=200,
+        body=json.dumps(contact_data),
+    )
+    contact = api_client.contacts.find("first")
+    assert contact["id"] == 1
+    assert contact["name"] == "first"
+    assert len(mocked_responses.calls) == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -184,4 +184,28 @@ def test_call_resource_method(mocked_responses, api_client, api_url):
         Contact, 1, "remove_duplicates", {}
     )
     assert isinstance(contact, Contact)
+<<<<<<< HEAD
     assert len(mocked_responses.calls) == 1
+=======
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_201_response(api_client, api_url):
+    contact_data = {
+        "id": 1,
+        "name": "first",
+        "email": "first@example.com",
+    }
+    responses.add(
+        responses.POST,
+        api_url + "/contacts/",
+        content_type='application/json',
+        status=201,  # This HTTP status still indicates success,
+                     # even though it's not 200.
+        body=json.dumps(contact_data),
+    )
+    contact = api_client.contacts.create()
+    contact.save()
+    assert len(responses.calls) == 1
+>>>>>>> Refactor how client validates responses


### PR DESCRIPTION
This will also accept successful responses with non-200 status codes. For example, "201 Created" is a successful status code. Fixes #63 and fixes #64.