### PR TITLE
Update message model to include Reply-To data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ local/
 
 pip-selfcheck.json
 tests/output
+.idea

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -148,6 +148,7 @@ class Message(NylasAPIObject):
         "_folder",
         "_labels",
         "headers",
+        "reply_to",
     ]
     datetime_attrs = {"received_at": "date"}
     datetime_filter_attrs = {


### PR DESCRIPTION
Hello,

When working with python client, I needed the Reply-To field (which is exposed on raw data).
It is missing on Python Client, although.

I extracted it in the pull request below (which I am actually using).