### PR TITLE
create message.from_ alias

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -66,6 +66,8 @@ class NylasAPIObject(dict):
                 attr = attr_name[1:]
             if attr in kwargs:
                 obj[attr_name] = kwargs[attr]
+                if attr_name == "from":
+                    obj["from_"] = kwargs[attr]
         for date_attr, iso_attr in cls.date_attrs.items():
             if kwargs.get(iso_attr):
                 obj[date_attr] = datetime.strptime(kwargs[iso_attr], "%Y-%m-%d").date()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,8 @@ def mock_messages(mocked_responses, api_url, account_id):
         [
             {
                 "id": "1234",
+                "to": [{"email": "foo@yahoo.com", "name": "Foo"}],
+                "from": [{"email": "bar@gmail.com", "name": "Bar"}],
                 "subject": "Test Message",
                 "account_id": account_id,
                 "object": "message",
@@ -299,6 +301,8 @@ def mock_messages(mocked_responses, api_url, account_id):
             },
             {
                 "id": "1238",
+                "to": [{"email": "foo2@yahoo.com", "name": "Foo Two"}],
+                "from": [{"email": "bar2@gmail.com", "name": "Bar Two"}],
                 "subject": "Test Message 2",
                 "account_id": account_id,
                 "object": "message",
@@ -309,6 +313,8 @@ def mock_messages(mocked_responses, api_url, account_id):
             },
             {
                 "id": "12",
+                "to": [{"email": "foo3@yahoo.com", "name": "Foo Three"}],
+                "from": [{"email": "bar3@gmail.com", "name": "Bar Three"}],
                 "subject": "Test Message 3",
                 "account_id": account_id,
                 "object": "message",
@@ -335,6 +341,8 @@ def mock_messages(mocked_responses, api_url, account_id):
 def mock_message(mocked_responses, api_url, account_id):
     base_msg = {
         "id": "1234",
+        "to": [{"email": "foo@yahoo.com", "name": "Foo"}],
+        "from": [{"email": "bar@gmail.com", "name": "Bar"}],
         "subject": "Test Message",
         "account_id": account_id,
         "object": "message",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -74,6 +74,8 @@ def test_message_raw(api_client, account_id):
     parsed = json.loads(raw)
     assert parsed == {
         "object": "message",
+        "to": [{"email": "foo@yahoo.com", "name": "Foo"}],
+        "from": [{"email": "bar@gmail.com", "name": "Bar"}],
         "account_id": account_id,
         "labels": [{"display_name": "Inbox", "name": "inbox", "id": "abcd"}],
         "starred": False,
@@ -90,6 +92,21 @@ def test_message_delete_by_id(mocked_responses, api_client):
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)
     assert url.query_dict["forceful"] == "True"
+
+
+@pytest.mark.usefixtures("mock_message")
+def test_message_resolution(mocked_responses, api_client, account_id):
+    message = api_client.messages.get(1234)
+    assert message.object == "message"
+    assert message.to == [{"email": "foo@yahoo.com", "name": "Foo"}]
+    assert message.from_ == [{"email": "bar@gmail.com", "name": "Bar"}]
+    assert message["from"] == [{"email": "bar@gmail.com", "name": "Bar"}]
+    assert message.account_id == account_id
+    assert message._labels == [{"display_name": "Inbox", "name": "inbox", "id": "abcd"}]
+    assert message.id == "1234"
+    assert message.subject == "Test Message"
+    assert message.starred is False
+    assert message.unread is True
 
 
 @pytest.mark.usefixtures("mock_messages")


### PR DESCRIPTION
Following [PEP8](https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles) variable naming guidelines: `single_trailing_underscore_`: used by convention to avoid conflicts with Python keyword