### PR TITLE
[58500] Python SDK support for metadata for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ nylas-python Changelog
 
 Unreleased (dev)
 ----------------
-nothing yet
+* Add `metadata` field in the Event model to support new event metadata feature
+* Add filtering support for `metadata_pair`
 
 v4.12.1
 -------

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -77,9 +77,9 @@ class RestfulModelCollection(object):
             filters.update(filter)
         filters.setdefault("offset", 0)
 
-        if 'metadata_pair' in filters:
-            pairs = convert_metadata_pairs_to_array(filters['metadata_pair'])
-            filters['metadata_pair'] = pairs
+        if "metadata_pair" in filters:
+            pairs = convert_metadata_pairs_to_array(filters["metadata_pair"])
+            filters["metadata_pair"] = pairs
 
         collection = copy(self)
         collection.filters = filters

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -1,4 +1,5 @@
 from copy import copy
+from nylas.utils import convert_metadata_pairs_to_array
 
 CHUNK_SIZE = 50
 
@@ -75,6 +76,11 @@ class RestfulModelCollection(object):
         if filter:
             filters.update(filter)
         filters.setdefault("offset", 0)
+
+        if 'metadata_pair' in filters:
+            pairs = convert_metadata_pairs_to_array(filters['metadata_pair'])
+            filters['metadata_pair'] = pairs
+
         collection = copy(self)
         collection.filters = filters
         return collection

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -590,7 +590,7 @@ class Event(NylasAPIObject):
         "object",
         "message_id",
         "ical_uid",
-        "metadata"
+        "metadata",
     ]
     datetime_attrs = {"original_start_at": "original_start_time"}
     collection_name = "events"

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -590,6 +590,7 @@ class Event(NylasAPIObject):
         "object",
         "message_id",
         "ical_uid",
+        "metadata"
     ]
     datetime_attrs = {"original_start_at": "original_start_time"}
     collection_name = "events"

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -42,6 +42,6 @@ def convert_metadata_pairs_to_array(data):
 
     metadata_pair = []
     for key, value in data.items():
-        metadata_pair.append(key + ':' + value)
+        metadata_pair.append(key + ":" + value)
 
     return metadata_pair

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -30,3 +30,18 @@ def convert_datetimes_to_timestamps(data, datetime_attrs):
             new_data[key] = value
 
     return new_data
+
+
+def convert_metadata_pairs_to_array(data):
+    """
+    Given a dictionary of metadata pairs, convert it to key-value pairs
+    in the format the Nylas API expects: "events?metadata_pair=<key>:<value>"
+    """
+    if not data:
+        return data
+
+    metadata_pair = []
+    for key, value in data.items():
+        metadata_pair.append(key + ':' + value)
+
+    return metadata_pair

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1180,6 +1180,7 @@ def mock_events(mocked_responses, api_url):
                     "status": "no",
                 },
             ],
+            "metadata": {},
         },
         {
             "id": "9876543cba",
@@ -1187,14 +1188,42 @@ def mock_events(mocked_responses, api_url):
             "ical_uid": None,
             "title": "Event Without Message",
             "description": "This event does not have a corresponding message ID.",
+            "metadata": {},
+        },
+        {
+            "id": "1231241zxc",
+            "message_id": None,
+            "ical_uid": None,
+            "title": "Event With Metadata",
+            "description": "This event uses metadata to store custom values.",
+            "metadata": {
+                "platform": "python",
+                "event_type": "meeting"
+            },
         },
     ]
 
     def list_callback(request):
         url = URLObject(request.url)
         offset = int(url.query_dict.get("offset") or 0)
+        metadata_key = url.query_multi_dict.get("metadata_key")
+        metadata_value = url.query_multi_dict.get("metadata_value")
+        metadata_pair = url.query_multi_dict.get("metadata_pair")
+
         if offset:
             return (200, {}, json.dumps([]))
+        if metadata_key or metadata_value or metadata_pair:
+            results = []
+            for event in events:
+                if (metadata_key and set(metadata_key) & set(event["metadata"]) or
+                        metadata_value and set(metadata_value) & set(event["metadata"].values())):
+                    results.append(event)
+                elif metadata_pair:
+                    for pair in metadata_pair:
+                        key_value = pair.split(":")
+                        if key_value[0] in event["metadata"] and event["metadata"][key_value[0]] == key_value[1]:
+                            results.append(event)
+            return (200, {}, json.dumps(results))
         return (200, {}, json.dumps(events))
 
     endpoint = re.compile(api_url + "/events")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1196,10 +1196,7 @@ def mock_events(mocked_responses, api_url):
             "ical_uid": None,
             "title": "Event With Metadata",
             "description": "This event uses metadata to store custom values.",
