### PR TITLE
Add `ical_uid` to Event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ nylas-python Changelog
 
 Unreleased (dev)
 ----------------
-nothing yet
+* Add `ical_uid` to Event model, only available on API version 2.1 or above. See https://headwayapp.co/nylas-changelog/icaluid-support-132816
 
 v4.9.0
 ------

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -591,6 +591,7 @@ class Event(NylasAPIObject):
         "original_start_time",
         "object",
         "message_id",
+        "ical_uid",
     ]
     datetime_attrs = {"original_start_at": "original_start_time"}
     collection_name = "events"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1115,6 +1115,7 @@ def mock_events(mocked_responses, api_url):
             {
                 "id": "1234abcd5678",
                 "message_id": "evh5uy0shhpm5d0le89goor17",
+                "ical_uid": "19960401T080045Z-4000F192713-0052@example.com",
                 "title": "Pool party",
                 "location": "Local Community Pool",
                 "participants": [
@@ -1135,6 +1136,7 @@ def mock_events(mocked_responses, api_url):
             {
                 "id": "9876543cba",
                 "message_id": None,
+                "ical_uid": None,
                 "title": "Event Without Message",
                 "description": "This event does not have a corresponding message ID.",
             },


### PR DESCRIPTION
Add `ical_uid` to Event model, only available on API version 2.1 or above. See https://headwayapp.co/nylas-changelog/icaluid-support-132816