### PR TITLE
[62132] Fix issue when converting offset-aware `datetime` objects to `timestamp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (dev)
 ----------------
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
+* Fix issue when converting offset-aware `datetime` objects to `timestamp`
 
 v4.12.1
 -------

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
@@ -13,7 +13,7 @@ def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
 
     delta = dt - epoch
 
-    return delta.seconds + delta.days * 86400
+    return int(delta.total_seconds() / timedelta(seconds=1).total_seconds())
 
 
 def convert_datetimes_to_timestamps(data, datetime_attrs):

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -7,8 +7,12 @@ def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     Convert a datetime to a timestamp.
     https://stackoverflow.com/a/8778548/141395
     """
+    # For offset-aware datetime objects, convert them first before performing delta
+    if dt.tzinfo is not None and dt.utcoffset() is not None:
+        dt = dt.replace(tzinfo=None) - dt.utcoffset()
+
     delta = dt - epoch
-    # return delta.total_seconds()
+
     return delta.seconds + delta.days * 86400
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ TEST_DEPENDENCIES = [
     "pytest-timeout",
     "responses==0.10.5",
     "twine",
+    "pytz"
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TEST_DEPENDENCIES = [
     "pytest-timeout",
     "responses==0.10.5",
     "twine",
-    "pytz"
+    "pytz",
 ]
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -127,7 +127,9 @@ def test_filter_messages_dt(mocked_responses, api_client):
 
 @pytest.mark.usefixtures("mock_messages")
 def test_filter_messages_dt_with_timezone(mocked_responses, api_client):
-    api_client.messages.where(received_before=datetime.datetime(2010, 6, 1, tzinfo=datetime.timezone.utc)).all()
+    api_client.messages.where(
+        received_before=datetime.datetime(2010, 6, 1, tzinfo=datetime.timezone.utc)
+    ).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import json
 
 import six
@@ -6,6 +6,7 @@ import pytest
 from urlobject import URLObject
 from nylas.client.restful_models import Message
 from nylas.utils import timestamp_from_dt
+import pytz
 
 
 @pytest.mark.usefixtures("mock_messages")
@@ -21,7 +22,7 @@ def test_messages(api_client):
 @pytest.mark.usefixtures("mock_messages")
 def test_message_attrs(api_client):
     message = api_client.messages.first()
-    expected_received = datetime.datetime(2010, 2, 2, 2, 22, 22)
+    expected_received = datetime(2010, 2, 2, 2, 22, 22)
     assert message.received_at == expected_received
     assert message.date == timestamp_from_dt(expected_received)
 
@@ -118,7 +119,7 @@ def test_slice_messages(api_client):
 
 @pytest.mark.usefixtures("mock_messages")
 def test_filter_messages_dt(mocked_responses, api_client):
-    api_client.messages.where(received_before=datetime.datetime(2010, 6, 1)).all()
+    api_client.messages.where(received_before=datetime(2010, 6, 1)).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)
@@ -128,7 +129,7 @@ def test_filter_messages_dt(mocked_responses, api_client):
 @pytest.mark.usefixtures("mock_messages")
 def test_filter_messages_dt_with_timezone(mocked_responses, api_client):
     api_client.messages.where(
-        received_before=datetime.datetime(2010, 6, 1, tzinfo=datetime.timezone.utc)
+        received_before=datetime(2010, 6, 1, tzinfo=pytz.utc)
     ).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 import json
 
 import six
@@ -21,7 +21,7 @@ def test_messages(api_client):
 @pytest.mark.usefixtures("mock_messages")
 def test_message_attrs(api_client):
     message = api_client.messages.first()
-    expected_received = datetime(2010, 2, 2, 2, 22, 22)
+    expected_received = datetime.datetime(2010, 2, 2, 2, 22, 22)
     assert message.received_at == expected_received
     assert message.date == timestamp_from_dt(expected_received)
 
@@ -118,7 +118,16 @@ def test_slice_messages(api_client):
 
 @pytest.mark.usefixtures("mock_messages")
 def test_filter_messages_dt(mocked_responses, api_client):
-    api_client.messages.where(received_before=datetime(2010, 6, 1)).all()
+    api_client.messages.where(received_before=datetime.datetime(2010, 6, 1)).all()
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    url = URLObject(request.url)
+    assert url.query_dict["received_before"] == "1275350400"
+
+
+@pytest.mark.usefixtures("mock_messages")
+def test_filter_messages_dt_with_timezone(mocked_responses, api_client):
+    api_client.messages.where(received_before=datetime.datetime(2010, 6, 1, tzinfo=datetime.timezone.utc)).all()
     assert len(mocked_responses.calls) == 1
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)


### PR DESCRIPTION
# Description
Wherever we accept a date as a filtering parameter, we usually convert it from a `datetime` object to a `timestamp` object. However the way we convert it does not take into consideration if the `datetime` is offset-aware or not (timezone), and thus would throw an error when it's attempted. Now we check if the `datetime` is context-aware, and if it is, we convert it properly to being an offset-naive object before converting it to a timestamp.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
