### PR TITLE
[69627] Component CRUD Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Add support for Component CRUD
+
 v5.2.0
 ----------------
 * Add support for calendar consecutive availability

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -27,6 +27,7 @@ from nylas.client.restful_models import (
     Folder,
     Label,
     Draft,
+    Component,
 )
 from nylas.client.neural_api_models import Neural
 from nylas.utils import timestamp_from_dt, create_request_body
@@ -417,6 +418,10 @@ class APIClient(json.JSONEncoder):
     @property
     def calendars(self):
         return RestfulModelCollection(Calendar, self)
+
+    @property
+    def components(self):
+        return RestfulModelCollection(Component, self)
 
     @property
     def neural(self):

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -473,8 +473,13 @@ class APIClient(json.JSONEncoder):
                 server=self.api_server, path=path, id=id, postfix=postfix
             )
         else:
-            url = "{}/a/{}/{}{}{}".format(
-                self.api_server, self.client_id, cls.collection_name, id, postfix
+            url = "{server}/{prefix}/{client_id}{path}{id}{postfix}".format(
+                server=self.api_server,
+                prefix=cls.api_root,
+                client_id=self.client_id,
+                path=path,
+                id=id,
+                postfix=postfix,
             )
 
         converted_data = create_request_body(filters, cls.datetime_filter_attrs)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -462,9 +462,6 @@ class APIClient(json.JSONEncoder):
         self, cls, id, extra=None, headers=None, stream=False, **filters
     ):
         """Get an individual REST resource"""
-        headers = headers or {}
-        headers.update(self.session.headers)
-
         postfix = "/{}".format(extra) if extra else ""
         path = "/{}".format(cls.collection_name) if cls.collection_name else ""
         id = "/{}".format(id) if id else ""
@@ -484,9 +481,12 @@ class APIClient(json.JSONEncoder):
 
         converted_data = create_request_body(filters, cls.datetime_filter_attrs)
         url = str(URLObject(url).add_query_params(converted_data.items()))
-        response = self._get_http_session(cls.api_root).get(
-            url, headers=headers, stream=stream
-        )
+
+        session = self._get_http_session(cls.api_root)
+
+        headers = headers or {}
+        headers.update(session.headers)
+        response = session.get(url, headers=headers, stream=stream)
         return _validate(response)
 
     def _get_resource(self, cls, id, **filters):
@@ -522,7 +522,7 @@ class APIClient(json.JSONEncoder):
         else:
             converted_data = create_request_body(data, cls.datetime_attrs)
             headers = {"Content-Type": "application/json"}
-            headers.update(self.session.headers)
+            headers.update(session.headers)
             response = session.post(url, json=converted_data, headers=headers)
 
         result = _validate(response).json()
@@ -547,7 +547,7 @@ class APIClient(json.JSONEncoder):
                 create_request_body(datum, cls.datetime_attrs) for datum in data
             ]
             headers = {"Content-Type": "application/json"}
-            headers.update(self.session.headers)
+            headers.update(session.headers)
             response = session.post(url, json=converted_data, headers=headers)
 
         results = _validate(response).json()

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -459,10 +459,11 @@ class APIClient(json.JSONEncoder):
         headers.update(self.session.headers)
 
         postfix = "/{}".format(extra) if extra else ""
+        id = "/{}".format(id) if id else ""
         if cls.api_root != "a":
-            url = "{}/{}/{}{}".format(self.api_server, cls.collection_name, id, postfix)
+            url = "{}/{}{}{}".format(self.api_server, cls.collection_name, id, postfix)
         else:
