### PR TITLE
[66512] Support Calendar consecutive availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Add support for calendar consecutive availability
+
 v5.1.0
 ----------------
 * Add Event conferencing support

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -602,7 +602,9 @@ class APIClient(json.JSONEncoder):
     def _validate_open_hours(self, emails, open_hours, free_busy):
         if isinstance(open_hours, list) is False:
             raise ValueError("'open_hours' must be an array.")
-        open_hours_emails = list(chain.from_iterable([oh["emails"] for oh in open_hours]))
+        open_hours_emails = list(
+            chain.from_iterable([oh["emails"] for oh in open_hours])
+        )
         free_busy_emails = (
             [fb["email"] for fb in free_busy] if free_busy is not None else []
         )

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -275,6 +275,8 @@ class APIClient(json.JSONEncoder):
         interval,
         start_at,
         end_at,
+        buffer=None,
+        round_robin=None,
         free_busy=None,
         open_hours=None,
     ):
@@ -306,6 +308,8 @@ class APIClient(json.JSONEncoder):
             "interval_minutes": interval_minutes,
             "start_time": start_time,
             "end_time": end_time,
+            "buffer": buffer,
+            "round_robin": round_robin,
             "free_busy": free_busy or [],
             "open_hours": open_hours or [],
         }

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -326,6 +326,8 @@ class APIClient(json.JSONEncoder):
     ):
         if isinstance(emails, six.string_types):
             emails = [[emails]]
+        elif isinstance(emails[0], list) is False:
+            raise ValueError("'emails' must be a list of lists.")
         if isinstance(duration, timedelta):
             duration_minutes = int(duration.total_seconds() // 60)
         else:

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -249,6 +249,24 @@ class APIClient(json.JSONEncoder):
         _validate(resp)
         return resp.json()
 
+    def open_hours(self, emails, days, timezone, start, end):
+        if isinstance(emails, six.string_types):
+            emails = [emails]
+        if isinstance(days, int):
+            days = [days]
+        if isinstance(start, datetime):
+            start = "{hour}:{minute}".format(hour=start.hour, minute=start.minute)
+        if isinstance(start, datetime):
+            end = "{hour}:{minute}".format(hour=end.hour, minute=end.minute)
+        return {
+            "emails": emails,
+            "days": days,
+            "timezone": timezone,
+            "start": start,
+            "end": end,
+            "object_type": "open_hours",
+        }
+
     def availability(
         self, emails, duration, interval, start_at, end_at, free_busy=None
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1468,6 +1468,13 @@ def mock_availability(mocked_responses, api_url):
         callback=availability_callback,
     )
 
+    mocked_responses.add_callback(
+        responses.POST,
+        "{url}/consecutive".format(url=availability_url),
+        content_type="application/json",
+        callback=availability_callback,
+    )
+
 
 @pytest.fixture
 def mock_sentiment_analysis(mocked_responses, api_url, account_id):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -318,7 +318,7 @@ def test_consecutive_availability(mocked_responses, api_client):
         "14:00",
     )
     api_client.consecutive_availability(
-        emails, duration, interval, start_at, end_at, open_hours=open_hours
+        emails, duration, interval, start_at, end_at, open_hours=[open_hours]
     )
 
     request = mocked_responses.calls[-1].request
@@ -332,15 +332,15 @@ def test_consecutive_availability(mocked_responses, api_client):
     assert data["start_time"] == 1577836800
     assert data["end_time"] == 1577923200
     assert data["free_busy"] == []
-    assert data["open_hours"]["emails"] == [
+    assert data["open_hours"][0]["emails"] == [
         "one@example.com",
         "two@example.com",
         "three@example.com",
     ]
-    assert data["open_hours"]["days"] == [0]
-    assert data["open_hours"]["timezone"] == "America/Chicago"
-    assert data["open_hours"]["start"] == "10:00"
-    assert data["open_hours"]["end"] == "14:00"
+    assert data["open_hours"][0]["days"] == [0]
+    assert data["open_hours"][0]["timezone"] == "America/Chicago"
+    assert data["open_hours"][0]["start"] == "10:00"
+    assert data["open_hours"][0]["end"] == "14:00"
 
 
 @pytest.mark.usefixtures("mock_availability")
@@ -382,7 +382,7 @@ def test_consecutive_availability_free_busy(mocked_responses, api_client):
         start_at,
         end_at,
         free_busy=free_busy,
-        open_hours=open_hours,
+        open_hours=[open_hours],
     )
 
     request = mocked_responses.calls[-1].request
