### PR TITLE
[62077] Fix adding a tracking object to an existing `draft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (dev)
 ----------------
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
+* Fix adding a tracking object to an existing `draft`
 
 v4.12.1
 -------

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -460,6 +460,8 @@ class Draft(Message):
             data = {"draft_id": self.id}
             if hasattr(self, "version"):
                 data["version"] = self.version
+            if hasattr(self, "tracking") and self.tracking is not None:
+                data["tracking"] = self.tracking
 
         msg = self.api._create_resource(Send, data)
         if msg:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -705,35 +705,10 @@ def mock_draft_sent_response(mocked_responses, api_url):
 
 @pytest.fixture
 def mock_draft_send_unsaved_response(mocked_responses, api_url):
-    body = {
-        "id": None,
-        "bcc": [],
-        "body": "Our latest sale!",
-        "cc": [],
-        "date": 1438684486,
-        "events": [],
-        "files": [],
-        "folder": None,
-        "from": [{"email": "benb@nylas.com"}],
-        "namespace_id": "384uhp3aj8l7rpmv9s2y2rukn",
-        "object": "draft",
-        "reply_to": [],
-        "reply_to_message_id": None,
-        "snippet": "",
-        "starred": False,
-        "subject": "Newsletter",
-        "thread_id": None,
-        "to": [{"email": "my.friend@example.com", "name": "My Friend"}],
-        "unread": False,
-        "version": 0,
-    }
-
-    values = [(400, {}, "Couldn't send email"), (200, {}, json.dumps(body))]
-
     def callback(request):
         payload = json.loads(request.body)
         payload["draft_id"] = "2h111aefv8pzwzfykrn7hercj"
-        return values.pop()
+        return 200, {}, json.dumps(payload)
 
     mocked_responses.add_callback(
         responses.POST,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -704,6 +704,46 @@ def mock_draft_sent_response(mocked_responses, api_url):
 
 
 @pytest.fixture
+def mock_draft_send_unsaved_response(mocked_responses, api_url):
+    body = {
+        "id": None,
+        "bcc": [],
+        "body": "Our latest sale!",
+        "cc": [],
+        "date": 1438684486,
+        "events": [],
+        "files": [],
+        "folder": None,
+        "from": [{"email": "benb@nylas.com"}],
+        "namespace_id": "384uhp3aj8l7rpmv9s2y2rukn",
+        "object": "draft",
+        "reply_to": [],
+        "reply_to_message_id": None,
+        "snippet": "",
+        "starred": False,
+        "subject": "Newsletter",
+        "thread_id": None,
+        "to": [{"email": "my.friend@example.com", "name": "My Friend"}],
+        "unread": False,
+        "version": 0,
+    }
+
+    values = [(400, {}, "Couldn't send email"), (200, {}, json.dumps(body))]
+
+    def callback(request):
+        payload = json.loads(request.body)
+        payload["draft_id"] = "2h111aefv8pzwzfykrn7hercj"
+        return values.pop()
+
+    mocked_responses.add_callback(
+        responses.POST,
+        api_url + "/send/",
+        callback=callback,
+        content_type="application/json",
+    )
+
+
+@pytest.fixture
 def mock_files(mocked_responses, api_url, account_id):
     files_content = {"3qfe4k3siosfjtjpfdnon8zbn": b"Hello, World!"}
     files_metadata = {


### PR DESCRIPTION
# Description
The Python SDK creates a special payload specifically for sending an already-existing `draft` object that extracts the draft ID and the draft's version and sends that as a payload. However, it does not check if a tracking object exists, and thus if a user were to save a draft, and come add a tracking object to it (or if the user saves the draft with the tracking object first) and tries to send it after the save, the SDK never sends the tracking object in the payload. This PR adds a check to add a tracking object if present in the `draft`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
