### PR TITLE
change to client_id and client_secret naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ There are several example Flask apps in the `examples` directory. You can run th
 
 ## Usage
 
-### App ID and Secret
+### Client ID and Secret
 
-Before you can interact with the Nylas REST API, you need to create a Nylas developer account at [https://www.nylas.com/](https://www.nylas.com/). After you've created a developer account, you can create a new application to generate an App ID / Secret pair.
+Before you can interact with the Nylas REST API, you need to create a Nylas developer account at [https://www.nylas.com/](https://www.nylas.com/). After you've created a developer account, you can create a new application to generate an Client ID / Secret pair.
 
-Generally, you should store your App ID and Secret into environment variables to avoid adding them to source control. The example projects use configuration
+Generally, you should store your Client ID and Secret into environment variables to avoid adding them to source control. The example projects use configuration
 files instead, to make it easier to get started.
 
 
@@ -31,7 +31,7 @@ files instead, to make it easier to get started.
 The Nylas REST API uses server-side (three-legged) OAuth, and this library provides convenience methods to simplify the OAuth process.
 Here's how it works:
 
-1. You redirect the user to our login page, along with your App Id and Secret
+1. You redirect the user to our login page, along with your Client ID and Secret
 2. Your user logs in
 3. She is redirected to a callback URL of your own, along with an access code
 4. You use this access code to get an authorization token to the API
@@ -49,7 +49,7 @@ from nylas import APIClient
 @app.route('/')
 def index():
     redirect_url = "http://0.0.0.0:8888/login_callback"
-    client = APIClient(APP_ID, APP_SECRET)
+    client = APIClient(CLIENT_ID, CLIENT_SECRET)
     return redirect(client.authentication_url(redirect_url))
 
 ```
@@ -69,7 +69,7 @@ def login_callback():
         return "Login error: {0}".format(request.args['error'])
 
     # Exchange the authorization code for an access token
-    client = APIClient(APP_ID, APP_SECRET)
+    client = APIClient(CLIENT_ID, CLIENT_SECRET)
     code = request.args.get('code')
     session['access_token'] = client.token_for_code(code)
 ```
@@ -104,7 +104,7 @@ use the `revoke_all_tokens` method on APIClient. Pass in the optional
 ### Connecting to an account
 
 ```python
-client = APIClient(APP_ID, APP_SECRET, token)
+client = APIClient(CLIENT_ID, CLIENT_SECRET, token)
 
 # Print out the email address and provider (Gmail, Exchange)
 print(client.account.email_address)
@@ -377,7 +377,7 @@ print([(acc.sync_status, acc.account_id, acc.trial, acc.trial_expires) for acc i
 
 ## Open-Source Sync Engine
 
-The [Nylas Sync Engine](http://github.com/nylas/sync-engine) is open-source, and you can also use the Python library with the open-source API. Since the open-source API provides no authentication or security, connecting to it is simple. When you instantiate the Nylas object, provide null for the App ID, App Secret, and API Token, and pass the fully-qualified address of your copy of the sync engine:
+The [Nylas Sync Engine](http://github.com/nylas/sync-engine) is open-source, and you can also use the Python library with the open-source API. Since the open-source API provides no authentication or security, connecting to it is simple. When you instantiate the Nylas object, provide null for the Client ID, Client Secret, and API Token, and pass the fully-qualified address of your copy of the sync engine:
 
 ```python
 from nylas import APIClient

--- a/examples/hosted-oauth/server.py
+++ b/examples/hosted-oauth/server.py
@@ -87,8 +87,8 @@ def index():
     # If we've gotten to this point, then the user has already connected
     # to Nylas via OAuth. Let's set up the SDK client with the OAuth token:
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=nylas.access_token,
     )
 

--- a/examples/native-authentication-exchange/server.py
+++ b/examples/native-authentication-exchange/server.py
@@ -154,8 +154,8 @@ def success():
         return render_template("missing_token.html")
 
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=session["nylas_access_token"],
     )
 

--- a/examples/native-authentication-gmail/server.py
+++ b/examples/native-authentication-gmail/server.py
@@ -112,8 +112,8 @@ def index():
     # to both Google and Nylas.
     # Let's set up the SDK client with the OAuth token:
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=session["nylas_access_token"],
     )
 

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -118,27 +118,25 @@ class APIClient(json.JSONEncoder):
 
     @property
     def app_id(self):
-        warn(DeprecationWarning('"app_id" naming convention will be deprecated Sept 2019. '
-                                'Use "client_id" instead.'))
+        warn('"app_id" will be deprecated in version 5.0.0. Use "client_id" instead.', PendingDeprecationWarning)
         return self.client_id
 
     @app_id.setter
     def app_id(self, value):
         self.client_id = value
