### PR TITLE
Prevent timing attacks by using hmac.compare_digest

### DIFF
--- a/examples/webhooks/server.py
+++ b/examples/webhooks/server.py
@@ -117,7 +117,7 @@ def verify_signature(message, key, signature):
     is your OAuth client secret, which only you and Nylas know.
     """
     digest = hmac.new(key, msg=message, digestmod=hashlib.sha256).hexdigest()
-    return digest == signature
+    return hmac.compare_digest(digest, signature)
 
 
 @celery.task


### PR DESCRIPTION
Per security review from Thomas: https://foundry376.slack.com/archives/CHZ6HDTNG/p1570573877215700

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
