### PR TITLE
[63415] Neural API support for Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased (dev)
 ----------------
 * Transitioned from `app_id` and `app_secret` naming to `client_id` and `client_secret`
+* Add support for the Nylas Neural API
 * Add `metadata` field in the Event model to support new event metadata feature
 * Add filtering support for `metadata_pair`
 * Add new Room Resource fields  

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -511,9 +511,10 @@ class APIClient(json.JSONEncoder):
         response = session.request(method, url, json=converted_data)
 
         result = _validate(response).json()
-        # The Neural API will always return only one item
-        # but sometimes it returns it in the form of a 'singleton' array
         if isinstance(result, list):
-            result = result[0]
+            object_list = []
+            for obj in result:
+                object_list.append(cls.create(self, **obj))
+            return object_list
 
         return cls.create(self, **result)

--- a/nylas/client/neural_api_models.py
+++ b/nylas/client/neural_api_models.py
@@ -30,9 +30,7 @@ class Neural(RestfulModel):
         signatures = self.api._request_neural_resource(NeuralSignatureExtraction, body)
         if parse_contacts is not False:
             for sig in signatures:
-                sig.contacts = NeuralSignatureContact.create(
-                    self.api, **sig.contacts
-                )
+                sig.contacts = NeuralSignatureContact.create(self.api, **sig.contacts)
         return signatures
 
     def ocr_request(self, file_id, pages=None):

--- a/nylas/client/neural_api_models.py
+++ b/nylas/client/neural_api_models.py
@@ -1,0 +1,182 @@
+from nylas.client.restful_models import RestfulModel, Message, File, Contact
+import re
+
+
+def _add_options_to_body(body, options):
+    options_dict = options.__dict__
+    # Only append set options to body to prevent a 400 error
+    options_filtered = {k: v for k, v in options_dict.items() if v is not None}
+    return body.update(options_filtered)
+
+
+class Neural(RestfulModel):
+    def __init__(self, api):
+        RestfulModel.__init__(self, Neural, api)
+
+    def sentiment_analysis_message(self, message_id):
+        body = {"message_id": [message_id]}
+        return self.api._request_neural_resource(NeuralSentimentAnalysis, body)
+
+    def sentiment_analysis_text(self, text):
+        body = {"text": text}
+        return self.api._request_neural_resource(NeuralSentimentAnalysis, body)
+
+    def extract_signature(self, message_id, parse_contacts=None, options=None):
+        body = {"message_id": [message_id]}
+        if parse_contacts is not None and isinstance(parse_contacts, bool):
+            body["parse_contacts"] = parse_contacts
+        if options is not None and isinstance(options, NeuralMessageOptions):
+            _add_options_to_body(body, options)
+        signature = self.api._request_neural_resource(NeuralSignatureExtraction, body)
+        if signature.contacts:
+            signature.contacts = NeuralSignatureContact.create(
+                self.api, **signature.contacts
+            )
+        return signature
+
+    def ocr_request(self, file_id, pages=None):
+        body = {"file_id": file_id}
+        if pages is not None and isinstance(pages, list):
+            body["pages"] = pages
+        return self.api._request_neural_resource(NeuralOcr, body)
+
+    def categorize(self, message_id):
+        body = {"message_id": [message_id]}
+        category = self.api._request_neural_resource(NeuralCategorizer, body)
+        if category.categorizer:
+            category.categorizer = Categorize.create(self.api, **category.categorizer)
+        return category
+
+    def clean_conversation(self, message_id, options=None):
+        body = {"message_id": [message_id]}
+        if options is not None and isinstance(options, NeuralMessageOptions):
+            _add_options_to_body(body, options)
+        return self.api._request_neural_resource(NeuralCleanConversation, body)
+
+
+class NeuralMessageOptions:
+    def __init__(
+        self,
+        ignore_links=None,
+        ignore_images=None,
+        ignore_tables=None,
+        remove_conclusion_phrases=None,
+        images_as_markdowns=None,
+    ):
+        self.ignore_links = ignore_links
+        self.ignore_images = ignore_images
+        self.ignore_tables = ignore_tables
+        self.remove_conclusion_phrases = remove_conclusion_phrases
+        self.images_as_markdowns = images_as_markdowns
+
+
+class NeuralSentimentAnalysis(RestfulModel):
+    attrs = [
+        "account_id",
+        "sentiment",
+        "sentiment_score",
+        "processed_length",
+        "text",
+    ]
+    collection_name = "sentiment"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralSentimentAnalysis, api)
+
+
+class NeuralSignatureExtraction(Message):
+    attrs = Message.attrs + ["signature", "model_version", "contacts"]
+    collection_name = "signature"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralSignatureExtraction, api)
+
+
+class NeuralSignatureContact(RestfulModel):
+    attrs = ["job_titles", "links", "phone_numbers", "emails", "names"]
+    collection_name = "signature_contact"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralSignatureContact, api)
+
+    def to_contact_object(self):
+        contact = {}
+        if self.names is not None:
+            contact["given_name"] = self.names[0]["first_name"]
+            contact["surname"] = self.names[0]["last_name"]
+        if self.job_titles is not None:
+            contact["job_title"] = self.job_titles[0]
+        if self.emails is not None:
+            contact["emails"] = []
+            for email in self.emails:
+                contact["emails"].append({"type": "personal", "email": email})
+        if self.phone_numbers is not None:
+            contact["phone_numbers"] = []
+            for number in self.phone_numbers:
+                contact["phone_numbers"].append({"type": "mobile", "number": number})
+        if self.links is not None:
+            contact["web_pages"] = []
+            for url in self.links:
+                description = url["description"] if url["description"] else "homepage"
+                contact["web_pages"].append({"type": description, "url": url["url"]})
+
+        return Contact.create(self.api, **contact)
+
+
+class NeuralCategorizer(Message):
+    attrs = Message.attrs + ["categorizer"]
+    collection_name = "categorize"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralCategorizer, api)
+
+    def recategorize(self, category):
+        data = {"message_id": self.id, "category": category}
+        self.api._request_neural_resource(
+            NeuralCategorizer, data, "categorize/feedback", "POST"
+        )
+        data = {"message_id": self.id}
+        categorize = self.api._request_neural_resource(NeuralCategorizer, data)
+        if categorize.categorizer:
+            categorize.categorizer = Categorize.create(
+                self.api, **categorize.categorizer
+            )
+        return categorize
+
+
+class Categorize(RestfulModel):
+    attrs = ["category", "categorized_at", "model_version", "subcategories"]
+    collection_name = "category"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, Categorize, api)
+
+
+class NeuralCleanConversation(Message):
+    attrs = Message.attrs + [
+        "conversation",
+        "model_version",
+    ]
+    collection_name = "conversation"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralCleanConversation, api)
+
+    def extract_images(self):
+        pattern = "[\(']cid:(.*?)[\)']"
+        file_ids = re.findall(pattern, self.conversation)
+        files = []
+        for match in file_ids:
+            files.append(self.api.files.get(match))
+        return files
+
+
+class NeuralOcr(File):
+    attrs = File.attrs + [
+        "ocr",
+        "processed_pages",
+    ]
+    collection_name = "ocr"
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, NeuralOcr, api)

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -21,6 +21,13 @@ def typed_dict_attr(items, attr_name=None):
 
 
 class NylasAPIObject(dict):
