### PR TITLE
Depend on requests[security]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,9 @@ with open('nylas/_client_sdk_version.py', 'r') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 RUN_DEPENDENCIES = [
-    "requests>=2.4.2",
+    "requests[security]>=2.4.2",
     "six>=1.4.1",
     "bumpversion>=0.5.0",
-    "pyOpenSSL",  # needed for SNI support, required by api.nylas.com
-    "ndg-httpsclient",
-    "pyasn1",
     "urlobject",
 ]
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
Rather than including additional libraries in the dependencies list that appear to be unused. Replaces #109 