### PR TITLE
[62389] Remove `bumpversion` as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased (dev)
 * Add filtering support for `metadata_pair`
 * Fix adding a tracking object to an existing `draft`
 * Fix issue when converting offset-aware `datetime` objects to `timestamp`
+* Remove `bumpversion` from a required dependency to an extra dependency
 
 v4.12.1
 -------

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ class PyTest(TestCommand):
 
 def main():
     # A few handy release helpers.
+    # For publishing you should install the extra 'release' dependencies
+    # by running: pip install nylas['release']
     if len(sys.argv) > 1:
         if sys.argv[1] == "publish":
             subprocess.run("git push --follow-tags && python setup.py sdist upload")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-import os
 import sys
 import re
+import subprocess
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -14,7 +14,6 @@ with open("nylas/_client_sdk_version.py", "r") as fd:
 RUN_DEPENDENCIES = [
     "requests[security]>=2.4.2",
     "six>=1.4.1",
-    "bumpversion>=0.5.0",
     "urlobject",
 ]
 TEST_DEPENDENCIES = [
@@ -25,6 +24,7 @@ TEST_DEPENDENCIES = [
     "twine",
     "pytz",
 ]
+RELEASE_DEPENDENCIES = ["bumpversion>=0.5.0"]
 
 
 class PyTest(TestCommand):
@@ -60,14 +60,22 @@ def main():
     # A few handy release helpers.
     if len(sys.argv) > 1:
         if sys.argv[1] == "publish":
-            os.system("git push --follow-tags && python setup.py sdist upload")
+            subprocess.run("git push --follow-tags && python setup.py sdist upload")
             sys.exit()
         elif sys.argv[1] == "release":
             if len(sys.argv) < 3:
                 type_ = "patch"
             else:
                 type_ = sys.argv[2]
-            os.system("bumpversion --current-version {} {}".format(VERSION, type_))
+            try:
+                subprocess.check_output(
+                    ["bumpversion", "--current-version", VERSION, type_]
+                )
+            except FileNotFoundError as e:
+                print(
+                    "Error encountered: {}.\n\n".format(e),
+                    "Did you install the extra 'release' dependencies? (pip install nylas['release'])",
+                )
             sys.exit()
 
     setup(
@@ -77,7 +85,7 @@ def main():
         install_requires=RUN_DEPENDENCIES,
         dependency_links=[],
         tests_require=TEST_DEPENDENCIES,
-        extras_require={"test": TEST_DEPENDENCIES},
+        extras_require={"test": TEST_DEPENDENCIES, "release": RELEASE_DEPENDENCIES},
         cmdclass={"test": PyTest},
         author="Nylas Team",
         author_email="support@nylas.com",


### PR DESCRIPTION
# Description
We don't need `bumpversion` for running the package, only for releasing, so we shouldn't include it as a required dependency. Also we switched to `subprocess` for safer execution of child processes.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
