### PR TITLE
[47453] Fix `limit` value in filter not being used when making `.all()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (dev)
 ----------------
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
+* Fix `limit` value in filter not being used when making `.all()` call
 
 v4.12.1
 -------

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -59,6 +59,8 @@ class RestfulModelCollection(object):
         return None
 
     def all(self, limit=float("infinity")):
+        if "limit" in self.filters and self.filters["limit"] is not None:
+            limit = self.filters["limit"]
         return self._range(self.filters["offset"], limit)
 
     def where(self, filter=None, **filters):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -778,6 +778,17 @@ def mock_event_create_response(mocked_responses, api_url, message_body):
 
 
 @pytest.fixture
+def mock_event_create_response_with_limits(mocked_responses, api_url, message_body):
+    def callback(request):
+        url = URLObject(request.url)
+        limit = int(url.query_dict.get("limit") or 50)
+        body = [message_body for _ in range(0, limit)]
+        return 200, {}, json.dumps(body)
+
+    mocked_responses.add_callback(responses.GET, api_url + "/events", callback=callback)
+
+
+@pytest.fixture
 def mock_event_create_notify_response(mocked_responses, api_url, message_body):
     mocked_responses.add(
         responses.POST,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,7 @@
 import json
 import random
+
+import pytest
 import responses
 from urlobject import URLObject
 
@@ -31,6 +33,15 @@ def test_two_filters(mocked_responses, api_client, api_url):
     query = URLObject(url).query_dict
     assert query["param1"] == "a"
     assert query["param2"] == "b"
+
+
+@pytest.mark.usefixtures("mock_event_create_response_with_limits")
+def test_limit_filter(mocked_responses, api_client, api_url, message_body):
+    events = api_client.events.where(limit=51).all()
+    assert len(events) == 51  # pylint: disable=len-as-condition
+    url = mocked_responses.calls[-1].request.url
+    query = URLObject(url).query_dict
+    assert query["limit"] == "51"
 
 
 def test_no_offset(mocked_responses, api_client, api_url):


### PR DESCRIPTION
# Description
There's a bug where if the user adds a `limit` value as a filter before calling `.all()`, their value will be discarded (e.g. `nylas.threads.where(limit=50).all()`. Now we properly check if the filter exists and apply the setting before making the request to the API, resulting in the expected behaviour. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
