### PR TITLE
Add support for `/token_info` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ nylas-python Changelog
 
 Unreleased (dev)
 ----------------
-nothing yet
+* Add support for `/token_info` endpoint, which allows you to query the
+  available scopes and validity of a given access token for an account.
 
 v4.7.0
 ------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -78,6 +78,9 @@ class APIClient(json.JSONEncoder):
             api_server + "/a/{client_id}/accounts/{account_id}/revoke-all"
         )
         self.ip_addresses_url = api_server + "/a/{client_id}/ip_addresses"
+        self.token_info_url = (
+            api_server + "/a/{client_id}/accounts/{account_id}/token_info"
+        )
 
         self.app_secret = app_secret
         self.app_id = app_id
@@ -202,6 +205,14 @@ class APIClient(json.JSONEncoder):
     def ip_addresses(self):
         ip_addresses_url = self.ip_addresses_url.format(client_id=self.app_id)
         resp = self.admin_session.get(ip_addresses_url)
+        _validate(resp).json()
+        return resp.json()
+
+    def token_info(self):
+        token_info_url = self.token_info_url.format(
+            client_id=self.app_id, account_id=self.account.id
+        )
+        resp = self.admin_session.get(token_info_url)
         _validate(resp).json()
         return resp.json()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1199,3 +1199,24 @@ def mock_ip_addresses(mocked_responses, api_url, app_id):
             }
         ),
     )
+
+
+@pytest.fixture
+def mock_token_info(mocked_responses, api_url, account_id, app_id):
+    token_info_url = "{base}/a/{app_id}/accounts/{id}/token_info".format(
+        base=api_url, id=account_id, app_id=app_id
+    )
+    mocked_responses.add(
+        responses.GET,
+        token_info_url,
+        content_type="application/json",
+        status=200,
+        body=json.dumps(
+            {
+                "created_at": 1563496685,
+                "scopes": "calendar,email,contacts",
+                "state": "valid",
+                "updated_at": 1563496685,
+            }
+        ),
+    )

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -30,6 +30,14 @@ def test_ip_addresses(api_client_with_app_id):
     assert "ip_addresses" in result
 
 
+@pytest.mark.usefixtures("mock_token_info", "mock_account")
+def test_token_info(api_client_with_app_id):
+    result = api_client_with_app_id.token_info()
+    assert isinstance(result, dict)
+    assert "updated_at" in result
+    assert "scopes" in result
+
+
 @pytest.mark.usefixtures("mock_account")
 def test_account_datetime(api_client):
     account = api_client.account


### PR DESCRIPTION
https://changelog.nylas.com/new-token-info-endpoint-110263