### PR TITLE
[67238] Return better error details from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased (dev)
 ----------------
 * Add support for Component CRUD
+* Improve error details returned from the API
 
 v5.2.0
 ----------------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -7,11 +7,12 @@ from datetime import datetime, timedelta
 from itertools import chain
 
 import requests
+from requests import HTTPError
 from urlobject import URLObject
 import six
 from six.moves.urllib.parse import urlencode
 from nylas._client_sdk_version import __VERSION__
-from nylas.client.errors import MessageRejectedError
+from nylas.client.errors import MessageRejectedError, NylasApiError
 from nylas.client.restful_model_collection import RestfulModelCollection
 from nylas.client.restful_models import (
     Calendar,
@@ -57,8 +58,9 @@ def _validate(response):
         # we will handle it separate and handle a _different_ exception
         # so that users don't think they need to pay.
         raise MessageRejectedError(response)
+    elif response.status_code >= 400:
+        raise NylasApiError(response)
 
-    response.raise_for_status()
     return response
 
 

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -29,6 +29,7 @@ class NylasApiError(HTTPError):
     Error class for Nylas API Errors
     This class provides more information to the user sent from the server, if present
     """
+
     def __init__(self, response):
         try:
             response_json = json.loads(response.text)

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -1,3 +1,8 @@
+import json
+
+from requests import HTTPError
+
+
 class NylasError(Exception):
     pass
 
@@ -17,3 +22,22 @@ class UnSyncedError(NylasError):
     """
 
     pass
+
+
+class NylasApiError(HTTPError):
+    """
+    Error class for Nylas API Errors
+    This class provides more information to the user sent from the server, if present
+    """
+    def __init__(self, response):
+        response_json = json.loads(response.text)
+        if response_json and "message" in response_json and "type" in response_json:
+            error_message = u"%s %s. Reason: %s. Nylas Error Type: %s" % (
+                response.status_code,
+                response.reason,
+                response_json["message"],
+                response_json["type"],
+            )
+            super(NylasApiError, self).__init__(error_message, response=response)
+        else:
+            super(NylasApiError, self).__init__(response.text, response=response)

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -30,8 +30,8 @@ class NylasApiError(HTTPError):
     This class provides more information to the user sent from the server, if present
     """
     def __init__(self, response):
-        response_json = json.loads(response.text)
-        if response_json and "message" in response_json and "type" in response_json:
+        try:
+            response_json = json.loads(response.text)
             error_message = u"%s %s. Reason: %s. Nylas Error Type: %s" % (
                 response.status_code,
                 response.reason,
@@ -39,5 +39,5 @@ class NylasApiError(HTTPError):
                 response_json["type"],
             )
             super(NylasApiError, self).__init__(error_message, response=response)
-        else:
+        except ValueError or KeyError:
             super(NylasApiError, self).__init__(response.text, response=response)

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -39,5 +39,5 @@ class NylasApiError(HTTPError):
                 response_json["type"],
             )
             super(NylasApiError, self).__init__(error_message, response=response)
-        except ValueError or KeyError:
+        except (ValueError, KeyError):
             super(NylasApiError, self).__init__(response.text, response=response)

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from six import StringIO
 from nylas.client.restful_model_collection import RestfulModelCollection
-from nylas.client.errors import FileUploadError, UnSyncedError
+from nylas.client.errors import FileUploadError, UnSyncedError, NylasApiError
 from nylas.utils import timestamp_from_dt
 
 # pylint: disable=attribute-defined-outside-init
@@ -596,7 +596,8 @@ class Contact(NylasAPIObject):
         response = self.api._get_resource_raw(
             Contact, self.id, extra="picture", stream=True
         )
-        response.raise_for_status()
+        if response.status_code >= 400:
+            raise NylasApiError(response)
         return response.raw
 
 
@@ -669,7 +670,8 @@ class Event(NylasAPIObject):
             "comment": comment,
         }
         response = self.api.session.post(url, json=data)
-        response.raise_for_status()
+        if response.status_code >= 400:
+            raise NylasApiError(response)
         result = response.json()
         return Event.create(self, **result)
 


### PR DESCRIPTION
# Description
Previously, we would only return a vague error message thrown from the requests library, without any detail from the Nylas API. Now we return a custom error object (that extends `HTTPError`) that properly returns a message that includes the error code and the HTTP error type, as well as the error reason and error type from the Nylas API.

### Errors Before
`requests.exceptions.HTTPError: 404 Client Error: NOT FOUND for url: https://api.nylas.com/calendars/foo`

### After
`nylas.client.errors.NylasApiError: 404 NOT FOUND. Reason: Calendar foo not found. Nylas Error Type: invalid_request_error`

# Usage

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
