### PR TITLE
[63008] `from_` field set by attribute on draft ignored

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -81,9 +81,17 @@ class NylasAPIObject(dict):
 
     def as_json(self):
         dct = {}
+        # Some API parameters like "from" and "in" also are
+        # Python reserved keywords. To work around this, we rename
+        # them to "from_" and "in_". The API still needs them in
+        # their correct form though.
+        reserved_keywords = ["from", "in"]
         for attr in self.cls.attrs:
             if hasattr(self, attr):
-                dct[attr] = getattr(self, attr)
+                if attr in reserved_keywords:
+                    dct[attr] = getattr(self, "{}_".format(attr))
+                else:
+                    dct[attr] = getattr(self, attr)
         for date_attr, iso_attr in self.cls.date_attrs.items():
             if self.get(date_attr):
                 dct[iso_attr] = self[date_attr].strftime("%Y-%m-%d")

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -36,6 +36,19 @@ def test_save_send_draft(api_client):
         draft.send()
 
 
+def test_draft_as_json(api_client):
+    draft = api_client.drafts.create()
+    draft.to = [{"name": "My Friend", "email": "my.friend@example.com"}]
+    draft.subject = "Here's an attachment"
+    draft.body = "Cheers mate!"
+    draft.from_ = [{"name": "Me", "email": "me@example.com"}]
+    msg = draft.as_json()
+    assert msg["to"] == [{"name": "My Friend", "email": "my.friend@example.com"}]
+    assert msg["subject"] == "Here's an attachment"
+    assert msg["body"] == "Cheers mate!"
+    assert msg["from"] == [{"name": "Me", "email": "me@example.com"}]
+
+
 @pytest.mark.usefixtures("mock_draft_saved_response", "mock_draft_sent_response")
 def test_save_send_draft_with_tracking(mocked_responses, api_client):
     tracking = {


### PR DESCRIPTION
# Description
`from` and `in` are reserved keywords, and to do circumvent this issue we add underscores after the attribute name. However, during the as_json method, we did not look for the underscored variable names.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