-        warn(DeprecationWarning('"app_id" naming convention will be deprecated Sept 2019. '
-                                'Use "client_id" instead.'))
+        warn('"app_id" will be deprecated in version 5.0.0. Use "client_id" instead.', PendingDeprecationWarning)
 
     @property
     def app_secret(self):
-        warn(DeprecationWarning('"app_secret" naming convention will be deprecated Sept 2019. '
-                                'Use "client_secret" instead.'))
+        warn('"app_secret" will be deprecated in version 5.0.0. Use "client_secret" instead.',
+             PendingDeprecationWarning)
         return self.client_secret
 
     @app_secret.setter
     def app_secret(self, value):
         self.client_secret = value
-        warn(DeprecationWarning('"app_secret" naming convention will be deprecated Sept 2019. '
-                                'Use "client_secret" instead.'))
+        warn('"app_secret" will be deprecated in version 5.0.0. Use "client_secret" instead.',
+             PendingDeprecationWarning)
 
     @property
     def access_token(self):
@@ -226,7 +224,7 @@ class APIClient(json.JSONEncoder):
             self.access_token = None
 
     def ip_addresses(self):
-        ip_addresses_url = self.ip_addresses_url.format(client_id=self.app_id)
+        ip_addresses_url = self.ip_addresses_url.format(client_id=self.client_id)
         resp = self.admin_session.get(ip_addresses_url)
         _validate(resp).json()
         return resp.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1178,9 +1178,9 @@ def mock_revoke_all_tokens(mocked_responses, api_url, account_id, client_id):
 
 
 @pytest.fixture
