### PR TITLE
[62378] Updated credential naming to be consistent with the API and other SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ nylas-python Changelog
 
 Unreleased (dev)
 ----------------
+* Transitioned from `app_id` and `app_secret` naming to `client_id` and `client_secret`
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
 * Fix adding a tracking object to an existing `draft`

--- a/examples/hosted-oauth/server.py
+++ b/examples/hosted-oauth/server.py
@@ -87,8 +87,8 @@ def index():
     # If we've gotten to this point, then the user has already connected
     # to Nylas via OAuth. Let's set up the SDK client with the OAuth token:
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=nylas.access_token,
     )
 

--- a/examples/native-authentication-exchange/server.py
+++ b/examples/native-authentication-exchange/server.py
@@ -154,8 +154,8 @@ def success():
         return render_template("missing_token.html")
 
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=session["nylas_access_token"],
     )
 

--- a/examples/native-authentication-gmail/server.py
+++ b/examples/native-authentication-gmail/server.py
@@ -113,8 +113,8 @@ def index():
     # to both Google and Nylas.
     # Let's set up the SDK client with the OAuth token:
     client = APIClient(
-        app_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
-        app_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
+        client_id=app.config["NYLAS_OAUTH_CLIENT_ID"],
+        client_secret=app.config["NYLAS_OAUTH_CLIENT_SECRET"],
         access_token=session["nylas_access_token"],
     )
 

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -63,8 +63,8 @@ class APIClient(json.JSONEncoder):
 
     def __init__(
         self,
-        app_id=environ.get("NYLAS_APP_ID"),
-        app_secret=environ.get("NYLAS_APP_SECRET"),
+        client_id=environ.get("NYLAS_CLIENT_ID"),
+        client_secret=environ.get("NYLAS_CLIENT_SECRET"),
         access_token=environ.get("NYLAS_ACCESS_TOKEN"),
         api_server=API_SERVER,
     ):
@@ -85,8 +85,8 @@ class APIClient(json.JSONEncoder):
             api_server + "/a/{client_id}/accounts/{account_id}/token-info"
         )
 
-        self.app_secret = app_secret
-        self.app_id = app_id
+        self.client_secret = client_secret
+        self.client_id = client_id
 
         self.session = requests.Session()
         self.version = __VERSION__
@@ -96,7 +96,7 @@ class APIClient(json.JSONEncoder):
         )
         self.session.headers = {
             "X-Nylas-API-Wrapper": "python",
-            "X-Nylas-Client-Id": self.app_id,
+            "X-Nylas-Client-Id": self.client_id,
             "User-Agent": version_header,
         }
         self._access_token = None
@@ -104,18 +104,18 @@ class APIClient(json.JSONEncoder):
         self.auth_token = None
 
         # Requests to the /a/ namespace don't use an auth token but
-        # the app_secret. Set up a specific session for this.
+        # the client_secret. Set up a specific session for this.
         self.admin_session = requests.Session()
 
-        if app_secret is not None:
-            b64_app_secret = b64encode((app_secret + ":").encode("utf8"))
+        if client_secret is not None:
+            b64_client_secret = b64encode((client_secret + ":").encode("utf8"))
             authorization = "Basic {secret}".format(
-                secret=b64_app_secret.decode("utf8")
+                secret=b64_client_secret.decode("utf8")
             )
             self.admin_session.headers = {
                 "Authorization": authorization,
                 "X-Nylas-API-Wrapper": "python",
-                "X-Nylas-Client-Id": self.app_id,
+                "X-Nylas-Client-Id": self.client_id,
                 "User-Agent": version_header,
             }
         super(APIClient, self).__init__()