+def _is_subclass(cls, parent):
+    for base in cls.__bases__:
+        if base.__name__.lower() == parent:
+            return True
+    return False
+
+
     attrs = []
     date_attrs = {}
     datetime_attrs = {}
@@ -46,7 +53,12 @@ class NylasAPIObject(dict):
     def create(cls, api, **kwargs):
         object_type = kwargs.get("object")
         cls_object_type = getattr(cls, "object_type", cls.__name__.lower())
-        if object_type and object_type != cls_object_type and object_type != "account":
+        if (
+            object_type
+            and object_type != cls_object_type
+            and object_type != "account"
+            and not _is_subclass(cls, object_type)
+        ):
             # We were given a specific object type and we're trying to
             # instantiate something different; abort. (Relevant for folders
             # and labels API.)

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -20,7 +20,6 @@ def typed_dict_attr(items, attr_name=None):
     return dct
 
 
-class NylasAPIObject(dict):
 def _is_subclass(cls, parent):
     for base in cls.__bases__:
         if base.__name__.lower() == parent:
@@ -28,6 +27,7 @@ def _is_subclass(cls, parent):
     return False
 
 
+class RestfulModel(dict):
     attrs = []
     date_attrs = {}
     datetime_attrs = {}
@@ -43,7 +43,7 @@ def _is_subclass(cls, parent):
         self.id = None
         self.cls = cls
         self.api = api
-        super(NylasAPIObject, self).__init__()
+        super(RestfulModel, self).__init__()
 
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
@@ -123,6 +123,11 @@ def _is_subclass(cls, parent):
                     for value in values:
                         dct[attr].append(value)
         return dct
