### PR TITLE
Remove httpretty

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -377,7 +377,7 @@ class APIClient(json.JSONEncoder):
         for example /a/.../accounts/id/upgrade"""
 
         if cls.api_root != 'a':
-            url_path =  "/{name}/{id}/{method}".format(
+            url_path = "/{name}/{id}/{method}".format(
                 name=cls.collection_name, id=id, method=method_name
             )
         else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-pytest
-responses

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ TEST_DEPENDENCIES = [
     "pytest-cov",
     "pytest-pylint",
     "responses",
-    "httpretty",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def mock_label(mocked_responses, api_url, account_id):
             "object": "label"
         }
     )
-    url = api_url + '/labels/anuep8pe5ugmxrucchrzba2o8')
+    url = api_url + '/labels/anuep8pe5ugmxrucchrzba2o8'
     mocked_responses.add(
         responses.GET,
         url,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -676,7 +676,7 @@ def mock_event_create_response(mocked_responses, api_url, message_body):
     values = [(400, {}, ""),
               (200, {}, json.dumps(message_body))]
 
-    def callback(request):
+    def callback(_request):
         return values.pop()
 
     mocked_responses.add_callback(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,13 +53,20 @@ def api_client(api_url):
 
 
 @pytest.fixture
-def mock_save_draft(api_url):
+def mocked_responses():
+    rmock = responses.RequestsMock(assert_all_requests_are_fired=False)
+    with rmock:
+        yield rmock
+
+
+@pytest.fixture
+def mock_save_draft(mocked_responses, api_url):
     save_endpoint = re.compile(api_url + '/drafts/')
     response_body = json.dumps({
         "id": "4dl0ni6vxomazo73r5oydo16k",
         "version": "4dw0ni6txomazo33r5ozdo16j"
     })
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         save_endpoint,
         content_type='application/json',
@@ -70,7 +77,7 @@ def mock_save_draft(api_url):
 
 
 @pytest.fixture
-def mock_account(api_url, account_id):
+def mock_account(mocked_responses, api_url, account_id):
     response_body = json.dumps(
         {
             "account_id": account_id,
@@ -83,7 +90,7 @@ def mock_account(api_url, account_id):
             "billing_state": "paid",
         }
     )
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         re.compile(api_url + '/account/?'),
         content_type='application/json',
@@ -93,7 +100,7 @@ def mock_account(api_url, account_id):
 
 
 @pytest.fixture
-def mock_accounts(api_url, account_id, app_id):
+def mock_accounts(mocked_responses, api_url, account_id, app_id):
     response_body = json.dumps([
         {
             "account_id": account_id,
@@ -107,7 +114,7 @@ def mock_accounts(api_url, account_id, app_id):
         }
     ])
     url_re = "{base}(/a/{app_id})?/accounts/?".format(base=api_url, app_id=app_id)
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         re.compile(url_re),
         content_type='application/json',
@@ -117,7 +124,7 @@ def mock_accounts(api_url, account_id, app_id):
 
 
 @pytest.fixture
-def mock_folder_account(api_url, account_id):
+def mock_folder_account(mocked_responses, api_url, account_id):
     response_body = json.dumps(
         {
             "email_address": "ben.bitdiddle1861@office365.com",
@@ -129,7 +136,7 @@ def mock_folder_account(api_url, account_id):
             "organization_unit": "folder"
         }
     )
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         api_url + '/account',
         content_type='application/json',
@@ -140,7 +147,7 @@ def mock_folder_account(api_url, account_id):
 
 
 @pytest.fixture
-def mock_labels(api_url, account_id):
+def mock_labels(mocked_responses, api_url, account_id):
     response_body = json.dumps([
         {
             "display_name": "Important",
@@ -179,7 +186,7 @@ def mock_labels(api_url, account_id):
         }
     ])
     endpoint = re.compile(api_url + '/labels.*')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
@@ -189,7 +196,7 @@ def mock_labels(api_url, account_id):
 
 
 @pytest.fixture
-def mock_label(api_url, account_id):
+def mock_label(mocked_responses, api_url, account_id):
     response_body = json.dumps(
         {
             "display_name": "Important",
@@ -199,8 +206,8 @@ def mock_label(api_url, account_id):
             "object": "label"
         }
     )
-    url = api_url + '/labels/anuep8pe5ugmxrucchrzba2o8'
-    responses.add(
+    url = api_url + '/labels/anuep8pe5ugmxrucchrzba2o8')
+    mocked_responses.add(
         responses.GET,
         url,
         content_type='application/json',
@@ -210,7 +217,7 @@ def mock_label(api_url, account_id):
 
 
 @pytest.fixture
-def mock_folder(api_url, account_id):
+def mock_folder(mocked_responses, api_url, account_id):
     folder = {
         "display_name": "My Folder",
         "id": "anuep8pe5ug3xrupchwzba2o8",
@@ -220,7 +227,7 @@ def mock_folder(api_url, account_id):
         }
     response_body = json.dumps(folder)
     url = api_url + '/folders/anuep8pe5ug3xrupchwzba2o8'
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         url,
         content_type='application/json',
@@ -234,7 +241,7 @@ def mock_folder(api_url, account_id):
             folder.update(payload)
         return (200, {}, json.dumps(folder))
 
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.PUT,
         url,
         content_type='application/json',
@@ -243,7 +250,7 @@ def mock_folder(api_url, account_id):
 
 
 @pytest.fixture
-def mock_messages(api_url, account_id):
+def mock_messages(mocked_responses, api_url, account_id):
     response_body = json.dumps([
         {
             "id": "1234",
@@ -290,16 +297,17 @@ def mock_messages(api_url, account_id):
         }
     ])
     endpoint = re.compile(api_url + '/messages')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
         status=200,
-        body=response_body)
+        body=response_body
+    )
 
 
 @pytest.fixture
-def mock_message(api_url, account_id):
+def mock_message(mocked_responses, api_url, account_id):
     base_msg = {
         "id": "1234",
         "subject": "Test Message",
@@ -326,20 +334,20 @@ def mock_message(api_url, account_id):
         return (200, {}, json.dumps(base_msg))
 
     endpoint = re.compile(api_url + '/messages/1234')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
         status=200,
         body=response_body
     )
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.PUT,
         endpoint,
         content_type='application/json',
         callback=request_callback
     )
-    responses.add(
+    mocked_responses.add(
         responses.DELETE,
         endpoint,
         content_type='application/json',
@@ -349,7 +357,7 @@ def mock_message(api_url, account_id):
 
 
 @pytest.fixture
-def mock_threads(api_url, account_id):
+def mock_threads(mocked_responses, api_url, account_id):
     response_body = json.dumps([
         {
             "id": "5678",
@@ -366,7 +374,7 @@ def mock_threads(api_url, account_id):
         }
     ])
     endpoint = re.compile(api_url + '/threads')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
@@ -376,7 +384,7 @@ def mock_threads(api_url, account_id):
 
 
 @pytest.fixture
-def mock_thread(api_url, account_id):
+def mock_thread(mocked_responses, api_url, account_id):
     base_thrd = {
         "id": "5678",
         "subject": "Test Thread",
@@ -401,14 +409,14 @@ def mock_thread(api_url, account_id):
         return (200, {}, json.dumps(base_thrd))
 
     endpoint = re.compile(api_url + '/threads/5678')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
         status=200,
         body=response_body
     )
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.PUT,
         endpoint,
         content_type='application/json',
@@ -417,7 +425,7 @@ def mock_thread(api_url, account_id):
 
 
 @pytest.fixture
-def mock_labelled_thread(api_url, account_id):
+def mock_labelled_thread(mocked_responses, api_url, account_id):
     base_thread = {
         "id": "111",
         "subject": "Labelled Thread",
@@ -472,14 +480,14 @@ def mock_labelled_thread(api_url, account_id):
         return (200, {}, json.dumps(copied))
 
     endpoint = re.compile(api_url + '/threads/111')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
         status=200,
         body=response_body
     )
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.PUT,
         endpoint,
         content_type='application/json',
@@ -488,7 +496,7 @@ def mock_labelled_thread(api_url, account_id):
 
 
 @pytest.fixture
-def mock_drafts(api_url):
+def mock_drafts(mocked_responses, api_url):
     response_body = json.dumps([{
         "bcc": [],
         "body": "Cheers mate!",
@@ -517,7 +525,7 @@ def mock_drafts(api_url):
         "version": 0
     }])
 
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         api_url + '/drafts',
         content_type='application/json',
@@ -527,7 +535,7 @@ def mock_drafts(api_url):
 
 
 @pytest.fixture
-def mock_draft_saved_response(api_url):
+def mock_draft_saved_response(mocked_responses, api_url):
     draft_json = {
         "bcc": [],
         "body": "Cheers mate!",
@@ -569,14 +577,14 @@ def mock_draft_saved_response(api_url):
         updated_draft_json.update(stripped_payload)
         return (200, {}, json.dumps(updated_draft_json))
 
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.POST,
         api_url + '/drafts/',
         content_type='application/json',
         callback=request_callback,
     )
 
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.PUT,
         api_url + '/drafts/2h111aefv8pzwzfykrn7hercj',
         content_type='application/json',
@@ -585,8 +593,8 @@ def mock_draft_saved_response(api_url):
 
 
 @pytest.fixture
-def mock_draft_deleted_response(api_url):
-    responses.add(
+def mock_draft_deleted_response(mocked_responses, api_url):
+    mocked_responses.add(
         responses.DELETE,
         api_url + '/drafts/2h111aefv8pzwzfykrn7hercj',
         content_type='application/json',
@@ -596,7 +604,7 @@ def mock_draft_deleted_response(api_url):
 
 
 @pytest.fixture
-def mock_draft_sent_response(api_url):
+def mock_draft_sent_response(mocked_responses, api_url):
     body = {
         "bcc": [],
         "body": "",
@@ -634,7 +642,7 @@ def mock_draft_sent_response(api_url):
         assert payload['version'] == 0
         return values.pop()
 
-    responses.add_callback(
+    mocked_responses.add_callback(
         responses.POST,
         api_url + '/send/',
         callback=callback,
@@ -693,7 +701,7 @@ def mock_event_create_notify_response(api_url, message_body):
 
 
 @pytest.fixture
-def mock_thread_search_response(api_url):
+def mock_thread_search_response(mocked_responses, api_url):
     snippet = (
         "Hey Helena, Looking forward to getting together for dinner on Friday. "
         "What can I bring? I have a couple bottles of wine or could put together"
@@ -735,7 +743,7 @@ def mock_thread_search_response(api_url):
         }
     ])
 
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         api_url + '/threads/search?q=Helena',
         body=response_body,
@@ -745,7 +753,7 @@ def mock_thread_search_response(api_url):
     )
 
 @pytest.fixture
-def mock_message_search_response(api_url):
+def mock_message_search_response(mocked_responses, api_url):
     snippet = (
         "Sounds good--that bottle of Pinot should go well with the meal. "
         "I'll also bring a surprise for dessert. :) "
@@ -822,7 +830,7 @@ def mock_message_search_response(api_url):
         }
     ])
 
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         api_url + '/messages/search?q=Pinot',
         body=response_body,
@@ -833,7 +841,7 @@ def mock_message_search_response(api_url):
 
 
 @pytest.fixture
-def mock_calendars(api_url):
+def mock_calendars(mocked_responses, api_url):
     response_body = json.dumps([
         {
             "id": "8765",
@@ -852,7 +860,7 @@ def mock_calendars(api_url):
         }
     ])
     endpoint = re.compile(api_url + '/calendars')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
@@ -861,7 +869,7 @@ def mock_calendars(api_url):
     )
 
 @pytest.fixture
-def mock_events(api_url):
+def mock_events(mocked_responses, api_url):
     response_body = json.dumps([
         {
             "title": "Pool party",
@@ -875,7 +883,7 @@ def mock_events(api_url):
         }
     ])
     endpoint = re.compile(api_url + '/events')
-    responses.add(
+    mocked_responses.add(
         responses.GET,
         endpoint,
         content_type='application/json',
@@ -885,7 +893,7 @@ def mock_events(api_url):
 
 
 @pytest.fixture
-def mock_account_management(api_url, account_id, app_id):
+def mock_account_management(mocked_responses, api_url, account_id, app_id):
     account = {
         "account_id": account_id,
         "email_address": "ben.bitdiddle1861@gmail.com",
@@ -906,14 +914,14 @@ def mock_account_management(api_url, account_id, app_id):
     downgrade_url = "{base}/a/{app_id}/accounts/{id}/downgrade".format(
         base=api_url, id=account_id, app_id=app_id,
     )
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         upgrade_url,
         content_type='application/json',
         status=200,
         body=paid_response,
     )
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         downgrade_url,
         content_type='application/json',

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from nylas.client.restful_models import Account, APIAccount, SingletonAccount
 
 
@@ -41,7 +40,7 @@ def test_account_delete(api_client, monkeypatch):
 
 
 @pytest.mark.usefixtures("mock_accounts", "mock_account")
-def test_account_access(api_client, mocked_responses):
+def test_account_access(api_client):
     account1 = api_client.account
     assert isinstance(account1, SingletonAccount)
     account2 = api_client.accounts[0]

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -22,7 +22,6 @@ def test_account_json(api_client, monkeypatch):
     assert isinstance(result, dict)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_accounts", "mock_account_management")
 def test_account_upgrade(api_client, app_id):
     api_client.app_id = app_id
@@ -41,9 +40,8 @@ def test_account_delete(api_client, monkeypatch):
         account.delete()
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_accounts", "mock_account")
-def test_account_access(api_client):
+def test_account_access(api_client, mocked_responses):
     account1 = api_client.account
     assert isinstance(account1, SingletonAccount)
     account2 = api_client.accounts[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,11 +90,10 @@ def test_client_authentication_url(api_client, api_url):
     assert urls_equal(expected3, actual3)
 
 
-@responses.activate
-def test_client_token_for_code(api_client, api_url):
+def test_client_token_for_code(mocked_responses, api_client, api_url):
     endpoint = re.compile(api_url + '/oauth/token')
     response_body = json.dumps({"access_token": "hooray"})
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         endpoint,
         content_type='application/json',
@@ -103,8 +102,8 @@ def test_client_token_for_code(api_client, api_url):
     )
 
     assert api_client.token_for_code("foo") == "hooray"
-    assert len(responses.calls) == 1
-    request = responses.calls[0].request
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
     body = parse_qs(request.body)
     assert body["grant_type"] == ["authorization_code"]
     assert body["code"] == ["foo"]
@@ -120,10 +119,9 @@ def test_client_opensource_api(api_client):
     assert api_client.is_opensource_api() == True
 
 
-@responses.activate
-def test_client_revoke_token(api_client, api_url):
+def test_client_revoke_token(mocked_responses, api_client, api_url):
     endpoint = re.compile(api_url + '/oauth/revoke')
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         endpoint,
         status=200,
@@ -135,11 +133,10 @@ def test_client_revoke_token(api_client, api_url):
     api_client.revoke_token()
     assert api_client.auth_token is None
     assert api_client.access_token is None
-    assert len(responses.calls) == 1
+    assert len(mocked_responses.calls) == 1
 
 
-@responses.activate
-def test_create_resources(api_client, api_url):
+def test_create_resources(mocked_responses, api_client, api_url):
     contacts_data = [
         {
             "id": 1,
@@ -151,7 +148,7 @@ def test_create_resources(api_client, api_url):
             "email": "second@example.com",
         }
     ]
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         api_url + "/contacts/",
         content_type='application/json',
@@ -166,17 +163,16 @@ def test_create_resources(api_client, api_url):
     contacts = api_client._create_resources(Contact, post_data)
     assert len(contacts) == 2
     assert all(isinstance(contact, Contact) for contact in contacts)
-    assert len(responses.calls) == 1
+    assert len(mocked_responses.calls) == 1
 
 
-@responses.activate
-def test_call_resource_method(api_client, api_url):
+def test_call_resource_method(mocked_responses, api_client, api_url):
     contact_data = {
         "id": 1,
         "name": "first",
         "email": "first@example.com",
     }
-    responses.add(
+    mocked_responses.add(
         responses.POST,
         api_url + "/contacts/1/remove_duplicates",
         content_type='application/json',
@@ -188,4 +184,4 @@ def test_call_resource_method(api_client, api_url):
         Contact, 1, "remove_duplicates", {}
     )
     assert isinstance(contact, Contact)
-    assert len(responses.calls) == 1
+    assert len(mocked_responses.calls) == 1

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from nylas.client.errors import InvalidRequestError
 
 # pylint: disable=len-as-condition

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -5,7 +5,6 @@ from nylas.client.errors import InvalidRequestError
 # pylint: disable=len-as-condition
 
 
-@responses.activate
 @pytest.mark.usefixtures(
     "mock_draft_saved_response", "mock_draft_sent_response"
 )
@@ -52,7 +51,6 @@ def test_draft_attachment(api_client):
     assert len(draft.file_ids) == 0
 
 
-@responses.activate
 @pytest.mark.usefixtures(
     "mock_draft_saved_response", "mock_draft_deleted_response"
 )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -41,7 +41,6 @@ def test_event_notify(api_client):
     assert query['other_param'][0] == '1'
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_calendars", "mock_events")
 def test_calendar_events(api_client):
     calendar = api_client.calendars.first()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from urlobject import URLObject
 from nylas.client.errors import InvalidRequestError
 from nylas.client.restful_models import Event

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,6 @@
 import pytest
-import httpretty
 import responses
+from urlobject import URLObject
 from nylas.client.errors import InvalidRequestError
 from nylas.client.restful_models import Event
 
@@ -31,14 +31,15 @@ def test_event_crud(api_client):
 
 
 @pytest.mark.usefixtures("mock_event_create_notify_response")
-def test_event_notify(api_client):
+def test_event_notify(mocked_responses, api_client):
     event1 = blank_event(api_client)
     event1.save(notify_participants='true', other_param='1')
     assert event1.id == 'cv4ei7syx10uvsxbs21ccsezf'
 
-    query = httpretty.last_request().querystring
-    assert query['notify_participants'][0] == 'true'
-    assert query['other_param'][0] == '1'
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query['notify_participants'] == 'true'
+    assert query['other_param'] == '1'
 
 
 @pytest.mark.usefixtures("mock_calendars", "mock_events")

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -13,7 +13,7 @@ def test_no_filter(mocked_responses, api_client, api_url, message_body):
         (200, {}, json.dumps(message_body_list_50)),
     ]
 
-    def callback(request):
+    def callback(_request):
         return values.pop()
 
     mocked_responses.add_callback(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,91 +1,79 @@
 import json
 import random
-import httpretty
-from httpretty import Response
+import responses
+from urlobject import URLObject
 
 
-def test_no_filter(api_client, api_url, message_body):
-    httpretty.enable()
-
+def test_no_filter(mocked_responses, api_client, api_url, message_body):
     message_body_list_50 = [message_body for _ in range(1, 51)]
     message_body_list_22 = [message_body for _ in range(1, 23)]
 
-    # httpretty kind of sucks and strips & parameters from the URL
     values = [
-        Response(status=200, body=json.dumps(message_body_list_50)),
-        Response(status=200, body=json.dumps(message_body_list_22)),
+        (200, {}, json.dumps(message_body_list_22)),
+        (200, {}, json.dumps(message_body_list_50)),
     ]
-    httpretty.register_uri(
-        httpretty.GET,
+
+    def callback(request):
+        return values.pop()
+
+    mocked_responses.add_callback(
+        responses.GET,
         api_url + '/events',
-        responses=values,
+        callback=callback,
     )
 
     events = api_client.events.all()
     assert len(events) == 72
     assert events[0].id == 'cv4ei7syx10uvsxbs21ccsezf'
 
-    httpretty.disable()
 
-
-def test_two_filters(api_client, api_url):
-    httpretty.enable()
-
-    values2 = [Response(status=200, body='[]')]
-    httpretty.register_uri(
-        httpretty.GET,
+def test_two_filters(mocked_responses, api_client, api_url):
+    mocked_responses.add(
+        responses.GET,
         api_url + '/events?param1=a&param2=b',
-        responses=values2,
+        body='[]',
     )
     events = api_client.events.where(param1='a', param2='b').all()
     assert len(events) == 0  # pylint: disable=len-as-condition
-    query = httpretty.last_request().querystring
-    assert query['param1'][0] == 'a'
-    assert query['param2'][0] == 'b'
-    httpretty.disable()
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query['param1'] == 'a'
+    assert query['param2'] == 'b'
 
-def test_no_offset(api_client, api_url):
-    httpretty.enable()
-
-    values = [Response(status=200, body='[]')]
-    httpretty.register_uri(
-        httpretty.GET,
+def test_no_offset(mocked_responses, api_client, api_url):
+    mocked_responses.add(
+        responses.GET,
         api_url + '/events?in=Nylas',
-        responses=values,
+        body='[]',
     )
     list(api_client.events.where({'in': 'Nylas'}).items())
-    query = httpretty.last_request().querystring
-    assert query['in'][0] == 'Nylas'
-    assert query['offset'][0] == '0'
-    httpretty.disable()
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query['in'] == 'Nylas'
+    assert query['offset'] == '0'
 
-def test_zero_offset(api_client, api_url):
-    httpretty.enable()
-
-    values = [Response(status=200, body='[]')]
-    httpretty.register_uri(
-        httpretty.GET,
+def test_zero_offset(mocked_responses, api_client, api_url):
+    mocked_responses.add(
+        responses.GET,
         api_url + '/events?in=Nylas&offset=0',
-        responses=values,
+        body='[]',
     )
     list(api_client.events.where({'in': 'Nylas', 'offset': 0}).items())
-    query = httpretty.last_request().querystring
-    assert query['in'][0] == 'Nylas'
-    assert query['offset'][0] == '0'
-    httpretty.disable()
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query['in'] == 'Nylas'
+    assert query['offset'] == '0'
 
-def test_non_zero_offset(api_client, api_url):
-    httpretty.enable()
-
+def test_non_zero_offset(mocked_responses, api_client, api_url):
     offset = random.randint(1, 1000)
-    values = [Response(status=200, body='[]')]
-    httpretty.register_uri(
-        httpretty.GET,
+    mocked_responses.add(
+        responses.GET,
         api_url + '/events?in=Nylas&offset=' + str(offset),
-        responses=values,
+        body='[]',
     )
+
     list(api_client.events.where({'in': 'Nylas', 'offset': offset}).items())
-    query = httpretty.last_request().querystring
-    assert query['in'][0] == 'Nylas'
-    assert query['offset'][0] == str(offset)
-    httpretty.disable()
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query['in'] == 'Nylas'
+    assert query['offset'] == str(offset)

--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from nylas.client.restful_models import Folder, Thread, Message
 
 

--- a/tests/test_folders.py
+++ b/tests/test_folders.py
@@ -3,7 +3,6 @@ import responses
 from nylas.client.restful_models import Folder, Thread, Message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_folder")
 def test_get_change_folder(api_client):
     folder = api_client.folders.find('anuep8pe5ug3xrupchwzba2o8')
@@ -15,7 +14,6 @@ def test_get_change_folder(api_client):
     assert folder.display_name == 'My New Folder'
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_folder", "mock_threads")
 def test_folder_threads(api_client):
     folder = api_client.folders.find('anuep8pe5ug3xrupchwzba2o8')
@@ -24,7 +22,6 @@ def test_folder_threads(api_client):
                for thread in folder.threads)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_folder", "mock_messages")
 def test_folder_messages(api_client):
     folder = api_client.folders.find('anuep8pe5ug3xrupchwzba2o8')

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -3,7 +3,6 @@ import responses
 from nylas.client.restful_models import Label, Thread, Message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_labels")
 def test_list_labels(api_client):
     labels = api_client.labels
@@ -12,7 +11,6 @@ def test_list_labels(api_client):
     assert all(isinstance(x, Label) for x in labels)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_label")
 def test_get_label(api_client):
     label = api_client.labels.find('anuep8pe5ugmxrucchrzba2o8')

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from nylas.client.restful_models import Label, Thread, Message
 
 
@@ -19,7 +18,6 @@ def test_get_label(api_client):
     assert label.display_name == 'Important'
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_label", "mock_threads")
 def test_label_threads(api_client):
     label = api_client.labels.find('anuep8pe5ugmxrucchrzba2o8')
@@ -28,7 +26,6 @@ def test_label_threads(api_client):
                for thread in label.threads)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_label", "mock_messages")
 def test_label_messages(api_client):
     label = api_client.labels.find('anuep8pe5ugmxrucchrzba2o8')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,12 +1,10 @@
 import json
 import six
 import pytest
-import responses
 from urlobject import URLObject
 from nylas.client.restful_models import Message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_messages")
 def test_messages(api_client):
     message = api_client.messages.first()
@@ -17,7 +15,6 @@ def test_messages(api_client):
     assert not message.starred
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_messages", "mock_message")
 def test_message_stars(api_client):
     message = api_client.messages.first()
@@ -28,7 +25,6 @@ def test_message_stars(api_client):
     assert message.starred is False
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_messages", "mock_message")
 def test_message_read(api_client):
     message = api_client.messages.first()
@@ -41,7 +37,7 @@ def test_message_read(api_client):
     message.mark_as_seen()
     assert message.unread is False
 
-@responses.activate
+
 @pytest.mark.usefixtures("mock_account", "mock_messages", "mock_message")
 def test_message_labels(api_client):
     message = api_client.messages.first()
@@ -59,7 +55,6 @@ def test_message_labels(api_client):
     assert message.folder is None
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_message", "mock_messages")
 def test_message_raw(api_client, account_id):
     message = api_client.messages.first()
@@ -80,17 +75,15 @@ def test_message_raw(api_client, account_id):
     }
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_message")
-def test_message_delete_by_id(api_client):
+def test_message_delete_by_id(mocked_responses, api_client):
     api_client.messages.delete(1234, forceful=True)
-    assert len(responses.calls) == 1
-    request = responses.calls[0].request
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
     url = URLObject(request.url)
     assert url.query_dict["forceful"] == "True"
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_messages")
 def test_slice_messages(api_client):
     messages = api_client.messages[0:2]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 
 
 @pytest.mark.usefixtures("mock_thread_search_response")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,14 +2,13 @@ import pytest
 import responses
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_thread_search_response")
 def test_search_threads(api_client):
     threads = api_client.threads.search("Helena")
     assert len(threads) == 1
     assert "Helena" in threads[0].snippet
 
-@responses.activate
+
 @pytest.mark.usefixtures("mock_message_search_response")
 def test_search_messages(api_client):
     messages = api_client.messages.search("Pinot")
@@ -17,7 +16,7 @@ def test_search_messages(api_client):
     assert "Pinot" in messages[0].snippet
     assert "Pinot" in messages[1].snippet
 
-@responses.activate
+
 @pytest.mark.usefixtures("mock_message_search_response")
 def test_search_drafts(api_client):
     with pytest.raises(Exception):

--- a/tests/test_send_error_handling.py
+++ b/tests/test_send_error_handling.py
@@ -8,7 +8,7 @@ from nylas.client.errors import (
 )
 
 
-def mock_sending_error(http_code, message, api_url, server_error=None):
+def mock_sending_error(http_code, message, mocked_responses, api_url, server_error=None):
     send_endpoint = re.compile(api_url + '/send')
     response_body = {
         "type": "api_error",
@@ -23,51 +23,51 @@ def mock_sending_error(http_code, message, api_url, server_error=None):
         response_body['server_error'] = server_error
 
     response_body = json.dumps(response_body)
-    responses.add(responses.POST, send_endpoint,
-                  content_type='application/json', status=http_code,
-                  body=response_body)
+    mocked_responses.add(
+        responses.POST,
+        send_endpoint,
+        content_type='application/json',
+        status=http_code,
+        body=response_body,
+    )
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
-def test_handle_message_rejected(api_client, api_url):
+def test_handle_message_rejected(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = 'Sending to all recipients failed'
-    mock_sending_error(402, error_message, api_url=api_url)
+    mock_sending_error(402, error_message, mocked_responses, api_url=api_url)
     with pytest.raises(MessageRejectedError) as exc:
         draft.send()
     assert exc.value.message == error_message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
-def test_handle_quota_exceeded(api_client, api_url):
+def test_handle_quota_exceeded(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = 'Daily sending quota exceeded'
-    mock_sending_error(429, error_message, api_url=api_url)
+    mock_sending_error(429, error_message, mocked_responses, api_url=api_url)
     with pytest.raises(SendingQuotaExceededError) as exc:
         draft.send()
     assert exc.value.message == error_message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
-def test_handle_service_unavailable(api_client, api_url):
+def test_handle_service_unavailable(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = 'The server unexpectedly closed the connection'
-    mock_sending_error(503, error_message, api_url=api_url)
+    mock_sending_error(503, error_message, mocked_responses, api_url=api_url)
     with pytest.raises(ServiceUnavailableError) as exc:
         draft.send()
     assert exc.value.message == error_message
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
-def test_returns_server_error(api_client, api_url):
+def test_returns_server_error(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = 'The server unexpectedly closed the connection'
     reason = 'Rejected potential SPAM'
-    mock_sending_error(503, error_message, api_url=api_url,
+    mock_sending_error(503, error_message, mocked_responses, api_url=api_url,
                        server_error=reason)
     with pytest.raises(ServiceUnavailableError) as exc:
         draft.send()
@@ -76,12 +76,11 @@ def test_returns_server_error(api_client, api_url):
     assert exc.value.server_error == reason
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
-def test_doesnt_return_server_error_if_not_defined(api_client, api_url):
+def test_doesnt_return_server_error_if_not_defined(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = 'The server unexpectedly closed the connection'
-    mock_sending_error(503, error_message, api_url=api_url)
+    mock_sending_error(503, error_message, mocked_responses, api_url=api_url)
     with pytest.raises(ServiceUnavailableError) as exc:
         draft.send()
     assert exc.value.message == error_message

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -3,7 +3,6 @@ import responses
 from nylas.client.restful_models import Message, Draft, Label
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_threads")
 def test_thread_folder(api_client):
     thread = api_client.threads.first()
@@ -14,7 +13,6 @@ def test_thread_folder(api_client):
     assert thread.starred
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_folder_account", "mock_threads", "mock_thread")
 def test_thread_change(api_client):
     thread = api_client.threads.first()
@@ -30,7 +28,6 @@ def test_thread_change(api_client):
     assert thread.folders[0].id == 'qwer'
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_threads", "mock_messages")
 def test_thread_messages(api_client):
     thread = api_client.threads.first()
@@ -39,7 +36,6 @@ def test_thread_messages(api_client):
                for message in thread.messages)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_threads", "mock_drafts")
 def test_thread_drafts(api_client):
     thread = api_client.threads.first()
@@ -48,7 +44,6 @@ def test_thread_drafts(api_client):
                for draft in thread.drafts)
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_labelled_thread", "mock_labels")
 def test_thread_label(api_client):
     thread = api_client.threads.find(111)
@@ -65,7 +60,6 @@ def test_thread_label(api_client):
     assert thread.labels == returned
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_labelled_thread", "mock_labels")
 def test_thread_labels(api_client):
     thread = api_client.threads.find(111)
@@ -83,7 +77,6 @@ def test_thread_labels(api_client):
     assert thread.labels == returned
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_threads", "mock_thread")
 def test_thread_read(api_client):
     thread = api_client.threads.first()
@@ -99,7 +92,6 @@ def test_thread_read(api_client):
     assert thread.unread is False
 
 
-@responses.activate
 @pytest.mark.usefixtures("mock_threads")
 def test_thread_reply(api_client):
     thread = api_client.threads.first()

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,5 +1,4 @@
 import pytest
-import responses
 from nylas.client.restful_models import Message, Draft, Label
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,5 @@ envlist = py27,pypy,py34
 
 [testenv]
 commands =
- pip install -e .
+ pip install -e .[test]
  pytest
-deps =
- -rrequirements-dev.txt


### PR DESCRIPTION
This pull request does three things:

* Refactors all usage of [responses](https://github.com/getsentry/responses) to use Pytest fixtures to activate & deactivate the mock. (No more `@responses.activate` decorator on every single test!)
* Replace all usage of [httpretty](https://github.com/gabrielfalcao/HTTPretty) with responses
* Remove all references to httpretty