-            url = "{}/a/{}/{}/{}{}".format(
+            url = "{}/a/{}/{}{}{}".format(
                 self.api_server, self.client_id, cls.collection_name, id, postfix
             )
 
@@ -489,7 +490,7 @@ class APIClient(json.JSONEncoder):
     def _create_resource(self, cls, data, **kwargs):
         url = (
             URLObject(self.api_server)
-            .with_path("/{name}/".format(name=cls.collection_name))
+            .with_path("/{name}".format(name=cls.collection_name))
             .set_query_params(**kwargs)
         )
 
@@ -510,7 +511,7 @@ class APIClient(json.JSONEncoder):
 
     def _create_resources(self, cls, data):
         url = URLObject(self.api_server).with_path(
-            "/{name}/".format(name=cls.collection_name)
+            "/{name}".format(name=cls.collection_name)
         )
         session = self._get_http_session(cls.api_root)
 

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -703,6 +703,41 @@ class RoomResource(NylasAPIObject):
         NylasAPIObject.__init__(self, RoomResource, api)
 
 
+class Component(NylasAPIObject):
+    attrs = [
+        "id",
+        "account_id",
+        "name",
+        "type",
+        "action",
+        "active",
+        "settings",
+        "public_account_id",
+        "public_token_id",
+        "public_application_id",
+        "access_token",
+        "allowed_domains",
+    ]
+    datetime_attrs = {
+        "created_at": "created_at",
+        "updated_at": "updated_at",
+    }
+    read_only_attrs = {"id", "public_application_id", "created_at", "updated_at"}
+
+    collection_name = None
+    api_root = "component"
+
+    def __init__(self, api):
+        NylasAPIObject.__init__(self, RoomResource, api)
+
+    def as_json(self):
+        dct = NylasAPIObject.as_json(self)
+        # "type" cannot be modified after created
+        if self.id:
+            dct.pop("type")
+        return dct
+
+
 class Namespace(NylasAPIObject):
     attrs = [
         "account",

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -82,7 +82,13 @@ class RestfulModel(dict):
                 obj[date_attr] = datetime.strptime(kwargs[iso_attr], "%Y-%m-%d").date()
         for dt_attr, ts_attr in cls.datetime_attrs.items():
             if kwargs.get(ts_attr):
-                obj[dt_attr] = datetime.utcfromtimestamp(kwargs[ts_attr])
+                try:
+                    obj[dt_attr] = datetime.utcfromtimestamp(kwargs[ts_attr])
+                except TypeError:
+                    # If the datetime format is in the format of ISO8601
+                    obj[dt_attr] = datetime.strptime(
+                        kwargs[ts_attr], "%Y-%m-%dT%H:%M:%S.%fZ"
+                    )
         for attr, value_attr_name in cls.typed_dict_attrs.items():
             obj[attr] = typed_dict_attr(kwargs.get(attr, []), attr_name=value_attr_name)
 

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -37,7 +37,7 @@ class RestfulModel(dict):
     # but some of them are under '/a' (mostly the account-management
     # and billing code). api_root is a tiny metaprogramming hack to let
     # us use the same code for both.
-    api_root = "n"
+    api_root = None
 
     def __init__(self, cls, api):
         self.id = None

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -33,6 +33,7 @@ class RestfulModel(dict):
     datetime_attrs = {}
     datetime_filter_attrs = {}
     typed_dict_attrs = {}
+    read_only_attrs = {}
     # The Nylas API holds most objects for an account directly under '/',
     # but some of them are under '/a' (mostly the account-management
     # and billing code). api_root is a tiny metaprogramming hack to let
@@ -105,18 +106,26 @@ class RestfulModel(dict):
         # their correct form though.
         reserved_keywords = ["from", "in"]
         for attr in self.cls.attrs:
+            if attr in self.read_only_attrs:
+                continue
             if hasattr(self, attr):
                 if attr in reserved_keywords:
                     dct[attr] = getattr(self, "{}_".format(attr))
                 else:
                     dct[attr] = getattr(self, attr)
         for date_attr, iso_attr in self.cls.date_attrs.items():
+            if date_attr in self.read_only_attrs:
+                continue
             if self.get(date_attr):
                 dct[iso_attr] = self[date_attr].strftime("%Y-%m-%d")
         for dt_attr, ts_attr in self.cls.datetime_attrs.items():
+            if dt_attr in self.read_only_attrs:
+                continue
             if self.get(dt_attr):
                 dct[ts_attr] = timestamp_from_dt(self[dt_attr])
         for attr, value_attr in self.cls.typed_dict_attrs.items():
+            if attr in self.read_only_attrs:
+                continue
             typed_dict = getattr(self, attr)
             if value_attr:
                 dct[attr] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -828,6 +828,28 @@ def mock_send_rsvp(mocked_responses, api_url, message_body):
 
 
 @pytest.fixture
+def mock_components_create_response(mocked_responses, api_url, message_body):
+    def callback(_request):
+        try:
+            payload = json.loads(_request.body)
+        except ValueError:
+            return 400, {}, ""
+
+        payload["id"] = "cv4ei7syx10uvsxbs21ccsezf"
+        return 200, {}, json.dumps(payload)
+
+    mocked_responses.add_callback(
+        responses.POST, re.compile(api_url + "/component/*"), callback=callback
+    )
+
+    mocked_responses.add(
+        responses.PUT,
+        re.compile(api_url + "/component/*"),
+        body=json.dumps(message_body),
+    )
+
+
+@pytest.fixture
 def mock_thread_search_response(mocked_responses, api_url):
     snippet = (
         "Hey Helena, Looking forward to getting together for dinner on Friday. "
@@ -1263,6 +1285,34 @@ def mock_events(mocked_responses, api_url):
         return (200, {}, json.dumps(events))
 
     endpoint = re.compile(api_url + "/events")
+    mocked_responses.add_callback(
+        responses.GET, endpoint, content_type="application/json", callback=list_callback
+    )
+
+
+@pytest.fixture
+def mock_components(mocked_responses, api_url):
+    components = [
+        {
+            "active": True,
+            "settings": {},
+            "allowed_domains": [],
+            "id": "component-id",
+            "name": "PyTest Component",
+            "public_account_id": "account-id",
+            "public_application_id": "application-id",
+            "type": "agenda",
+            "created_at": "2021-10-22T18:02:10.000Z",
+            "updated_at": "2021-10-22T18:02:10.000Z",
+            "accessed_at": None,
+            "public_token_id": "token-id"
+        },
+    ]
+
+    def list_callback(arg=None):
+        return 200, {}, json.dumps(components)
+
+    endpoint = re.compile(api_url + "/component/*")
     mocked_responses.add_callback(
         responses.GET, endpoint, content_type="application/json", callback=list_callback
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1305,7 +1305,7 @@ def mock_components(mocked_responses, api_url):
             "created_at": "2021-10-22T18:02:10.000Z",
             "updated_at": "2021-10-22T18:02:10.000Z",
             "accessed_at": None,
-            "public_token_id": "token-id"
+            "public_token_id": "token-id",
         },
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def mocked_responses():
 
 @pytest.fixture
 def mock_save_draft(mocked_responses, api_url):
-    save_endpoint = re.compile(api_url + "/drafts/")
+    save_endpoint = re.compile(api_url + "/drafts")
     response_body = json.dumps(
         {"id": "4dl0ni6vxomazo73r5oydo16k", "version": "4dw0ni6txomazo33r5ozdo16j"}
     )
@@ -641,7 +641,7 @@ def mock_draft_saved_response(mocked_responses, api_url):
 
     mocked_responses.add_callback(
         responses.POST,
-        api_url + "/drafts/",
+        api_url + "/drafts",
         content_type="application/json",
         callback=create_callback,
     )
@@ -699,7 +699,7 @@ def mock_draft_sent_response(mocked_responses, api_url):
 
     mocked_responses.add_callback(
         responses.POST,
-        api_url + "/send/",
+        api_url + "/send",
         callback=callback,
         content_type="application/json",
     )
@@ -714,7 +714,7 @@ def mock_draft_send_unsaved_response(mocked_responses, api_url):
 
     mocked_responses.add_callback(
         responses.POST,
-        api_url + "/send/",
+        api_url + "/send",
         callback=callback,
         content_type="application/json",
     )
@@ -771,7 +771,7 @@ def mock_files(mocked_responses, api_url, account_id):
         return (200, {}, json.dumps(body))
 
     mocked_responses.add_callback(
-        responses.POST, api_url + "/files/", callback=create_callback
+        responses.POST, api_url + "/files", callback=create_callback
     )
 
 
@@ -787,7 +787,7 @@ def mock_event_create_response(mocked_responses, api_url, message_body):
         return 200, {}, json.dumps(payload)
 
     mocked_responses.add_callback(
-        responses.POST, api_url + "/events/", callback=callback
+        responses.POST, api_url + "/events", callback=callback
     )
 
     put_body = {"title": "loaded from JSON", "ignored": "ignored"}
@@ -813,7 +813,7 @@ def mock_event_create_response_with_limits(mocked_responses, api_url, message_bo
 def mock_event_create_notify_response(mocked_responses, api_url, message_body):
     mocked_responses.add(
         responses.POST,
-        api_url + "/events/?notify_participants=true&other_param=1",
+        api_url + "/events?notify_participants=true&other_param=1",
         body=json.dumps(message_body),
     )
 
@@ -1094,7 +1094,7 @@ def mock_contacts(mocked_responses, account_id, api_url):
     )
     mocked_responses.add_callback(
         responses.POST,
-        api_url + "/contacts/",
+        api_url + "/contacts",
         content_type="application/json",
         callback=create_callback,
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -187,7 +187,7 @@ def test_create_resources(mocked_responses, api_client, api_url):
     ]
     mocked_responses.add(
         responses.POST,
-        api_url + "/contacts/",
+        api_url + "/contacts",
         content_type="application/json",
         status=200,
         body=json.dumps(contacts_data),
@@ -222,7 +222,7 @@ def test_201_response(mocked_responses, api_client, api_url):
     contact_data = {"id": 1, "given_name": "Charlie", "surname": "Bucket"}
     mocked_responses.add(
         responses.POST,
-        api_url + "/contacts/",
+        api_url + "/contacts",
         content_type="application/json",
         status=201,  # This HTTP status still indicates success,
         # even though it's not 200.

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+import pytest
+
+from nylas.client.restful_models import Component
+
+
+def blank_component(api_client):
+    component = api_client.components.create()
+    component.name = "Python Component Test"
+    component.type = "agenda"
+    component.public_account_id = "test-account-id"
+    component.access_token = "test-access-token"
+    return component
+
+
+@pytest.mark.usefixtures("mock_components")
+def test_components(api_client):
+    component = api_client.components.first()
+    assert isinstance(component, Component)
+    assert component.id == "component-id"
+    assert component.active is True
+    assert component.name == "PyTest Component"
+    assert component.public_account_id == "account-id"
+    assert component.public_application_id == "application-id"
+    assert component.type == "agenda"
+    assert component.created_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.updated_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.public_token_id == "token-id"
+
+
+@pytest.mark.usefixtures("mock_components")
+def test_components(api_client):
+    component = api_client.components.first()
+    assert isinstance(component, Component)
+    assert component.id == "component-id"
+    assert component.active is True
+    assert component.name == "PyTest Component"
+    assert component.public_account_id == "account-id"
+    assert component.public_application_id == "application-id"
+    assert component.type == "agenda"
+    assert component.created_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.updated_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.public_token_id == "token-id"
+
+
+@pytest.mark.usefixtures("mock_components_create_response")
+def test_create_components(api_client):
+    component = blank_component(api_client)
+    component.save()
+    assert component.id == "cv4ei7syx10uvsxbs21ccsezf"
+
+
+@pytest.mark.usefixtures("mock_components_create_response")
+def test_modify_components(api_client):
+    component = blank_component(api_client)
+    component.id = "cv4ei7syx10uvsxbs21ccsezf"
+    component.name = "Updated Name"
+    component.save()
+    assert component.name == "Updated Name"
+
+
+@pytest.mark.usefixtures("mock_components_create_response")
+def test_components_as_json_read_only(api_client):
+    component = blank_component(api_client)
+    component.id = "test-id"
+    json = component.as_json()
+    assert 'id' not in json
+    assert 'public_application_id' not in json
+    assert 'created_at' not in json
+    assert 'updated_at' not in json

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -24,8 +24,12 @@ def test_components(api_client):
     assert component.public_account_id == "account-id"
     assert component.public_application_id == "application-id"
     assert component.type == "agenda"
-    assert component.created_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
-    assert component.updated_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.created_at == datetime.strptime(
+        "2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
+    assert component.updated_at == datetime.strptime(
+        "2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
     assert component.public_token_id == "token-id"
 
 
@@ -39,8 +43,12 @@ def test_components(api_client):
     assert component.public_account_id == "account-id"
     assert component.public_application_id == "application-id"
     assert component.type == "agenda"
-    assert component.created_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
-    assert component.updated_at == datetime.strptime("2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert component.created_at == datetime.strptime(
+        "2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
+    assert component.updated_at == datetime.strptime(
+        "2021-10-22T18:02:10.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
     assert component.public_token_id == "token-id"
 
 
@@ -65,7 +73,7 @@ def test_components_as_json_read_only(api_client):
     component = blank_component(api_client)
     component.id = "test-id"
     json = component.as_json()
-    assert 'id' not in json
-    assert 'public_application_id' not in json
-    assert 'created_at' not in json
-    assert 'updated_at' not in json
+    assert "id" not in json
+    assert "public_application_id" not in json
+    assert "created_at" not in json
+    assert "updated_at" not in json


### PR DESCRIPTION
# Description
This PR enables SDK support for the Nylas `/component` endpoints.

# Usage
To create a new component:
```python
component = nylas.components.create()
component.name = "Python Component"
component.type = "agenda"
component.public_account_id = "ACCOUNT_PUBLIC_ID"
component.access_token = "ACCOUNT_ACCESS_TOKEN"
component.save()
```

To get all components:
```python
components = nylas.components.all()
```

To get a specific component:
```python
component = nylas.components.get("{COMPONENT_ID}")
```

To update a component:
```python
component = nylas.components.get("{COMPONENT_ID}")
component.name = "Updated"
component.save()
```

To delete a component:
```python
nylas.components.delete("{COMPONENT_ID}")
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.