@@ -396,16 +396,16 @@ def test_consecutive_availability_free_busy(mocked_responses, api_client):
     assert data["start_time"] == 1577836800
     assert data["end_time"] == 1577923200
     assert data["free_busy"] == free_busy
-    assert data["open_hours"]["emails"] == [
+    assert data["open_hours"][0]["emails"] == [
         "one@example.com",
         "two@example.com",
         "three@example.com",
         "visitor@external.net",
     ]
-    assert data["open_hours"]["days"] == [0]
-    assert data["open_hours"]["timezone"] == "America/Chicago"
-    assert data["open_hours"]["start"] == "10:00"
-    assert data["open_hours"]["end"] == "14:00"
+    assert data["open_hours"][0]["days"] == [0]
+    assert data["open_hours"][0]["timezone"] == "America/Chicago"
+    assert data["open_hours"][0]["start"] == "10:00"
+    assert data["open_hours"][0]["end"] == "14:00"
 
 
 @pytest.mark.usefixtures("mock_availability")
@@ -451,7 +451,7 @@ def test_consecutive_availability_invalid_open_hours_email(
             start_at,
             end_at,
             free_busy=free_busy,
-            open_hours=open_hours,
+            open_hours=[open_hours],
         )
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -303,6 +303,158 @@ def test_availability_with_free_busy(mocked_responses, api_client):
     assert data["free_busy"] == free_busy
 
 
+@pytest.mark.usefixtures("mock_availability")
+def test_consecutive_availability(mocked_responses, api_client):
+    emails = [["one@example.com"], ["two@example.com", "three@example.com"]]
+    duration = timedelta(minutes=30)
+    interval = timedelta(hours=1, minutes=30)
+    start_at = datetime(2020, 1, 1)
+    end_at = datetime(2020, 1, 2)
+    open_hours = api_client.open_hours(
+        ["one@example.com", "two@example.com", "three@example.com"],
+        [0],
+        "America/Chicago",
+        "10:00",
+        "14:00",
+    )
+    api_client.consecutive_availability(
+        emails, duration, interval, start_at, end_at, open_hours=open_hours
+    )
+
+    request = mocked_responses.calls[-1].request
+    assert URLObject(request.url).path == "/calendars/availability/consecutive"
+    data = json.loads(request.body)
+    assert data["emails"] == emails
+    assert data["duration_minutes"] == 30
+    assert isinstance(data["duration_minutes"], int)
+    assert data["interval_minutes"] == 90
+    assert isinstance(data["interval_minutes"], int)
+    assert data["start_time"] == 1577836800
+    assert data["end_time"] == 1577923200
+    assert data["free_busy"] == []
+    assert data["open_hours"]["emails"] == [
+        "one@example.com",
+        "two@example.com",
+        "three@example.com",
+    ]
+    assert data["open_hours"]["days"] == [0]
+    assert data["open_hours"]["timezone"] == "America/Chicago"
+    assert data["open_hours"]["start"] == "10:00"
+    assert data["open_hours"]["end"] == "14:00"
+
+
+@pytest.mark.usefixtures("mock_availability")
+def test_consecutive_availability_free_busy(mocked_responses, api_client):
+    emails = [["one@example.com"], ["two@example.com", "three@example.com"]]
+    duration = timedelta(minutes=30)
+    interval = timedelta(hours=1, minutes=30)
+    start_at = datetime(2020, 1, 1)
+    end_at = datetime(2020, 1, 2)
+    open_hours = api_client.open_hours(
+        [
+            "one@example.com",
+            "two@example.com",
+            "three@example.com",
+            "visitor@external.net",
+        ],
+        [0],
+        "America/Chicago",
+        "10:00",
+        "14:00",
+    )
+    free_busy = [
+        {
+            "email": "visitor@external.net",
+            "time_slots": [
+                {
+                    "object": "time_slot",
+                    "status": "busy",
+                    "start_time": 1584377898,
+                    "end_time": 1584379800,
+                }
+            ],
+        }
+    ]
+    api_client.consecutive_availability(
+        emails,
+        duration,
+        interval,
+        start_at,
+        end_at,
+        free_busy=free_busy,
+        open_hours=open_hours,
+    )
+
+    request = mocked_responses.calls[-1].request
+    assert URLObject(request.url).path == "/calendars/availability/consecutive"
+    data = json.loads(request.body)
+    assert data["emails"] == emails
+    assert data["duration_minutes"] == 30
+    assert isinstance(data["duration_minutes"], int)
+    assert data["interval_minutes"] == 90
+    assert isinstance(data["interval_minutes"], int)
+    assert data["start_time"] == 1577836800
+    assert data["end_time"] == 1577923200
+    assert data["free_busy"] == free_busy
+    assert data["open_hours"]["emails"] == [
+        "one@example.com",
+        "two@example.com",
+        "three@example.com",
+        "visitor@external.net",
+    ]
+    assert data["open_hours"]["days"] == [0]
+    assert data["open_hours"]["timezone"] == "America/Chicago"
+    assert data["open_hours"]["start"] == "10:00"
+    assert data["open_hours"]["end"] == "14:00"
+
+
+@pytest.mark.usefixtures("mock_availability")
+def test_consecutive_availability_invalid_open_hours_email(
+    mocked_responses, api_client
+):
+    emails = [["one@example.com"], ["two@example.com", "three@example.com"]]
+    duration = timedelta(minutes=30)
+    interval = timedelta(hours=1, minutes=30)
+    start_at = datetime(2020, 1, 1)
+    end_at = datetime(2020, 1, 2)
+    open_hours = api_client.open_hours(
+        [
+            "one@example.com",
+            "two@example.com",
+            "three@example.com",
+            "visitor@external.net",
+            "four@example.com",
+        ],
+        [0],
+        "America/Chicago",
+        "10:00",
+        "14:00",
+    )
+    free_busy = [
+        {
+            "email": "visitor@external.net",
+            "time_slots": [
+                {
+                    "object": "time_slot",
+                    "status": "busy",
+                    "start_time": 1584377898,
+                    "end_time": 1584379800,
+                }
+            ],
+        }
+    ]
+    with pytest.raises(ValueError):
+        api_client.consecutive_availability(
+            emails,
+            duration,
+            interval,
+            start_at,
+            end_at,
+            free_busy=free_busy,
+            open_hours=open_hours,
+        )
+
+
 @pytest.mark.usefixtures("mock_events")
 def test_metadata_filtering(api_client):
     events_filtered_by_key = api_client.events.where(metadata_key="platform")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -281,6 +281,7 @@ def test_availability_with_free_busy(mocked_responses, api_client):
                     "end_time": 1584379800,
                 }
             ],
