### PR TITLE
contact resp has emails, not email_addresses

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -535,7 +535,7 @@ class Contact(NylasAPIObject):
     ]
     date_attrs = {"birthday": "birthday"}
     typed_dict_attrs = {
-        "email_addresses": "email",
+        "emails": "email",
         "im_addresses": "im_address",
         "physical_addresses": None,
         "phone_numbers": "number",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,7 +906,7 @@ def mock_contacts(mocked_responses, account_id, api_url):
         "picture_url": "{base}/contacts/{id}/picture".format(
             base=api_url, id="5x6b54whvcz1j22ggiyorhk9v"
         ),
-        "email_addresses": [{"email": "charlie@gmail.com", "type": None}],
+        "emails": [{"email": "charlie@gmail.com", "type": None}],
         "im_addresses": [],
         "physical_addresses": [],
         "phone_numbers": [],
@@ -928,7 +928,7 @@ def mock_contacts(mocked_responses, account_id, api_url):
         "office_location": "Willy Wonka Factory",
         "notes": None,
         "picture_url": None,
-        "email_addresses": [{"email": "scrumptious@wonka.com", "type": None}],
+        "emails": [{"email": "scrumptious@wonka.com", "type": None}],
         "im_addresses": [],
         "physical_addresses": [],
         "phone_numbers": [],
@@ -950,7 +950,7 @@ def mock_contacts(mocked_responses, account_id, api_url):
         "office_location": "Willy Wonka Factory",
         "notes": None,
         "picture_url": None,
-        "email_addresses": [],
+        "emails": [],
         "im_addresses": [],
         "physical_addresses": [],
         "phone_numbers": [],
@@ -1022,7 +1022,7 @@ def mock_contact(mocked_responses, account_id, api_url):
         "picture_url": "{base}/contacts/{id}/picture".format(
             base=api_url, id="9hga75n6mdvq4zgcmhcn7hpys"
         ),
-        "email_addresses": [
+        "emails": [
             {"type": "first", "email": "one@example.com"},
             {"type": "second", "email": "two@example.com"},
             {"type": "primary", "email": "abc@example.com"},

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -77,12 +77,12 @@ def test_contact_no_picture(api_client, mocked_responses):
 @pytest.mark.usefixtures("mock_contact")
 def test_contact_emails(api_client):
     contact = api_client.contacts.get("9hga75n6mdvq4zgcmhcn7hpys")
-    assert isinstance(contact.email_addresses, dict)
-    assert contact.email_addresses["first"] == ["one@example.com"]
-    assert contact.email_addresses["second"] == ["two@example.com"]
-    assert contact.email_addresses["primary"] == ["abc@example.com", "xyz@example.com"]
-    assert contact.email_addresses[None] == ["unknown@example.com"]
-    assert "absent" not in contact.email_addresses
+    assert isinstance(contact.emails, dict)
+    assert contact.emails["first"] == ["one@example.com"]
+    assert contact.emails["second"] == ["two@example.com"]
+    assert contact.emails["primary"] == ["abc@example.com", "xyz@example.com"]
+    assert contact.emails[None] == ["unknown@example.com"]
+    assert "absent" not in contact.emails
 
 
 @pytest.mark.usefixtures("mock_contact")
@@ -129,7 +129,7 @@ def test_update_contact_special_values(api_client, mocked_responses):
     contact = api_client.contacts.get("9hga75n6mdvq4zgcmhcn7hpys")
     assert len(mocked_responses.calls) == 1
     contact.birthday = date(1999, 3, 6)
-    contact.email_addresses["absent"].append("absent@fake.com")
+    contact.emails["absent"].append("absent@fake.com")
     contact.im_addresses["absent"].append("absent-im")
     contact.physical_addresses["absent"].append(
         {
@@ -143,7 +143,7 @@ def test_update_contact_special_values(api_client, mocked_responses):
     contact.save()
     assert len(mocked_responses.calls) == 2
     assert contact.id == "9hga75n6mdvq4zgcmhcn7hpys"
-    assert contact.email_addresses["absent"] == ["absent@fake.com"]
+    assert contact.emails["absent"] == ["absent@fake.com"]
     assert contact.im_addresses["absent"] == ["absent-im"]
     assert contact.physical_addresses["absent"] == [
         {
@@ -168,7 +168,7 @@ def test_update_contact_special_values(api_client, mocked_responses):
     phone_number = {"type": "absent", "number": "222-333-4444"}
     web_page = {"type": "absent", "url": "http://absent.com/me"}
     assert req_body["birthday"] == birthday
-    assert email_address in req_body["email_addresses"]
+    assert email_address in req_body["emails"]
     assert im_address in req_body["im_addresses"]
     assert physical_address in req_body["physical_addresses"]
     assert phone_number in req_body["phone_numbers"]


### PR DESCRIPTION
Bugfix re: expected name of the emails attribute. API docs: https://docs.nylas.com/reference#contacts-intro