### PR TITLE
Add recurrence rules for events (dateutil)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ language: python
 python:
   - "2.7"
   - "3.6"
-env:
-  - DATEUTIL=1
-  - DATEUTIL=0
 install:
   - "travis_retry pip install -U pip pytest pylint"
   - "travis_retry pip install .[test]"
   - "travis_retry pip install codecov"
-  - "if [[ $DATEUTIL == 1 ]]; then travis_retry pip install python-dateutil; fi"
 script: "python setup.py test"
 after_success:
   - "codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ language: python
 python:
   - "2.7"
   - "3.6"
+env:
+  - DATEUTIL=1
+  - DATEUTIL=0
 install:
   - "travis_retry pip install -U pip pytest pylint"
   - "travis_retry pip install .[test]"
   - "travis_retry pip install codecov"
+  - "if [[ $DATEUTIL == 1 ]]; then travis_retry pip install python-dateutil; fi"
 script: "python setup.py test"
 after_success:
   - "codecov"

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -24,7 +24,7 @@ from nylas.client.restful_models import (
     Label,
     Draft,
 )
-from nylas.utils import convert_datetimes_to_timestamps
+from nylas.utils import convert_data, convert_datetimes_to_timestamps
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
@@ -345,7 +345,7 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+            converted_data = convert_data(data, cls)
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
             response = session.post(url, json=converted_data, headers=headers)
@@ -364,10 +364,7 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            converted_data = [
-                convert_datetimes_to_timestamps(datum, cls.datetime_attrs)
-                for datum in data
-            ]
+            converted_data = [convert_data(datum, cls) for datum in data]
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
             response = session.post(url, json=converted_data, headers=headers)
@@ -396,7 +393,7 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        converted_data = convert_data(data, cls)
         response = session.put(url, json=converted_data)
 
         result = _validate(response).json()
@@ -417,7 +414,7 @@ class APIClient(json.JSONEncoder):
             )
 
         url = URLObject(self.api_server).with_path(url_path)
-        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        converted_data = convert_data(data, cls)
 
         session = self._get_http_session(cls.api_root)
         response = session.post(url, json=converted_data)

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from dateutil.rrule import rruleset, rrulestr
-from six import StringIO
+from six import StringIO, string_types
 from nylas.client.restful_model_collection import RestfulModelCollection
 from nylas.client.errors import FileUploadError, UnSyncedError
 from nylas.utils import timestamp_from_dt
@@ -81,7 +81,11 @@ class NylasAPIObject(dict):
         for rrule_attr, rrule_str_attr in cls.rrule_attrs.items():
             rrule_str = kwargs.get(rrule_str_attr)
             if rrule_str:
-                obj[rrule_attr] = rrulestr(rrule_str)
+                if isinstance(rrule_str, string_types):
+                    rrule = rrulestr(rrule_str)
+                else:
+                    rrule = rrule_str
+                obj[rrule_attr] = rrule
 
         if "id" not in kwargs:
             obj["id"] = None
@@ -121,7 +125,7 @@ class NylasAPIObject(dict):
             if tzinfo:
                 tzname = tzinfo.tzname()
             else:
-                tzname = None
+                tzname = "UTC"
             dct[rrule_attr] = {
                 "rrule": rrule_strs,
                 "timezone": tzname,

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -1,12 +1,7 @@
 from datetime import datetime
 from collections import defaultdict
 
-try:
-    from dateutil.rrule import rruleset, rrulestr
-except ImportError:
-    rruleset = None
-    rrulestr = lambda s: s
-
+from dateutil.rrule import rruleset, rrulestr
 from six import StringIO
 from nylas.client.restful_model_collection import RestfulModelCollection
 from nylas.client.errors import FileUploadError, UnSyncedError
@@ -116,22 +111,21 @@ class NylasAPIObject(dict):
                 for values in typed_dict.values():
                     for value in values:
                         dct[attr].append(value)
-        if rruleset:
-            for rrule_attr, rrule_str_attr in self.cls.rrule_attrs.items():
-                rrule_val = self.get(rrule_attr)
-                if isinstance(rrule_val, rruleset):
-                    rrule_strs = [str(rrule) for rrule in rrule_val]
-                else:
-                    rrule_strs = [str(rrule_val)]
-                tzinfo = getattr(rrule_val, "_tzinfo", None)
-                if tzinfo:
-                    tzname = tzinfo.tzname()
-                else:
-                    tzname = None
-                dct[rrule_attr] = {
-                    "rrule": rrule_strs,
-                    "timezone": tzname,
-                }
+        for rrule_attr, rrule_str_attr in self.cls.rrule_attrs.items():
+            rrule_val = self.get(rrule_attr)
+            if isinstance(rrule_val, rruleset):
+                rrule_strs = [str(rrule) for rrule in rrule_val]
+            else:
+                rrule_strs = [str(rrule_val)]
+            tzinfo = getattr(rrule_val, "_tzinfo", None)
+            if tzinfo:
+                tzname = tzinfo.tzname()
+            else:
+                tzname = None
+            dct[rrule_attr] = {
+                "rrule": rrule_strs,
+                "timezone": tzname,
+            }
         return dct
 
     def child_collection(self, cls, **filters):

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -1,6 +1,11 @@
 from __future__ import division
 from datetime import datetime
 
+try:
+    from dateutil.rrule import rrulebase, rruleset
+except ImportError:
+    rrulebase = rruleset = None
+
 
 def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     """
@@ -30,3 +35,43 @@ def convert_datetimes_to_timestamps(data, datetime_attrs):
             new_data[key] = value
 
     return new_data
+
+
+if rrulebase:
+
+    def convert_rrules_to_strings(data, rrule_attrs):
+        """
+        Given a dictionary of data, and a dict of rrule attributes,
+        return a new dictionary that converts any rrule attributes that may
+        be present to their string equivalent.
+        """
+        if not data:
+            return data
+
+        new_data = {}
+        for key, value in data.items():
+            if key in rrule_attrs and isinstance(value, rrulebase):
+                new_key = rrule_attrs[key]
+                if isinstance(value, rruleset):
+                    new_data[new_key] = [str(rrule) for rrule in value]
+                else:
+                    new_data[new_key] = [str(value)]
+            else:
+                new_data[key] = value
+
+        return new_data
+
+
+else:
+    # can't import dateutil, so this is a no-op
+    def convert_rrules_to_strings(data, rrule_attrs):
+        return data
+
+
+def convert_data(data, cls):
+    datetime_attrs = getattr(cls, "datetime_attrs", [])
+    rrule_attrs = getattr(cls, "rrule_attrs", [])
+
+    d1 = convert_datetimes_to_timestamps(data, datetime_attrs)
+    d2 = convert_rrules_to_strings(d1, rrule_attrs)
+    return d2

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -1,10 +1,7 @@
 from __future__ import division
 from datetime import datetime
 
-try:
-    from dateutil.rrule import rrulebase, rruleset
-except ImportError:
-    rrulebase = rruleset = None
+from dateutil.rrule import rrulebase, rruleset
 
 
 def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
@@ -37,35 +34,27 @@ def convert_datetimes_to_timestamps(data, datetime_attrs):
     return new_data
 
 
-if rrulebase:
-
-    def convert_rrules_to_strings(data, rrule_attrs):
-        """
-        Given a dictionary of data, and a dict of rrule attributes,
-        return a new dictionary that converts any rrule attributes that may
-        be present to their string equivalent.
-        """
-        if not data:
-            return data
-
-        new_data = {}
-        for key, value in data.items():
-            if key in rrule_attrs and isinstance(value, rrulebase):
-                new_key = rrule_attrs[key]
-                if isinstance(value, rruleset):
-                    new_data[new_key] = [str(rrule) for rrule in value]
-                else:
-                    new_data[new_key] = [str(value)]
-            else:
-                new_data[key] = value
-
-        return new_data
-
-
-else:
-    # can't import dateutil, so this is a no-op
-    def convert_rrules_to_strings(data, rrule_attrs):
+def convert_rrules_to_strings(data, rrule_attrs):
+    """
+    Given a dictionary of data, and a dict of rrule attributes,
+    return a new dictionary that converts any rrule attributes that may
+    be present to their string equivalent.
+    """
+    if not data:
         return data
+
+    new_data = {}
+    for key, value in data.items():
+        if key in rrule_attrs and isinstance(value, rrulebase):
+            new_key = rrule_attrs[key]
+            if isinstance(value, rruleset):
+                new_data[new_key] = [str(rrule) for rrule in value]
+            else:
+                new_data[new_key] = [str(value)]
+        else:
+            new_data[key] = value
+
+    return new_data
 
 
 def convert_data(data, cls):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ RUN_DEPENDENCIES = [
     "six>=1.4.1",
     "bumpversion>=0.5.0",
     "urlobject",
+    "python-dateutil",
 ]
 TEST_DEPENDENCIES = ["pytest", "pytest-cov", "responses==0.10.5", "twine"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1130,6 +1130,7 @@ def mock_events(mocked_responses, api_url):
                         "status": "no",
                     },
                 ],
+                "recurrence": "DTSTART:20141231T000000\nRRULE:FREQ=MONTHLY;COUNT=4",
             }
         ]
     )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -101,8 +101,7 @@ def test_recurring_event(api_client, mocked_responses):
     assert recurrence
     rrule_list = recurrence.get("rrule")
     assert rrule_list == ["DTSTART:20141231T000000\nRRULE:FREQ=MONTHLY;COUNT=4"]
-    assert "timezone" in recurrence
-    assert recurrence["timezone"] is None
+    assert recurrence["timezone"] == "UTC"
 
 
 @pytest.mark.usefixtures("mock_events")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,18 +1,11 @@
 import json
 import pytest
 import six
+import dateutil
 from datetime import datetime
 from urlobject import URLObject
 from requests import RequestException
 from nylas.client.restful_models import Event
-
-try:
-    import dateutil
-except ImportError:
-    dateutil = None
-
-requires_dateutil = pytest.mark.skipif(not dateutil, reason="dateutil is required")
-forbids_dateutil = pytest.mark.skipif(dateutil, reason="dateutil is forbidden")
 
 
 def blank_event(api_client):
@@ -92,7 +85,6 @@ def test_event_rsvp_invalid(mocked_responses, api_client):
         event.rsvp("purple")
 
 
-@requires_dateutil
 @pytest.mark.usefixtures("mock_event_create_response")
 def test_recurring_event(api_client, mocked_responses):
     event = blank_event(api_client)
@@ -113,17 +105,8 @@ def test_recurring_event(api_client, mocked_responses):
     assert recurrence["timezone"] is None
 
 
-@requires_dateutil
 @pytest.mark.usefixtures("mock_events")
 def test_get_recurring_event(api_client, mocked_responses):
     event = api_client.events.first()
     assert event.recurrence
     assert isinstance(event.recurrence, dateutil.rrule.rrule)
-
-
-@forbids_dateutil
-@pytest.mark.usefixtures("mock_events")
-def test_get_recurring_event_no_dateutil(api_client, mocked_responses):
-    event = api_client.events.first()
-    assert event.recurrence
-    assert isinstance(event.recurrence, six.text_type)


### PR DESCRIPTION
This pull request adds recurrence rules for creating events. If the [`dateutil` module](https://dateutil.readthedocs.io/en/stable/) is installed, the SDK will use `dateutil.rrule.rrule` objects to represent recurrence rules; otherwise, they will be plain text strings.

I haven't done much testing with this yet -- I just wrote an automated test as a sanity check, not to be exhaustive. Definitely interested in feedback on the direction here -- should we make `dateutil` a required dependency? Should we handle this differently somehow?