@@ -143,7 +143,7 @@ class APIClient(json.JSONEncoder):
     ):
         args = {
             "redirect_uri": redirect_uri,
-            "client_id": self.app_id or "None",  # 'None' for back-compat
+            "client_id": self.client_id or "None",  # 'None' for back-compat
             "response_type": "code",
             "login_hint": login_hint,
             "state": state,
@@ -159,8 +159,8 @@ class APIClient(json.JSONEncoder):
 
     def token_for_code(self, code):
         args = {
-            "client_id": self.app_id,
-            "client_secret": self.app_secret,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
             "grant_type": "authorization_code",
             "code": code,
         }
@@ -178,7 +178,7 @@ class APIClient(json.JSONEncoder):
         return self.access_token
 
     def is_opensource_api(self):
-        if self.app_id is None and self.app_secret is None:
+        if self.client_id is None and self.client_secret is None:
             return True
 
         return False
@@ -191,7 +191,7 @@ class APIClient(json.JSONEncoder):
 
     def revoke_all_tokens(self, keep_access_token=None):
         revoke_all_url = self.revoke_all_url.format(
-            client_id=self.app_id, account_id=self.account.id
+            client_id=self.client_id, account_id=self.account.id
         )
         data = {}
         if keep_access_token is not None:
@@ -206,14 +206,14 @@ class APIClient(json.JSONEncoder):
             self.access_token = None
 
     def ip_addresses(self):
-        ip_addresses_url = self.ip_addresses_url.format(client_id=self.app_id)
+        ip_addresses_url = self.ip_addresses_url.format(client_id=self.client_id)
         resp = self.admin_session.get(ip_addresses_url)
         _validate(resp).json()
         return resp.json()
 
     def token_info(self):
         token_info_url = self.token_info_url.format(
-            client_id=self.app_id, account_id=self.account.id
+            client_id=self.client_id, account_id=self.account.id
         )
         self.admin_session.headers["Content-Type"] = "application/json"
         resp = self.admin_session.post(
@@ -333,7 +333,7 @@ class APIClient(json.JSONEncoder):
 
     def _get_http_session(self, api_root):
         # Is this a request for a resource under the accounts/billing/admin
-        # namespace (/a)? If the latter, pass the app_secret
+        # namespace (/a)? If the latter, pass the client_secret
         # instead of the secret_token
         if api_root == "a":
             return self.admin_session
@@ -347,7 +347,7 @@ class APIClient(json.JSONEncoder):
             url = "{}/{}{}".format(self.api_server, cls.collection_name, postfix)
         else:
             url = "{}/a/{}/{}{}".format(
-                self.api_server, self.app_id, cls.collection_name, postfix
+                self.api_server, self.client_id, cls.collection_name, postfix
             )
 
         converted_filters = convert_datetimes_to_timestamps(
@@ -370,7 +370,7 @@ class APIClient(json.JSONEncoder):
             url = "{}/{}/{}{}".format(self.api_server, cls.collection_name, id, postfix)
         else:
             url = "{}/a/{}/{}/{}{}".format(
-                self.api_server, self.app_id, cls.collection_name, id, postfix
+                self.api_server, self.client_id, cls.collection_name, id, postfix
             )
 
         converted_filters = convert_datetimes_to_timestamps(
@@ -474,8 +474,8 @@ class APIClient(json.JSONEncoder):
             )
         else:
             # Management method.
-            url_path = "/a/{app_id}/{name}/{id}/{method}".format(
-                app_id=self.app_id, name=cls.collection_name, id=id, method=method_name
+            url_path = "/a/{client_id}/{name}/{id}/{method}".format(
+                client_id=self.client_id, name=cls.collection_name, id=id, method=method_name
             )
 
         url = URLObject(self.api_server).with_path(url_path)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -475,7 +475,10 @@ class APIClient(json.JSONEncoder):
         else:
             # Management method.
             url_path = "/a/{client_id}/{name}/{id}/{method}".format(
-                client_id=self.client_id, name=cls.collection_name, id=id, method=method_name
+                client_id=self.client_id,
+                name=cls.collection_name,
+                id=id,
+                method=method_name,
             )
 
         url = URLObject(self.api_server).with_path(url_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,9 @@ def mock_accounts(mocked_responses, api_url, account_id, client_id):
             return (200, {}, json.dumps([]))
         return (200, {}, json.dumps(accounts))
 
-    url_re = "{base}(/a/{client_id})?/accounts/?".format(base=api_url, client_id=client_id)
+    url_re = "{base}(/a/{client_id})?/accounts/?".format(
+        base=api_url, client_id=client_id
+    )
     mocked_responses.add_callback(
         responses.GET,
         re.compile(url_re),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,27 +75,27 @@ def api_url():
 
 
 @pytest.fixture
-def app_id():
-    return "fake-app-id"
+def client_id():
+    return "fake-client-id"
 
 
 @pytest.fixture
-def app_secret():
+def client_secret():
     return "nyl4n4ut"
 
 
 @pytest.fixture
 def api_client(api_url):
     return APIClient(
-        app_id=None, app_secret=None, access_token=None, api_server=api_url
+        client_id=None, client_secret=None, access_token=None, api_server=api_url
     )
 
 
 @pytest.fixture
-def api_client_with_app_id(access_token, api_url, app_id, app_secret):
+def api_client_with_client_id(access_token, api_url, client_id, client_secret):
     return APIClient(
-        app_id=app_id,
-        app_secret=app_secret,
+        client_id=client_id,
+        client_secret=client_secret,
         access_token=access_token,
         api_server=api_url,
     )
@@ -150,7 +150,7 @@ def mock_account(mocked_responses, api_url, account_id):
 
 
 @pytest.fixture
-def mock_accounts(mocked_responses, api_url, account_id, app_id):
+def mock_accounts(mocked_responses, api_url, account_id, client_id):
     accounts = [
         {
             "account_id": account_id,
@@ -173,7 +173,7 @@ def mock_accounts(mocked_responses, api_url, account_id, app_id):
             return (200, {}, json.dumps([]))
         return (200, {}, json.dumps(accounts))
 
-    url_re = "{base}(/a/{app_id})?/accounts/?".format(base=api_url, app_id=app_id)
+    url_re = "{base}(/a/{client_id})?/accounts/?".format(base=api_url, client_id=client_id)
     mocked_responses.add_callback(
         responses.GET,
         re.compile(url_re),
@@ -1283,7 +1283,7 @@ def mock_resources(mocked_responses, api_url):
 
 
 @pytest.fixture
-def mock_account_management(mocked_responses, api_url, account_id, app_id):
+def mock_account_management(mocked_responses, api_url, account_id, client_id):
     account = {
         "account_id": account_id,
         "email_address": "ben.bitdiddle1861@gmail.com",
@@ -1298,11 +1298,11 @@ def mock_account_management(mocked_responses, api_url, account_id, app_id):
     account["billing_state"] = "cancelled"
     cancelled_response = json.dumps(account)
 
-    upgrade_url = "{base}/a/{app_id}/accounts/{id}/upgrade".format(
-        base=api_url, id=account_id, app_id=app_id
+    upgrade_url = "{base}/a/{client_id}/accounts/{id}/upgrade".format(
+        base=api_url, id=account_id, client_id=client_id
     )
-    downgrade_url = "{base}/a/{app_id}/accounts/{id}/downgrade".format(
-        base=api_url, id=account_id, app_id=app_id
+    downgrade_url = "{base}/a/{client_id}/accounts/{id}/downgrade".format(
+        base=api_url, id=account_id, client_id=client_id
     )
     mocked_responses.add(
         responses.POST,
@@ -1321,9 +1321,9 @@ def mock_account_management(mocked_responses, api_url, account_id, app_id):
 
 
 @pytest.fixture
-def mock_revoke_all_tokens(mocked_responses, api_url, account_id, app_id):
-    revoke_all_url = "{base}/a/{app_id}/accounts/{id}/revoke-all".format(
-        base=api_url, id=account_id, app_id=app_id
+def mock_revoke_all_tokens(mocked_responses, api_url, account_id, client_id):
+    revoke_all_url = "{base}/a/{client_id}/accounts/{id}/revoke-all".format(
+        base=api_url, id=account_id, client_id=client_id
     )
     mocked_responses.add(
         responses.POST,
@@ -1335,9 +1335,9 @@ def mock_revoke_all_tokens(mocked_responses, api_url, account_id, app_id):
 
 
 @pytest.fixture
-def mock_ip_addresses(mocked_responses, api_url, app_id):
-    ip_addresses_url = "{base}/a/{app_id}/ip_addresses".format(
-        base=api_url, app_id=app_id
+def mock_ip_addresses(mocked_responses, api_url, client_id):
+    ip_addresses_url = "{base}/a/{client_id}/ip_addresses".format(
+        base=api_url, client_id=client_id
     )
     mocked_responses.add(
         responses.GET,
@@ -1359,9 +1359,9 @@ def mock_ip_addresses(mocked_responses, api_url, app_id):
 
 
 @pytest.fixture
-def mock_token_info(mocked_responses, api_url, account_id, app_id):
-    token_info_url = "{base}/a/{app_id}/accounts/{id}/token-info".format(
-        base=api_url, id=account_id, app_id=app_id
+def mock_token_info(mocked_responses, api_url, account_id, client_id):
+    token_info_url = "{base}/a/{client_id}/accounts/{id}/token-info".format(
+        base=api_url, id=account_id, client_id=client_id
     )
     mocked_responses.add(
         responses.POST,

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -70,7 +70,9 @@ def test_revoke_all_tokens(api_client_with_client_id):
 
 
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
-def test_revoke_all_tokens_with_keep_access_token(api_client_with_client_id, access_token):
+def test_revoke_all_tokens_with_keep_access_token(
+    api_client_with_client_id, access_token
+):
     assert api_client_with_client_id.access_token == access_token
     api_client_with_client_id.revoke_all_tokens(keep_access_token=access_token)
     assert api_client_with_client_id.access_token == access_token

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -23,16 +23,16 @@ def test_account_json(api_client, monkeypatch):
 
 
 @pytest.mark.usefixtures("mock_ip_addresses")
-def test_ip_addresses(api_client_with_app_id):
-    result = api_client_with_app_id.ip_addresses()
+def test_ip_addresses(api_client_with_client_id):
+    result = api_client_with_client_id.ip_addresses()
     assert isinstance(result, dict)
     assert "updated_at" in result
     assert "ip_addresses" in result
 
 
 @pytest.mark.usefixtures("mock_token_info", "mock_account")
-def test_token_info(api_client_with_app_id):
-    result = api_client_with_app_id.token_info()
+def test_token_info(api_client_with_client_id):
+    result = api_client_with_client_id.token_info()
     assert isinstance(result, dict)
     assert "updated_at" in result
     assert "scopes" in result
@@ -45,8 +45,8 @@ def test_account_datetime(api_client):
 
 
 @pytest.mark.usefixtures("mock_accounts", "mock_account_management")
-def test_account_upgrade(api_client, app_id):
-    api_client.app_id = app_id
+def test_account_upgrade(api_client, client_id):
+    api_client.client_id = client_id
     account = api_client.accounts.first()
     assert account.billing_state == "paid"
     account = account.downgrade()
@@ -63,17 +63,17 @@ def test_account_delete(api_client, monkeypatch):
 
 
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
-def test_revoke_all_tokens(api_client_with_app_id):
-    assert api_client_with_app_id.access_token is not None
-    api_client_with_app_id.revoke_all_tokens()
-    assert api_client_with_app_id.access_token is None
+def test_revoke_all_tokens(api_client_with_client_id):
+    assert api_client_with_client_id.access_token is not None
+    api_client_with_client_id.revoke_all_tokens()
+    assert api_client_with_client_id.access_token is None
 
 
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
-def test_revoke_all_tokens_with_keep_access_token(api_client_with_app_id, access_token):
-    assert api_client_with_app_id.access_token == access_token
-    api_client_with_app_id.revoke_all_tokens(keep_access_token=access_token)
-    assert api_client_with_app_id.access_token == access_token
+def test_revoke_all_tokens_with_keep_access_token(api_client_with_client_id, access_token):
+    assert api_client_with_client_id.access_token == access_token
+    api_client_with_client_id.revoke_all_tokens(keep_access_token=access_token)
+    assert api_client_with_client_id.access_token == access_token
 
 
 @pytest.mark.usefixtures("mock_accounts", "mock_account")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ def test_client_access_token():
 
 
 def test_client_headers():
-    client = APIClient(app_id="whee", app_secret="foo")
+    client = APIClient(client_id="whee", client_secret="foo")
     headers = client.session.headers
     assert headers["X-Nylas-API-Wrapper"] == "python"
     assert headers["X-Nylas-Client-Id"] == "whee"
@@ -52,7 +52,7 @@ def test_client_headers():
 
 
 def test_client_admin_headers():
-    client = APIClient(app_id="bounce", app_secret="foo")
+    client = APIClient(client_id="bounce", client_secret="foo")
     headers = client.admin_session.headers
     assert headers["Authorization"] == "Basic Zm9vOg=="
     assert headers["X-Nylas-API-Wrapper"] == "python"
@@ -153,10 +153,10 @@ def test_client_token_for_code(mocked_responses, api_client, api_url):
 def test_client_opensource_api(api_client):
     # pylint: disable=singleton-comparison
     assert api_client.is_opensource_api() == True
-    api_client.app_id = "foo"
-    api_client.app_secret = "super-sekrit"
+    api_client.client_id = "foo"
+    api_client.client_secret = "super-sekrit"
     assert api_client.is_opensource_api() == False
-    api_client.app_id = api_client.app_secret = None
+    api_client.client_id = api_client.client_secret = None
     assert api_client.is_opensource_api() == True
 
 


### PR DESCRIPTION
# Discussion
In the other Nylas components like the API and Dashboard, as well as the other SDKs, the credentials are referred to as `client_id` and `client_secret` however this SDK was referring to these credentials as `app_id` and `app_secret`. This causes some unnecessary confusion, and this change addresses this by switching all references of `app_id` and `app_secret` to `client_id` and `client_secret`.

# Usage
If you were previously initializing `APIClient` by passing in the credentials as a variable assignment, you are required to update your code to reflect the new credential variable names:
```
client = APIClient(
        client_id="CLIENT_ID",
        client_secret="CLIENT_SECRET",
    )
```

If you were initializing it by just passing in the values in order like so:
```
client = APIClient(
        "CLIENT_ID",
        "CLIENT_SECRET",
    )
```
then no change is required on your part.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
