### PR TITLE
[62344] Added `Nylas-API-Version` header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (dev)
 ----------------
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
+* Added `Nylas-API-Version` header support  
 * Fix adding a tracking object to an existing `draft`
 * Fix issue when converting offset-aware `datetime` objects to `timestamp`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased (dev)
 ----------------
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
-* Added `Nylas-API-Version` header support  
+* Add `Nylas-API-Version` header support  
 * Fix adding a tracking object to an existing `draft`
 * Fix issue when converting offset-aware `datetime` objects to `timestamp`
 

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -31,6 +31,7 @@ from nylas.utils import convert_datetimes_to_timestamps, timestamp_from_dt
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
+SUPPORTED_API_VERSION = '2.2'
 
 
 def _validate(response):
@@ -67,6 +68,7 @@ class APIClient(json.JSONEncoder):
         app_secret=environ.get("NYLAS_APP_SECRET"),
         access_token=environ.get("NYLAS_ACCESS_TOKEN"),
         api_server=API_SERVER,
+        api_version=SUPPORTED_API_VERSION,
     ):
         if not api_server.startswith("https://"):
             raise Exception(
@@ -74,6 +76,7 @@ class APIClient(json.JSONEncoder):
                 " must include https://"
             )
         self.api_server = api_server
+        self.api_version = api_version
         self.authorize_url = api_server + "/oauth/authorize"
         self.access_token_url = api_server + "/oauth/token"
         self.revoke_url = api_server + "/oauth/revoke"
@@ -97,6 +100,7 @@ class APIClient(json.JSONEncoder):
         self.session.headers = {
             "X-Nylas-API-Wrapper": "python",
             "X-Nylas-Client-Id": self.app_id,
+            "Nylas-API-Version": self.api_version,
             "User-Agent": version_header,
         }
         self._access_token = None

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -31,7 +31,7 @@ from nylas.utils import convert_datetimes_to_timestamps, timestamp_from_dt
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
-SUPPORTED_API_VERSION = '2.2'
+SUPPORTED_API_VERSION = "2.2"
 
 
 def _validate(response):
@@ -120,6 +120,7 @@ class APIClient(json.JSONEncoder):
                 "Authorization": authorization,
                 "X-Nylas-API-Wrapper": "python",
                 "X-Nylas-Client-Id": self.app_id,
+                "Nylas-API-Version": self.api_version,
                 "User-Agent": version_header,
             }
         super(APIClient, self).__init__()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,6 +67,7 @@ def test_custom_api_version():
     custom = APIClient(api_version="500")
     assert custom.api_version == "500"
 
+
 def test_client_authentication_url(api_client, api_url):
     expected = (
         URLObject(api_url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,6 +47,7 @@ def test_client_headers():
     headers = client.session.headers
     assert headers["X-Nylas-API-Wrapper"] == "python"
     assert headers["X-Nylas-Client-Id"] == "whee"
+    assert "Nylas-API-Version" in headers
     assert "Nylas Python SDK" in headers["User-Agent"]
     assert "Authorization" not in headers
 
@@ -57,8 +58,14 @@ def test_client_admin_headers():
     assert headers["Authorization"] == "Basic Zm9vOg=="
     assert headers["X-Nylas-API-Wrapper"] == "python"
     assert headers["X-Nylas-Client-Id"] == "bounce"
+    assert "Nylas-API-Version" in headers
     assert "Nylas Python SDK" in headers["User-Agent"]
 
+
+def test_custom_api_version():
+    # Can specify API server
+    custom = APIClient(api_version="500")
+    assert custom.api_version == "500"
 
 def test_client_authentication_url(api_client, api_url):
     expected = (


### PR DESCRIPTION
# Description
Now we specify the `Nylas-API-Version` header and send it with every request made to the Nylas API. With this change:

* There is a new `SUPPORTED_API_VERSION` value that acts as the default API version
* Users are able to override this value and use an API version of their choice to specify a `api_version` when initializing a new `APIClient`

# Usage
The usage does not change if you are fine with using the latest supported API. However, if you want to use a different version you may create a new instance of `APIClient` like so:
```
nylas = APIClient(
    app_id=CLIENT_ID,
    app_secret=CLIENT_SECRET,
    access_token=ACCESS_TOKEN,
    api_version='2.1'
)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
