### PR TITLE
Add client.delete_account()

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -179,6 +179,10 @@ class APIClient(json.JSONEncoder):
         self.auth_token = None
         self.access_token = None
 
+    def delete_account(self):
+        self.account.downgrade()
+        self.revoke_token()
+
     @property
     def account(self):
         return self._get_resource(SingletonAccount, '')

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -180,8 +180,8 @@ class APIClient(json.JSONEncoder):
         self.access_token = None
 
     def delete_account(self):
-        self.account.downgrade()
         self.revoke_token()
+        self.account.downgrade()
 
     @property
     def account(self):

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -463,9 +463,6 @@ class Account(NylasAPIObject):
             self, self.account_id, 'downgrade', None
         )
 
-    def delete(self):
-        raise NotImplementedError
-
 
 class APIAccount(NylasAPIObject):
     attrs = ['account_id', 'email_address', 'id', 'name', 'object',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ TEST_DEPENDENCIES = [
     "pytest",
     "pytest-cov",
     "pytest-pylint",
+    "pytest-mock",
     "responses",
 ]
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -32,13 +32,6 @@ def test_account_upgrade(api_client, app_id):
     assert account.billing_state == "paid"
 
 
-def test_account_delete(api_client, monkeypatch):
-    monkeypatch.setattr(api_client, "is_opensource_api", lambda: False)
-    account = api_client.accounts.create()
-    with pytest.raises(NotImplementedError):
-        account.delete()
-
-
 @pytest.mark.usefixtures("mock_accounts", "mock_account")
 def test_account_access(api_client):
     account1 = api_client.account

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -136,6 +136,16 @@ def test_client_revoke_token(mocked_responses, api_client, api_url):
     assert len(mocked_responses.calls) == 1
 
 
+def test_delete_account(mocker, api_client):
+    mocker.patch.object(api_client, "revoke_token")
+    type(api_client).account = mocker.PropertyMock()
+
+    api_client.delete_account()
+
+    api_client.account.downgrade.assert_called_once_with()
+    api_client.revoke_token.assert_called_once_with()
+
+
 def test_create_resources(mocked_responses, api_client, api_url):
     contacts_data = [
         {


### PR DESCRIPTION
Can't make it a method on the account object, because the account doesn't have a reference to the client object :(