### PR TITLE
Check message ID before trying to RSVP to an event

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -611,6 +611,10 @@ class Event(NylasAPIObject):
         return dct
 
     def rsvp(self, status, comment=None):
+        if not self.message_id:
+            raise ValueError(
+                "This event was not imported from an iCalendar invite, and so it is not possible to RSVP via Nylas"
+            )
         if status not in {"yes", "no", "maybe"}:
             raise ValueError("invalid status: {status}".format(status=status))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1114,6 +1114,7 @@ def mock_events(mocked_responses, api_url):
         [
             {
                 "id": "1234abcd5678",
+                "message_id": "evh5uy0shhpm5d0le89goor17",
                 "title": "Pool party",
                 "location": "Local Community Pool",
                 "participants": [
@@ -1130,7 +1131,13 @@ def mock_events(mocked_responses, api_url):
                         "status": "no",
                     },
                 ],
-            }
+            },
+            {
+                "id": "9876543cba",
+                "message_id": None,
+                "title": "Event Without Message",
+                "description": "This event does not have a corresponding message ID.",
+            },
         ]
     )
     endpoint = re.compile(api_url + "/events")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -78,8 +78,9 @@ def test_event_rsvp_with_comment(mocked_responses, api_client):
 @pytest.mark.usefixtures("mock_events")
 def test_event_rsvp_invalid(api_client):
     event = api_client.events.first()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         event.rsvp("purple")
+    assert "invalid status" in str(excinfo)
 
 
 @pytest.mark.usefixtures("mock_events")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -76,14 +76,14 @@ def test_event_rsvp_with_comment(mocked_responses, api_client):
 
 
 @pytest.mark.usefixtures("mock_events")
-def test_event_rsvp_invalid(mocked_responses, api_client):
+def test_event_rsvp_invalid(api_client):
     event = api_client.events.first()
     with pytest.raises(ValueError):
         event.rsvp("purple")
 
 
 @pytest.mark.usefixtures("mock_events")
-def test_event_rsvp_no_message(mocked_responses, api_client):
+def test_event_rsvp_no_message(api_client):
     event = api_client.events.all()[1]
     with pytest.raises(ValueError) as excinfo:
         event.rsvp("yes")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -80,3 +80,11 @@ def test_event_rsvp_invalid(mocked_responses, api_client):
     event = api_client.events.first()
     with pytest.raises(ValueError):
         event.rsvp("purple")
+
+
+@pytest.mark.usefixtures("mock_events")
+def test_event_rsvp_no_message(mocked_responses, api_client):
+    event = api_client.events.all()[1]
+    with pytest.raises(ValueError) as excinfo:
+        event.rsvp("yes")
+    assert "This event was not imported from an iCalendar invite" in str(excinfo)


### PR DESCRIPTION
The Nylas API does not allow RSVPing to events without an associated message. Since we know that in advance, the SDK can raise an error before even sending the HTTP request. This not only saves bandwidth, but makes the error clearer for the developer.