-            "metadata": {
-                "platform": "python",
-                "event_type": "meeting"
-            },
+            "metadata": {"platform": "python", "event_type": "meeting"},
         },
     ]
 
@@ -1215,13 +1212,20 @@ def mock_events(mocked_responses, api_url):
         if metadata_key or metadata_value or metadata_pair:
             results = []
             for event in events:
-                if (metadata_key and set(metadata_key) & set(event["metadata"]) or
-                        metadata_value and set(metadata_value) & set(event["metadata"].values())):
+                if (
+                    metadata_key
+                    and set(metadata_key) & set(event["metadata"])
+                    or metadata_value
+                    and set(metadata_value) & set(event["metadata"].values())
+                ):
                     results.append(event)
                 elif metadata_pair:
                     for pair in metadata_pair:
                         key_value = pair.split(":")
-                        if key_value[0] in event["metadata"] and event["metadata"][key_value[0]] == key_value[1]:
+                        if (
+                            key_value[0] in event["metadata"]
+                            and event["metadata"][key_value[0]] == key_value[1]
+                        ):
                             results.append(event)
             return (200, {}, json.dumps(results))
         return (200, {}, json.dumps(events))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -272,3 +272,24 @@ def test_availability_with_free_busy(mocked_responses, api_client):
     assert data["start_time"] == 1577836800
     assert data["end_time"] == 1577923200
     assert data["free_busy"] == free_busy
+
+@pytest.mark.usefixtures("mock_events")
+def test_metadata_filtering(api_client):
+    events_filtered_by_key = api_client.events.where(metadata_key="platform")
+    assert len(events_filtered_by_key.all()) > 0
+    for event in events_filtered_by_key:
+        assert "platform" in event["metadata"]
+
+    events_filtered_by_value = api_client.events.where(metadata_value=["meeting", "java"])
+    assert len(events_filtered_by_value.all()) > 0
+    for event in events_filtered_by_value:
+        assert event["metadata"]["event_type"] == "meeting"
+
+    events_filtered_by_pair = api_client.events.where(metadata_pair={"platform": "python", "bla": "blablabla"})
+    assert len(events_filtered_by_pair.all()) > 0
+    for event in events_filtered_by_pair:
+        assert "platform" in event["metadata"]
+        assert event["metadata"]["platform"] == "python"
+
+    non_existant_event = api_client.events.where(metadata_pair={"bla": "blablabla"})
+    assert len(non_existant_event.all()) == 0

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -273,6 +273,7 @@ def test_availability_with_free_busy(mocked_responses, api_client):
     assert data["end_time"] == 1577923200
     assert data["free_busy"] == free_busy
 
+
 @pytest.mark.usefixtures("mock_events")
 def test_metadata_filtering(api_client):
     events_filtered_by_key = api_client.events.where(metadata_key="platform")
@@ -280,12 +281,16 @@ def test_metadata_filtering(api_client):
     for event in events_filtered_by_key:
         assert "platform" in event["metadata"]
 
-    events_filtered_by_value = api_client.events.where(metadata_value=["meeting", "java"])
+    events_filtered_by_value = api_client.events.where(
+        metadata_value=["meeting", "java"]
+    )
     assert len(events_filtered_by_value.all()) > 0
     for event in events_filtered_by_value:
         assert event["metadata"]["event_type"] == "meeting"
 
-    events_filtered_by_pair = api_client.events.where(metadata_pair={"platform": "python", "bla": "blablabla"})
+    events_filtered_by_pair = api_client.events.where(
+        metadata_pair={"platform": "python", "bla": "blablabla"}
+    )
     assert len(events_filtered_by_pair.all()) > 0
     for event in events_filtered_by_pair:
         assert "platform" in event["metadata"]


### PR DESCRIPTION
# Description
The Nylas Calendar API has a new beta feature of adding a new [metadata field to calendar events](https://www.nylas.com/blog/event-metadata). This PR makes the feature available via the Nylas Python SDK.

# Usage
To filter using either `metadata_key` or `metadata_value` you can pass in a string:
`events = nylas.events.where(metadata_key='hello').all()`
or, you can pass in multiple strings as an array:
`events = nylas.events.where(metadata_value=['value1', 'value2']).all()`

To filter on `metadata_pair` you can pass in a `dict` of key-value pairs to use in the query:
`events = nylas.events.where(metadata_pair={'hello': 'world'}).all()`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
