### PR TITLE
[66981] Add filtering of "None" value attributes before making requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased (dev)
 ----------------
 * Fix `categorized_at` type to be `epoch` in `NeuralCategorizer`
+* Add filtering of "None" value attributes before making requests
 
 v.5.0.0
 ----------------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -28,7 +28,7 @@ from nylas.client.restful_models import (
     Draft,
 )
 from nylas.client.neural_api_models import Neural
-from nylas.utils import convert_datetimes_to_timestamps, timestamp_from_dt
+from nylas.utils import timestamp_from_dt, save_request_body
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
@@ -360,9 +360,7 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, postfix
             )
 
-        converted_filters = convert_datetimes_to_timestamps(
-            filters, cls.datetime_filter_attrs
-        )
+        converted_filters = save_request_body(filters, cls.datetime_filter_attrs)
         url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
@@ -383,9 +381,7 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, id, postfix
             )
 
-        converted_filters = convert_datetimes_to_timestamps(
-            filters, cls.datetime_filter_attrs
-        )
+        converted_filters = save_request_body(filters, cls.datetime_filter_attrs)
         url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(
             url, headers=headers, stream=stream
@@ -417,7 +413,7 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+            converted_data = save_request_body(data, cls.datetime_attrs)
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
             response = session.post(url, json=converted_data, headers=headers)
@@ -437,8 +433,7 @@ class APIClient(json.JSONEncoder):
             response = session.post(url, files=data)
         else:
             converted_data = [
-                convert_datetimes_to_timestamps(datum, cls.datetime_attrs)
-                for datum in data
+                save_request_body(datum, cls.datetime_attrs) for datum in data
             ]
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
@@ -468,7 +463,7 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        converted_data = save_request_body(data, cls.datetime_attrs)
         response = session.put(url, json=converted_data)
 
         result = _validate(response).json()
@@ -492,7 +487,7 @@ class APIClient(json.JSONEncoder):
             )
 
         url = URLObject(self.api_server).with_path(url_path)
-        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        converted_data = save_request_body(data, cls.datetime_attrs)
 
         session = self._get_http_session(cls.api_root)
         response = session.post(url, json=converted_data)
@@ -507,7 +502,7 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        converted_data = convert_datetimes_to_timestamps(data, cls.datetime_attrs)
+        converted_data = save_request_body(data, cls.datetime_attrs)
         response = session.request(method, url, json=converted_data)
 
         result = _validate(response).json()

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -360,8 +360,8 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, postfix
             )
 
-        converted_filters = create_request_body(filters, cls.datetime_filter_attrs)
-        url = str(URLObject(url).add_query_params(converted_filters.items()))
+        converted_data = create_request_body(filters, cls.datetime_filter_attrs)
+        url = str(URLObject(url).add_query_params(converted_data.items()))
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
         return [cls.create(self, **x) for x in results if x is not None]
@@ -381,8 +381,8 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, id, postfix
             )
 
-        converted_filters = create_request_body(filters, cls.datetime_filter_attrs)
-        url = str(URLObject(url).add_query_params(converted_filters.items()))
+        converted_data = create_request_body(filters, cls.datetime_filter_attrs)
+        url = str(URLObject(url).add_query_params(converted_data.items()))
         response = self._get_http_session(cls.api_root).get(
             url, headers=headers, stream=stream
         )

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -28,7 +28,7 @@ from nylas.client.restful_models import (
     Draft,
 )
 from nylas.client.neural_api_models import Neural
-from nylas.utils import timestamp_from_dt, save_request_body
+from nylas.utils import timestamp_from_dt, create_request_body
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
@@ -360,7 +360,7 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, postfix
             )
 
-        converted_filters = save_request_body(filters, cls.datetime_filter_attrs)
+        converted_filters = create_request_body(filters, cls.datetime_filter_attrs)
         url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
@@ -381,7 +381,7 @@ class APIClient(json.JSONEncoder):
                 self.api_server, self.client_id, cls.collection_name, id, postfix
             )
 
-        converted_filters = save_request_body(filters, cls.datetime_filter_attrs)
+        converted_filters = create_request_body(filters, cls.datetime_filter_attrs)
         url = str(URLObject(url).add_query_params(converted_filters.items()))
         response = self._get_http_session(cls.api_root).get(
             url, headers=headers, stream=stream
@@ -413,7 +413,7 @@ class APIClient(json.JSONEncoder):
         if cls == File:
             response = session.post(url, files=data)
         else:
-            converted_data = save_request_body(data, cls.datetime_attrs)
+            converted_data = create_request_body(data, cls.datetime_attrs)
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
             response = session.post(url, json=converted_data, headers=headers)
@@ -433,7 +433,7 @@ class APIClient(json.JSONEncoder):
             response = session.post(url, files=data)
         else:
             converted_data = [
-                save_request_body(datum, cls.datetime_attrs) for datum in data
+                create_request_body(datum, cls.datetime_attrs) for datum in data
             ]
             headers = {"Content-Type": "application/json"}
             headers.update(self.session.headers)
@@ -463,7 +463,7 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        converted_data = save_request_body(data, cls.datetime_attrs)
+        converted_data = create_request_body(data, cls.datetime_attrs)
         response = session.put(url, json=converted_data)
 
         result = _validate(response).json()
@@ -487,7 +487,7 @@ class APIClient(json.JSONEncoder):
             )
 
         url = URLObject(self.api_server).with_path(url_path)
-        converted_data = save_request_body(data, cls.datetime_attrs)
+        converted_data = create_request_body(data, cls.datetime_attrs)
 
         session = self._get_http_session(cls.api_root)
         response = session.post(url, json=converted_data)
@@ -502,7 +502,7 @@ class APIClient(json.JSONEncoder):
 
         session = self._get_http_session(cls.api_root)
 
-        converted_data = save_request_body(data, cls.datetime_attrs)
+        converted_data = create_request_body(data, cls.datetime_attrs)
         response = session.request(method, url, json=converted_data)
 
         result = _validate(response).json()

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -16,11 +16,12 @@ def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     return int(delta.total_seconds() / timedelta(seconds=1).total_seconds())
 
 
-def convert_datetimes_to_timestamps(data, datetime_attrs):
+def save_request_body(data, datetime_attrs):
     """
     Given a dictionary of data, and a dictionary of datetime attributes,
-    return a new dictionary that converts any datetime attributes that may
-    be present to their timestamped equivalent.
+    return a new dictionary that is suitable for a request. It converts
+    any datetime attributes that may be present to their timestamped
+    equivalent, and it filters out any attributes set to "None".
     """
     if not data:
         return data
@@ -30,7 +31,7 @@ def convert_datetimes_to_timestamps(data, datetime_attrs):
         if key in datetime_attrs and isinstance(value, datetime):
             new_key = datetime_attrs[key]
             new_data[new_key] = timestamp_from_dt(value)
-        else:
+        elif value is not None:
             new_data[key] = value
 
     return new_data

--- a/nylas/utils.py
+++ b/nylas/utils.py
@@ -16,7 +16,7 @@ def timestamp_from_dt(dt, epoch=datetime(1970, 1, 1)):
     return int(delta.total_seconds() / timedelta(seconds=1).total_seconds())
 
 
-def save_request_body(data, datetime_attrs):
+def create_request_body(data, datetime_attrs):
     """
     Given a dictionary of data, and a dictionary of datetime attributes,
     return a new dictionary that is suitable for a request. It converts


### PR DESCRIPTION
# Description
We were not filtering out "None" values before sending them to the API, resulting in some calls returning 500.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
