### PR TITLE
[64739] Fix epoch datetime for `categorized_at` field in `NeuralCategorizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Fix `categorized_at` type to be `epoch` in `NeuralCategorizer`
+
 v.5.0.0
 ----------------
 * Transitioned from `app_id` and `app_secret` naming to `client_id` and `client_secret`

--- a/nylas/client/neural_api_models.py
+++ b/nylas/client/neural_api_models.py
@@ -146,6 +146,7 @@ class NeuralCategorizer(Message):
 
 class Categorize(RestfulModel):
     attrs = ["category", "categorized_at", "model_version", "subcategories"]
+    datetime_attrs = {"categorized_at": "categorized_at"}
     collection_name = "category"
 
     def __init__(self, api):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1567,7 +1567,7 @@ def mock_categorize(mocked_responses, api_url, account_id):
             "account_id": account_id,
             "body": "This is a body",
             "categorizer": {
-                "categorized_at": "2021-06-24T17:28:09.549266",
+                "categorized_at": 1627076720,
                 "category": "feed",
                 "model_version": "6194f733",
                 "subcategories": ["ooo"],

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime
+
 import pytest
 from nylas.client.restful_models import File
 
@@ -113,7 +115,7 @@ def test_categorize(mocked_responses, api_client):
     assert categorize.category == "feed"
     assert categorize.model_version == "6194f733"
     assert categorize.subcategories == ["ooo"]
-    assert categorize.categorized_at == "2021-06-24T17:28:09.549266"
+    assert categorize.categorized_at == datetime.utcfromtimestamp(1627076720)
 
 
 @pytest.mark.usefixtures("mock_categorize")


### PR DESCRIPTION
# Description
Minor change, `neural/categorize` endpoint now returns an epoch for a datetime instead of a string.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
