### PR TITLE
Convert timestamp fields to datetime fields

### DIFF
--- a/examples/webhooks/server.py
+++ b/examples/webhooks/server.py
@@ -129,7 +129,7 @@ def process_delta(delta):
     """
     kwargs = {
         "type": delta["type"],
-        "date": datetime.datetime.fromtimestamp(delta["date"]),
+        "date": datetime.datetime.utcfromtimestamp(delta["date"]),
         "object_id": delta["object_data"]["id"],
     }
     print(" * {type} at {date} with ID {object_id}".format(**kwargs))

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -258,7 +258,9 @@ class APIClient(json.JSONEncoder):
                 postfix
             )
 
-        converted_filters = convert_datetimes_to_timestamps(filters, cls.datetime_attrs)
+        converted_filters = convert_datetimes_to_timestamps(
+            filters, cls.datetime_filter_attrs,
+        )
         url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
@@ -283,7 +285,9 @@ class APIClient(json.JSONEncoder):
             url = "{}/a/{}/{}/{}{}".format(self.api_server, self.app_id,
                                            cls.collection_name, id, postfix)
 
-        converted_filters = convert_datetimes_to_timestamps(filters, cls.datetime_attrs)
+        converted_filters = convert_datetimes_to_timestamps(
+            filters, cls.datetime_filter_attrs,
+        )
         url = str(URLObject(url).add_query_params(converted_filters.items()))
 
         response = self._get_http_session(cls.api_root).get(url, headers=headers)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -19,7 +19,7 @@ from nylas.client.restful_models import (
     Label, Draft
 )
 from nylas.client.errors import APIClientError, ConnectionError, STATUS_MAP
-from nylas.utils import timestamped_data
+from nylas.utils import convert_datetimes_to_timestamps
 
 DEBUG = environ.get('NYLAS_CLIENT_DEBUG')
 API_SERVER = "https://api.nylas.com"
@@ -258,8 +258,8 @@ class APIClient(json.JSONEncoder):
                 postfix
             )
 
-        ts_filters = timestamped_data(filters, cls.datetime_attrs)
-        url = str(URLObject(url).add_query_params(ts_filters.items()))
+        converted_filters = convert_datetimes_to_timestamps(filters, cls.datetime_attrs)
+        url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
         return [
@@ -283,8 +283,8 @@ class APIClient(json.JSONEncoder):
             url = "{}/a/{}/{}/{}{}".format(self.api_server, self.app_id,
                                            cls.collection_name, id, postfix)
 
-        ts_filters = timestamped_data(filters, cls.datetime_attrs)
-        url = str(URLObject(url).add_query_params(ts_filters.items()))
+        converted_filters = convert_datetimes_to_timestamps(filters, cls.datetime_attrs)
+        url = str(URLObject(url).add_query_params(converted_filters.items()))
 
         response = self._get_http_session(cls.api_root).get(url, headers=headers)
         return _validate(response)
@@ -315,10 +315,10 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            ts_data = timestamped_data(data, cls.datetime_attrs)
+            converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
             headers = {'Content-Type': 'application/json'}
             headers.update(self.session.headers)
-            response = session.post(url, json=ts_data, headers=headers)
+            response = session.post(url, json=converted_data, headers=headers)
 
         result = _validate(response).json()
         if cls.collection_name == 'send':
@@ -336,13 +336,13 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            ts_data = [
-                timestamped_data(datum, cls.datetime_attrs)
+            converted_data = [
+                convert_datetimes_to_timestamps(datum, cls.datetime_attrs)
                 for datum in data
             ]
             headers = {'Content-Type': 'application/json'}
             headers.update(self.session.headers)
-            response = session.post(url, json=ts_data, headers=headers)
+            response = session.post(url, json=converted_data, headers=headers)
 
         results = _validate(response).json()
         return [cls.create(self, **x) for x in results]
@@ -370,8 +370,8 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        ts_data = timestamped_data(data, cls.datetime_attrs)
-        response = session.put(url, json=ts_data)
+        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        response = session.put(url, json=converted_data)
 
         result = _validate(response).json()
         return cls.create(self, **result)
@@ -398,10 +398,10 @@ class APIClient(json.JSONEncoder):
             URLObject(self.api_server)
             .with_path(url_path)
         )
-        ts_data = timestamped_data(data, cls.datetime_attrs)
+        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
 
         session = self._get_http_session(cls.api_root)
-        response = session.post(url, json=ts_data)
+        response = session.post(url, json=converted_data)
 
         result = _validate(response).json()
         return cls.create(self, **result)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -1,8 +1,13 @@
 from __future__ import print_function
 import sys
-import json
 from os import environ
 from base64 import b64encode
+import json
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 import requests
 from urlobject import URLObject
 from six.moves.urllib.parse import urlencode
@@ -15,10 +20,6 @@ from nylas.client.restful_models import (
 )
 from nylas.client.errors import APIClientError, ConnectionError, STATUS_MAP
 from nylas.utils import timestamped_data
-try:
-    from json import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
 
 DEBUG = environ.get('NYLAS_CLIENT_DEBUG')
 API_SERVER = "https://api.nylas.com"
@@ -370,7 +371,7 @@ class APIClient(json.JSONEncoder):
         session = self._get_http_session(cls.api_root)
 
         ts_data = timestamped_data(data, cls.datetime_attrs)
-        response = session.put(url, json=data)
+        response = session.put(url, json=ts_data)
 
         result = _validate(response).json()
         return cls.create(self, **result)

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -10,6 +10,7 @@ from six import StringIO
 
 class NylasAPIObject(dict):
     attrs = []
+    datetime_attrs = {}
     # The Nylas API holds most objects for an account directly under '/',
     # but some of them are under '/a' (mostly the account-management
     # and billing code). api_root is a tiny metaprogramming hack to let
@@ -47,7 +48,7 @@ class NylasAPIObject(dict):
                 attr = attr_name[1:]
             if attr in kwargs:
                 obj[attr_name] = kwargs[attr]
-        for dt_attr, ts_attr in getattr(cls, "datetime_attrs", {}).items():
+        for dt_attr, ts_attr in cls.datetime_attrs.items():
             if obj.get(ts_attr):
                 obj[dt_attr] = datetime.utcfromtimestamp(obj[ts_attr])
         if 'id' not in kwargs:
@@ -60,9 +61,9 @@ class NylasAPIObject(dict):
         for attr in self.cls.attrs:
             if hasattr(self, attr):
                 dct[attr] = getattr(self, attr)
-        for dt_attr, ts_attr in getattr(self.cls, "datetime_attrs", {}).items():
+        for dt_attr, ts_attr in self.cls.datetime_attrs.items():
             if self.get(dt_attr):
-                dct[ts_attr] = int(timestamp_from_dt(self[dt_attr]))
+                dct[ts_attr] = timestamp_from_dt(self[dt_attr])
         return dct
 
     def child_collection(self, cls, **filters):
@@ -93,7 +94,10 @@ class Message(NylasAPIObject):
              "thread_id", "to", "unread", "starred", "_folder", "_labels",
              "headers"]
     datetime_attrs = {
-        "received_at": "date"
+        "received_at": "date",
+        # The following are used for filtering:
+        "received_before": "received_before",
+        "received_after": "received_after",
     }
     collection_name = 'messages'
 
@@ -226,6 +230,11 @@ class Thread(NylasAPIObject):
         "last_message_at": "last_message_timestamp",
         "last_message_received_at": "last_message_received_timestamp",
         "last_message_sent_at": "last_message_sent_timestamp",
+        # The following are used for filtering:
+        "last_message_before": "last_message_before",
+        "last_message_after": "last_message_after",
+        "started_before": "started_before",
+        "started_after": "started_after",
     }
     collection_name = 'threads'
 

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -11,6 +11,7 @@ from six import StringIO
 class NylasAPIObject(dict):
     attrs = []
     datetime_attrs = {}
+    datetime_filter_attrs = {}
     # The Nylas API holds most objects for an account directly under '/',
     # but some of them are under '/a' (mostly the account-management
     # and billing code). api_root is a tiny metaprogramming hack to let
@@ -95,7 +96,8 @@ class Message(NylasAPIObject):
              "headers"]
     datetime_attrs = {
         "received_at": "date",
-        # The following are used for filtering:
+    }
+    datetime_filter_attrs = {
         "received_before": "received_before",
         "received_after": "received_after",
     }
@@ -230,7 +232,8 @@ class Thread(NylasAPIObject):
         "last_message_at": "last_message_timestamp",
         "last_message_received_at": "last_message_received_timestamp",
         "last_message_sent_at": "last_message_sent_timestamp",
-        # The following are used for filtering:
+    }
+    datetime_filter_attrs = {
         "last_message_before": "last_message_before",
         "last_message_after": "last_message_after",
         "started_before": "started_before",

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -12,7 +12,7 @@ def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     return delta.seconds + delta.days * 86400
 
 
-def timestamped_data(data, datetime_attrs):
+def convert_datetimes_to_timestamps(data, datetime_attrs):
     """
     Given a dictionary of data, and a dictionary of datetime attributes,
     return a new dictionary that converts any datetime attributes that may

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 def timestamp_from_dt(dt, epoch=datetime(1970,1,1)):
@@ -9,4 +9,24 @@ def timestamp_from_dt(dt, epoch=datetime(1970,1,1)):
     """
     td = dt - epoch
     # return td.total_seconds()
-    return (td.microseconds + (td.seconds + td.days * 86400) * 10**6) / 10**6
+    return td.seconds + td.days * 86400
+
+
+def timestamped_data(data, datetime_attrs):
+    """
+    Given a dictionary of data, and a dictionary of datetime attributes,
+    return a new dictionary that converts any datetime attributes that may
+    be present to their timestamped equivalent.
+    """
+    if not data:
+        return data
+
+    new_data = {}
+    for key, value in data.items():
+        if key in datetime_attrs:
+            new_key = datetime_attrs[key]
+            new_data[new_key] = timestamp_from_dt(value)
+        else:
+            new_data[key] = value
+
+    return new_data

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -1,0 +1,12 @@
+from __future__ import division
+from datetime import datetime, timedelta
+
+
+def timestamp_from_dt(dt, epoch=datetime(1970,1,1)):
+    """
+    Convert a datetime to a timestamp.
+    https://stackoverflow.com/a/8778548/141395
+    """
+    td = dt - epoch
+    # return td.total_seconds()
+    return (td.microseconds + (td.seconds + td.days * 86400) * 10**6) / 10**6

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -2,14 +2,14 @@ from __future__ import division
 from datetime import datetime
 
 
-def timestamp_from_dt(dt, epoch=datetime(1970,1,1)):
+def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     """
     Convert a datetime to a timestamp.
     https://stackoverflow.com/a/8778548/141395
     """
-    td = dt - epoch
-    # return td.total_seconds()
-    return td.seconds + td.days * 86400
+    delta = dt - epoch
+    # return delta.total_seconds()
+    return delta.seconds + delta.days * 86400
 
 
 def timestamped_data(data, datetime_attrs):

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -23,7 +23,7 @@ def convert_datetimes_to_timestamps(data, datetime_attrs):
 
     new_data = {}
     for key, value in data.items():
-        if key in datetime_attrs:
+        if key in datetime_attrs and isinstance(value, datetime):
             new_key = datetime_attrs[key]
             new_data[new_key] = timestamp_from_dt(value)
         else:

--- a/pylintrc
+++ b/pylintrc
@@ -156,7 +156,7 @@ function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 function-rgx=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_,id
+good-names=i,j,k,ex,Run,_,id,dt,db
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,7 +264,8 @@ def mock_messages(mocked_responses, api_url, account_id):
                 }
             ],
             "starred": False,
-            "unread": True
+            "unread": True,
+            "date": 1265077342,
         }, {
             "id": "1238",
             "subject": "Test Message 2",
@@ -278,7 +279,8 @@ def mock_messages(mocked_responses, api_url, account_id):
                 }
             ],
             "starred": False,
-            "unread": True
+            "unread": True,
+            "date": 1265085342,
         }, {
             "id": "12",
             "subject": "Test Message 3",
@@ -292,7 +294,8 @@ def mock_messages(mocked_responses, api_url, account_id):
                 }
             ],
             "starred": False,
-            "unread": False
+            "unread": False,
+            "date": 1265093842,
         }
     ])
     endpoint = re.compile(api_url + '/messages')
@@ -369,7 +372,11 @@ def mock_threads(mocked_responses, api_url, account_id):
                 "id": "abcd"
             }],
             "starred": True,
-            "unread": False
+            "unread": False,
+            "first_message_timestamp": 1451703845,
+            "last_message_timestamp": 1483326245,
+            "last_message_received_timestamp": 1483326245,
+            "last_message_sent_timestamp": 1483232461,
         }
     ])
     endpoint = re.compile(api_url + '/threads')
@@ -395,7 +402,11 @@ def mock_thread(mocked_responses, api_url, account_id):
             "id": "abcd"
         }],
         "starred": True,
-        "unread": False
+        "unread": False,
+        "first_message_timestamp": 1451703845,
+        "last_message_timestamp": 1483326245,
+        "last_message_received_timestamp": 1483326245,
+        "last_message_sent_timestamp": 1483232461,
     }
     response_body = json.dumps(base_thrd)
 
@@ -451,7 +462,11 @@ def mock_labelled_thread(mocked_responses, api_url, account_id):
                 "account_id": account_id,
                 "object": "label"
             }
-        ]
+        ],
+        "first_message_timestamp": 1451703845,
+        "last_message_timestamp": 1483326245,
+        "last_message_received_timestamp": 1483326245,
+        "last_message_sent_timestamp": 1483232461,
     }
     response_body = json.dumps(base_thread)
 
@@ -881,10 +896,17 @@ def mock_events(mocked_responses, api_url):
             "title": "Pool party",
             "location": "Local Community Pool",
             "participants": [
-                "Alice",
-                "Bob",
-                "Claire",
-                "Dot",
+                {
+                    "comment": None,
+                    "email": "kelly@nylas.com",
+                    "name": "Kelly Nylanaut",
+                    "status": "noreply",
+                }, {
+                    "comment": None,
+                    "email": "sarah@nylas.com",
+                    "name": "Sarah Nylanaut",
+                    "status": "no",
+                },
             ]
         }
     ])

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1,7 +1,18 @@
+from datetime import datetime
+
 import pytest
 from nylas.client.errors import InvalidRequestError
+from nylas.utils import timestamp_from_dt
 
 # pylint: disable=len-as-condition
+
+
+@pytest.mark.usefixtures("mock_drafts")
+def test_draft_attrs(api_client):
+    draft = api_client.drafts.first()
+    expected_modified = datetime(2015, 8, 4, 10, 34, 46)
+    assert draft.last_modified_at == expected_modified
+    assert draft.date == timestamp_from_dt(expected_modified)
 
 
 @pytest.mark.usefixtures(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,8 +1,11 @@
+from datetime import datetime
 import json
+
 import six
 import pytest
 from urlobject import URLObject
 from nylas.client.restful_models import Message
+from nylas.utils import timestamp_from_dt
 
 
 @pytest.mark.usefixtures("mock_messages")
@@ -13,6 +16,14 @@ def test_messages(api_client):
     assert message.folder is None
     assert message.unread
     assert not message.starred
+
+
+@pytest.mark.usefixtures("mock_messages")
+def test_message_attrs(api_client):
+    message = api_client.messages.first()
+    expected_received = datetime(2010, 2, 2, 2, 22, 22)
+    assert message.received_at == expected_received
+    assert message.date == timestamp_from_dt(expected_received)
 
 
 @pytest.mark.usefixtures("mock_account", "mock_messages", "mock_message")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -100,3 +100,12 @@ def test_slice_messages(api_client):
     messages = api_client.messages[0:2]
     assert len(messages) == 3
     assert all(isinstance(message, Message) for message in messages)
+
+
+@pytest.mark.usefixtures("mock_messages")
+def test_filter_messages(mocked_responses, api_client):
+    api_client.messages.where(received_before=datetime(2010, 6, 1)).all()
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    url = URLObject(request.url)
+    assert url.query_dict["received_before"] == "1275350400"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -103,8 +103,17 @@ def test_slice_messages(api_client):
 
 
 @pytest.mark.usefixtures("mock_messages")
-def test_filter_messages(mocked_responses, api_client):
+def test_filter_messages_dt(mocked_responses, api_client):
     api_client.messages.where(received_before=datetime(2010, 6, 1)).all()
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    url = URLObject(request.url)
+    assert url.query_dict["received_before"] == "1275350400"
+
+
+@pytest.mark.usefixtures("mock_messages")
+def test_filter_messages_ts(mocked_responses, api_client):
+    api_client.messages.where(received_before=1275350400).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from urlobject import URLObject
 from nylas.client.restful_models import Message, Draft, Label
 from nylas.utils import timestamp_from_dt
 
@@ -132,3 +133,12 @@ def test_thread_reply(api_client):
     assert isinstance(draft, Draft)
     assert draft.thread_id == thread.id
     assert draft.subject == thread.subject
+
+
+@pytest.mark.usefixtures("mock_threads")
+def test_filter_threads(mocked_responses, api_client):
+    api_client.threads.where(started_before=datetime(2010, 6, 1)).all()
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    url = URLObject(request.url)
+    assert url.query_dict["started_before"] == "1275350400"

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,5 +1,39 @@
+from datetime import datetime
+
 import pytest
 from nylas.client.restful_models import Message, Draft, Label
+from nylas.utils import timestamp_from_dt
+
+
+@pytest.mark.usefixtures("mock_threads")
+def test_thread_attrs(api_client):
+    thread = api_client.threads.first()
+    expected_first = datetime(2016, 1, 2, 3, 4, 5)
+    expected_last = datetime(2017, 1, 2, 3, 4, 5)
+    expected_last_received = datetime(2017, 1, 2, 3, 4, 5)
+    expected_last_sent = datetime(2017, 1, 1, 1, 1, 1)
+
+    assert thread.first_message_timestamp == timestamp_from_dt(expected_first)
+    assert thread.first_message_at == expected_first
+    assert thread.last_message_timestamp == timestamp_from_dt(expected_last)
+    assert thread.last_message_at == expected_last
+    assert thread.last_message_received_timestamp == timestamp_from_dt(expected_last_received)
+    assert thread.last_message_received_at == expected_last_received
+    assert thread.last_message_sent_timestamp == timestamp_from_dt(expected_last_sent)
+    assert thread.last_message_sent_at == expected_last_sent
+
+
+def test_update_thread_attrs(api_client):
+    thread = api_client.threads.create()
+    first = datetime(2017, 2, 3, 10, 0, 0)
+    second = datetime(2016, 10, 5, 14, 30, 0)
+    # timestamps and datetimes are handled totally separately
+    thread.last_message_at = first
+    thread.last_message_timestamp = timestamp_from_dt(second)
+    assert thread.last_message_at == first
+    assert thread.last_message_timestamp == timestamp_from_dt(second)
+    # but datetimes overwrite timestamps when serializing to JSON
+    assert thread.as_json()['last_message_timestamp'] == timestamp_from_dt(first)
 
 
 @pytest.mark.usefixtures("mock_threads")

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -136,8 +136,17 @@ def test_thread_reply(api_client):
 
 
 @pytest.mark.usefixtures("mock_threads")
-def test_filter_threads(mocked_responses, api_client):
+def test_filter_threads_dt(mocked_responses, api_client):
     api_client.threads.where(started_before=datetime(2010, 6, 1)).all()
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    url = URLObject(request.url)
+    assert url.query_dict["started_before"] == "1275350400"
+
+
+@pytest.mark.usefixtures("mock_threads")
+def test_filter_threads_ts(mocked_responses, api_client):
+    api_client.threads.where(started_before=1275350400).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)


### PR DESCRIPTION
Fixes #87.

This pull request will allow the SDK to automatically convert timestamp integers into datetime objects in Python. I wanted to make these datetime fields simply views of the timestamp data, but I figured it would be better to not introduce too much complexity into these models, especially since they're just `dict` subclasses to begin with. Check out the `test_update_thread_attrs` test for the implications of this.

Thoughts?