### PR TITLE
RestfulModelCollection.items method now checks against limit filter

### DIFF
--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -61,6 +61,7 @@ class RestfulModelCollection(object):
         if filter:
             filters.update(filter)
         filters.setdefault('offset', 0)
+        filters.setdefault('limit', CHUNK_SIZE)
         collection = copy(self)
         collection.filters = filters
         return collection

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -12,6 +12,7 @@ class RestfulModelCollection(object):
             raise Exception("Provided api was not an APIClient.")
 
         filters.setdefault('offset', offset)
+        filters.setdefault('limit', CHUNK_SIZE)
 
         self.model_class = cls
         self.filters = filters
@@ -22,15 +23,16 @@ class RestfulModelCollection(object):
 
     def items(self):
         offset = self.filters['offset']
+        limit = self.filters['limit']
         while True:
-            items = self._get_model_collection(offset, CHUNK_SIZE)
+            items = self._get_model_collection(offset, limit)
             if not items:
                 break
 
             for item in items:
                 yield item
 
-            if len(items) < CHUNK_SIZE:
+            if len(items) < limit:
                 break
 
             offset += len(items)


### PR DESCRIPTION
Without this PR, if you manually set a limit that is higher than `CHUNK_SIZE` you might do unnecessary API calls.

For example, if you have 100 threads, and your limit is 100, this will check that `100 < CHUNK_SIZE` and would continue to do another API call for the next page offset.

We could probably clean up other places in this file that `CHUNK_SIZE` is used since we now make `limit` default to `CHUNK_SIZE`, but I kept the changes minimal.