+
+
+class NylasAPIObject(RestfulModel):
+    def __init__(self, cls, api):
+        RestfulModel.__init__(self, cls, api)
 
     def child_collection(self, cls, **filters):
         return RestfulModelCollection(cls, self.api, **filters)

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -1,0 +1,174 @@
+import json
+import pytest
+from nylas.client.restful_models import File
+
+from nylas.client.neural_api_models import (
+    NeuralSignatureContact,
+    NeuralMessageOptions,
+    Categorize,
+    NeuralCategorizer,
+)
+
+
+@pytest.mark.usefixtures("mock_sentiment_analysis")
+def test_sentiment_analysis_message(mocked_responses, api_client, account_id):
+    analysis = api_client.neural.sentiment_analysis_message("message_id")
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"message_id": ["message_id"]}
+    assert analysis.account_id == account_id
+    assert analysis.processed_length == 11
+    assert analysis.sentiment == "NEUTRAL"
+    assert analysis.sentiment_score == 0.30000001192092896
+    assert analysis.text == "hello world"
+
+
+@pytest.mark.usefixtures("mock_sentiment_analysis")
+def test_sentiment_analysis_text(mocked_responses, api_client, account_id):
+    analysis = api_client.neural.sentiment_analysis_text("hello world")
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"text": "hello world"}
+    assert analysis.account_id == account_id
+    assert analysis.processed_length == 11
+    assert analysis.sentiment == "NEUTRAL"
+    assert analysis.sentiment_score == 0.30000001192092896
+    assert analysis.text == "hello world"
+
+
+@pytest.mark.usefixtures("mock_extract_signature")
+def test_extract_signature(mocked_responses, api_client):
+    signature = api_client.neural.extract_signature("abc123")
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"message_id": ["abc123"]}
+    assert (
+        signature.signature
+        == "Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\n\nswag@nylas.com"
+    )
+    assert signature.model_version == "0.0.1"
+    assert isinstance(signature.contacts, NeuralSignatureContact)
+    contact = signature.contacts
+    assert contact.job_titles == ["Software Engineer"]
+    assert contact.links == [
+        {
+            "description": "string",
+            "url": "https://example.com/link.html",
+        }
+    ]
+    assert contact.phone_numbers == ["123-456-8901"]
+    assert contact.emails == ["swag@nylas.com"]
+    assert contact.names == [
+        {
+            "first_name": "Nylas",
+            "last_name": "Swag",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mock_extract_signature")
+def test_extract_signature_options(mocked_responses, api_client):
+    options = NeuralMessageOptions(False, False, False, False, False)
+    api_client.neural.extract_signature("abc123", False, options)
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {
+        "message_id": ["abc123"],
+        "parse_contacts": False,
+        "ignore_links": False,
+        "ignore_images": False,
+        "ignore_tables": False,
+        "remove_conclusion_phrases": False,
+        "images_as_markdowns": False,
+    }
+
+
+@pytest.mark.usefixtures("mock_extract_signature")
+def test_signature_convert_contact(mocked_responses, api_client):
+    signature = api_client.neural.extract_signature("abc123")
+    contact = signature.contacts.to_contact_object()
+    assert contact.given_name == "Nylas"
+    assert contact.surname == "Swag"
+    assert contact.job_title == "Software Engineer"
+    assert len(contact.emails) == 1
+    assert contact.emails["personal"] == ["swag@nylas.com"]
+    assert len(contact.phone_numbers) == 1
+    assert contact.phone_numbers["mobile"] == ["123-456-8901"]
+    assert len(contact.web_pages) == 1
+    assert contact.web_pages["string"] == ["https://example.com/link.html"]
+
+
+@pytest.mark.usefixtures("mock_categorize")
+def test_categorize(mocked_responses, api_client):
+    response = api_client.neural.categorize("abc123")
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"message_id": ["abc123"]}
+    assert isinstance(response.categorizer, Categorize)
+    categorize = response.categorizer
+    assert categorize.category == "feed"
+    assert categorize.model_version == "6194f733"
+    assert categorize.subcategories == ["ooo"]
+    assert categorize.categorized_at == "2021-06-24T17:28:09.549266"
+
+
+@pytest.mark.usefixtures("mock_categorize")
+def test_recategorize(mocked_responses, api_client):
+    categorize = api_client.neural.categorize("abc123")
+    recategorize = categorize.recategorize("conversation")
+    assert len(mocked_responses.calls) == 3
+    request = mocked_responses.calls[1].request
+    assert json.loads(request.body) == {
+        "message_id": "abc123",
+        "category": "conversation",
+    }
+    assert isinstance(recategorize, NeuralCategorizer)
+
+
+@pytest.mark.usefixtures("mock_ocr_request")
+def test_ocr_request(mocked_responses, api_client):
+    ocr = api_client.neural.ocr_request("abc123", [2, 3])
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"file_id": "abc123", "pages": [2, 3]}
+    assert len(ocr.ocr) == 2
+    assert ocr.ocr[0] == "This is page 1"
+    assert ocr.ocr[1] == "This is page 2"
+    assert ocr.processed_pages == 2
+
+
+@pytest.mark.usefixtures("mock_clean_conversation")
+def test_clean_conversation(mocked_responses, api_client):
+    convo = api_client.neural.clean_conversation("abc123")
+    assert len(mocked_responses.calls) == 1
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {"message_id": ["abc123"]}
+    assert (
+        convo.conversation
+        == "<img src='cid:1781777f666586677621' /> This is the conversation"
+    )
+    assert convo.model_version == "0.0.1"
+
+
+@pytest.mark.usefixtures("mock_clean_conversation")
+def test_clean_conversation_options(mocked_responses, api_client):
+    options = NeuralMessageOptions(False, False, False, False, False)
+    api_client.neural.clean_conversation("abc123", options)
+    request = mocked_responses.calls[0].request
+    assert json.loads(request.body) == {
+        "message_id": ["abc123"],
+        "ignore_links": False,
+        "ignore_images": False,
+        "ignore_tables": False,
+        "remove_conclusion_phrases": False,
+        "images_as_markdowns": False,
+    }
+
+
+@pytest.mark.usefixtures("mock_clean_conversation")
+def test_clean_conversation_extract_images(mocked_responses, api_client):
+    convo = api_client.neural.clean_conversation("abc123")
+    extracted_files = convo.extract_images()
+    assert len(mocked_responses.calls) == 2
+    assert len(extracted_files) == 1
+    assert isinstance(extracted_files[0], File) is True
+    assert extracted_files[0].id == "1781777f666586677621"