+            "object": "free_busy",
         }
     ]
     availability = api_client.availability(
@@ -373,6 +374,7 @@ def test_consecutive_availability_free_busy(mocked_responses, api_client):
                     "end_time": 1584379800,
                 }
             ],
+            "object": "free_busy",
         }
     ]
     api_client.consecutive_availability(
@@ -441,6 +443,7 @@ def test_consecutive_availability_invalid_open_hours_email(
                     "end_time": 1584379800,
                 }
             ],
+            "object": "free_busy",
         }
     ]
     with pytest.raises(ValueError):


### PR DESCRIPTION
# Description
This PR enables support for the `/calendars/availability/consecutive` endpoint. 

# Usage
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

emails = [["one@example.com"], ["two@example.com", "three@example.com"]]
duration = 30
interval = 60
start_at = 1632236400
end_at = 1632240000
open_hours = api_client.open_hours(
    [
        "one@example.com",
        "two@example.com",
        "three@example.com",
        "visitor@external.net",
    ],
    [0],
    "America/Chicago",
    "10:00",
    "14:00",
)
free_busy = [
    {
        "email": "visitor@external.net",
        "time_slots": [
            {
                "object": "time_slot",
                "status": "busy",
                "start_time": 1632236400,
                "end_time": 1632240000,
            }
        ],
    }
]
api_client.consecutive_availability(
    emails,
    duration,
    interval,
    start_at,
    end_at,
    free_busy=free_busy,
    open_hours=open_hours,
)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
