### PR TITLE
Raise UnSyncedError when message.raw GET request returns 202

### DIFF
--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -6,3 +6,6 @@ class MessageRejectedError(NylasError):
 
 class FileUploadError(NylasError):
     pass
+
+class UnSyncedError(NylasError):
+    pass

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -2,7 +2,7 @@ from datetime import datetime, date
 from collections import defaultdict
 
 from nylas.client.restful_model_collection import RestfulModelCollection
-from nylas.client.errors import FileUploadError
+from nylas.client.errors import FileUploadError, UnSyncedError
 from nylas.utils import timestamp_from_dt
 from six import StringIO
 
@@ -219,8 +219,10 @@ class Message(NylasAPIObject):
     @property
     def raw(self):
         headers = {"Accept": "message/rfc822"}
-        data = self.api._get_resource_data(Message, self.id, headers=headers)
-        return data
+        response = self.api._get_resource_raw(Message, self.id, headers=headers)
+        if response.status_code == 202:
+            raise UnSyncedError(response.content)
+        return response.content
 
 
 class Folder(NylasAPIObject):


### PR DESCRIPTION
Within a few seconds of a message sent, `message.raw` will return with a 202 and content `Message {message_id} has not been synced yet`, so the caller will proceed as though that error message is the actual raw content. This change will raise an Error when that's the case so it's much easier for caller to be aware and deal with that situation.