### PR DESCRIPTION
# Description
This PR brings support for the Nylas [Neural API](https://developer.nylas.com/docs/intelligence/). The Neural API exposes endpoints that perform intelligent analysis on items in your Nylas account. This change will enable users to access the features of the Nylas Neural API and provides some utility functions to help improve the user's workflow.

# Usage
To use [Sentiment Analysis](https://developer.nylas.com/docs/intelligence/sentiment-analysis/):
```python
# To perform sentiment analysis on a message, pass in the list of message ID:
message_analysis = nylas.neural.sentiment_analysis_message([MESSAGE_ID])

# To perform sentiment analysis on just text, pass in a string:
text_analysis = nylas.neural.sentiment_analysis_text("Hi, thank you so much for reaching out! We can catch up tomorrow.")
```

To use [Signature Extraction](https://developer.nylas.com/docs/intelligence/signature-extraction/):
```python
const signature = nylas.neural.extract_signature([MESSAGE_ID])

# The method also accepts two optional parameters
# parseContact, a boolean for whether Nylas should parse the contact from the signature (API defaults to true)
# options, an object of options that can be enabled for the Neural endpoint, of type NeuralMessageOptions:
options = NeuralMessageOptions(
    ignore_links=False,
    ignore_images=False,
    ignore_tables=False,
    remove_conclusion_phrases=False,
    images_as_markdowns=False
)

signature = nylas.neural.extract_signature([MESSAGE_ID], true, options)
```
and to parse the contact and convert it to the standard Nylas contact object:
```python
contact = signature[0].contacts.to_contact_object()
```

To use [Clean Conversations](https://developer.nylas.com/docs/intelligence/clean-conversations/):
```python
convo = nylas.neural.clean_conversation([MESSAGE_ID])

# You can also pass in an object of options that can be enabled for the Neural endpoint, of type NeuralMessageOptions
convo = nylas.neural.clean_conversation([MESSAGE_ID], options);
```
and to extract images from the result:
```python
convo[0].extract_images()
```

To use [Optical Character Recognition](https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/):
```python
ocr = nylas.neural.ocr_request(FILE_ID)

# This endpoint also supports a second, optional parameter for an array specifying the pages that the user wants analyzed:
ocr = nylas.neural.ocr_request(FILE_ID, [2, 3])
```


To use [Categorizer](https://developer.nylas.com/docs/intelligence/categorizer/)
```python
cat = nylas.neural.categorize([MESSAGE_ID])

# You can also send a request to recategorize the message:
cat = cat[0].recategorize("conversation")
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.