-def mock_ip_addresses(mocked_responses, api_url, app_id):
-    ip_addresses_url = "{base}/a/{app_id}/ip_addresses".format(
-        base=api_url, app_id=app_id
+def mock_ip_addresses(mocked_responses, api_url, client_id):
+    ip_addresses_url = "{base}/a/{client_id}/ip_addresses".format(
+        base=api_url, client_id=client_id
     )
     mocked_responses.add(
         responses.GET,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,27 +56,27 @@ def api_url():
 
 
 @pytest.fixture
-def app_id():
+def client_id():
     return "fake-app-id"
 
 
 @pytest.fixture
-def app_secret():
+def client_secret():
     return "nyl4n4ut"
 
 
 @pytest.fixture
 def api_client(api_url):
     return APIClient(
-        app_id=None, app_secret=None, access_token=None, api_server=api_url
+        client_id=None, client_secret=None, access_token=None, api_server=api_url
     )
 
 
 @pytest.fixture
-def api_client_with_app_id(access_token, api_url, app_id, app_secret):
+def api_client_with_client_id(access_token, api_url, client_id, client_secret):
     return APIClient(
-        app_id=app_id,
-        app_secret=app_secret,
+        client_id=client_id,
+        client_secret=client_secret,
         access_token=access_token,
         api_server=api_url,
     )
@@ -131,7 +131,7 @@ def mock_account(mocked_responses, api_url, account_id):
 
 
 @pytest.fixture
-def mock_accounts(mocked_responses, api_url, account_id, app_id):
+def mock_accounts(mocked_responses, api_url, account_id, client_id):
     response_body = json.dumps(
         [
             {
@@ -148,7 +148,7 @@ def mock_accounts(mocked_responses, api_url, account_id, app_id):
             }
         ]
     )
-    url_re = "{base}(/a/{app_id})?/accounts/?".format(base=api_url, app_id=app_id)
+    url_re = "{base}(/a/{client_id})?/accounts/?".format(base=api_url, client_id=client_id)
     mocked_responses.add(
         responses.GET,
         re.compile(url_re),
@@ -1126,7 +1126,7 @@ def mock_events(mocked_responses, api_url):
 
 
 @pytest.fixture
-def mock_account_management(mocked_responses, api_url, account_id, app_id):
+def mock_account_management(mocked_responses, api_url, account_id, client_id):
     account = {
         "account_id": account_id,
         "email_address": "ben.bitdiddle1861@gmail.com",
@@ -1141,11 +1141,11 @@ def mock_account_management(mocked_responses, api_url, account_id, app_id):
     account["billing_state"] = "cancelled"
     cancelled_response = json.dumps(account)
 
-    upgrade_url = "{base}/a/{app_id}/accounts/{id}/upgrade".format(
-        base=api_url, id=account_id, app_id=app_id
+    upgrade_url = "{base}/a/{client_id}/accounts/{id}/upgrade".format(
+        base=api_url, id=account_id, client_id=client_id
     )
-    downgrade_url = "{base}/a/{app_id}/accounts/{id}/downgrade".format(
-        base=api_url, id=account_id, app_id=app_id
+    downgrade_url = "{base}/a/{client_id}/accounts/{id}/downgrade".format(
+        base=api_url, id=account_id, client_id=client_id
     )
     mocked_responses.add(
         responses.POST,
@@ -1164,9 +1164,9 @@ def mock_account_management(mocked_responses, api_url, account_id, app_id):
 
 
 @pytest.fixture
-def mock_revoke_all_tokens(mocked_responses, api_url, account_id, app_id):
-    revoke_all_url = "{base}/a/{app_id}/accounts/{id}/revoke-all".format(
-        base=api_url, id=account_id, app_id=app_id
+def mock_revoke_all_tokens(mocked_responses, api_url, account_id, client_id):
+    revoke_all_url = "{base}/a/{client_id}/accounts/{id}/revoke-all".format(
+        base=api_url, id=account_id, client_id=client_id
     )
     mocked_responses.add(
         responses.POST,

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -23,8 +23,8 @@ def test_account_json(api_client, monkeypatch):
 
 
 @pytest.mark.usefixtures("mock_ip_addresses")
-def test_ip_addresses(api_client_with_app_id):
-    result = api_client_with_app_id.ip_addresses()
+def test_ip_addresses(api_client_with_client_id):
+    result = api_client_with_client_id.ip_addresses()
     assert isinstance(result, dict)
     assert "updated_at" in result
     assert "ip_addresses" in result

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -37,8 +37,8 @@ def test_account_datetime(api_client):
 
 
 @pytest.mark.usefixtures("mock_accounts", "mock_account_management")
-def test_account_upgrade(api_client, app_id):
-    api_client.app_id = app_id
+def test_account_upgrade(api_client, client_id):
+    api_client.client_id = client_id
     account = api_client.accounts.first()
     assert account.billing_state == "paid"
     account = account.downgrade()
@@ -55,17 +55,17 @@ def test_account_delete(api_client, monkeypatch):
 
 
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
-def test_revoke_all_tokens(api_client_with_app_id):
-    assert api_client_with_app_id.access_token is not None
-    api_client_with_app_id.revoke_all_tokens()
-    assert api_client_with_app_id.access_token is None
+def test_revoke_all_tokens(api_client_with_client_id):
+    assert api_client_with_client_id.access_token is not None
+    api_client_with_client_id.revoke_all_tokens()
+    assert api_client_with_client_id.access_token is None
 
 
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
-def test_revoke_all_tokens_with_keep_access_token(api_client_with_app_id, access_token):
-    assert api_client_with_app_id.access_token == access_token
-    api_client_with_app_id.revoke_all_tokens(keep_access_token=access_token)
-    assert api_client_with_app_id.access_token == access_token
+def test_revoke_all_tokens_with_keep_access_token(api_client_with_client_id, access_token):
+    assert api_client_with_client_id.access_token == access_token
+    api_client_with_client_id.revoke_all_tokens(keep_access_token=access_token)
+    assert api_client_with_client_id.access_token == access_token
 
 
 @pytest.mark.usefixtures("mock_accounts", "mock_account")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -245,3 +245,11 @@ def test_301_response(mocked_responses, api_client, api_url):
     assert contact["given_name"] == "Charlie"
     assert contact["surname"] == "Bucket"
     assert len(mocked_responses.calls) == 2
+
+
+def test_client_naming_backwards_compatible():
+    client = APIClient(app_id="foo", app_secret="bar")
+    assert client.app_id == "foo"
+    assert client.app_secret == "bar"
+    assert client.client_id == "foo"
+    assert client.client_secret == "bar"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ def test_client_access_token():
 
 
 def test_client_headers():
-    client = APIClient(app_id="whee", app_secret="foo")
+    client = APIClient(client_id="whee", client_secret="foo")
     headers = client.session.headers
     assert headers["X-Nylas-API-Wrapper"] == "python"
     assert headers["X-Nylas-Client-Id"] == "whee"
@@ -52,7 +52,7 @@ def test_client_headers():
 
 
 def test_client_admin_headers():
-    client = APIClient(app_id="bounce", app_secret="foo")
+    client = APIClient(client_id="bounce", client_secret="foo")
     headers = client.admin_session.headers
     assert headers["Authorization"] == "Basic Zm9vOg=="
     assert headers["X-Nylas-API-Wrapper"] == "python"
@@ -153,10 +153,10 @@ def test_client_token_for_code(mocked_responses, api_client, api_url):
 def test_client_opensource_api(api_client):
     # pylint: disable=singleton-comparison
     assert api_client.is_opensource_api() == True
-    api_client.app_id = "foo"
-    api_client.app_secret = "super-sekrit"
+    api_client.client_id = "foo"
+    api_client.client_secret = "super-sekrit"
     assert api_client.is_opensource_api() == False
-    api_client.app_id = api_client.app_secret = None
+    api_client.client_id = api_client.client_secret = None
     assert api_client.is_opensource_api() == True
 
 


### PR DESCRIPTION
Addresses open issue #86 Credentials naming should be consistent - adds deprecation warning for September 2019 and migrates to `client_id` and `client_secret` naming.