### PR TITLE
[73524] Metadata Support for Calendars, Accounts, and Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (dev)
 ----------------
 * Add support for Event notifications
 * Add support for Component CRUD
+* Add metadata support for `Calendar`, `Message` and `Account`
 * Improve error details returned from the API
 
 v5.2.0

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -184,6 +184,7 @@ class Message(NylasAPIObject):
         "to",
         "unread",
         "starred",
+        "metadata",
         "_folder",
         "_labels",
         "headers",
@@ -602,7 +603,15 @@ class Contact(NylasAPIObject):
 
 
 class Calendar(NylasAPIObject):
-    attrs = ["id", "account_id", "name", "description", "read_only", "object"]
+    attrs = [
+        "id",
+        "account_id",
+        "name",
+        "description",
+        "metadata",
+        "read_only",
+        "object",
+    ]
     collection_name = "calendars"
 
     def __init__(self, api):
@@ -773,6 +782,7 @@ class Account(NylasAPIObject):
         "provider",
         "sync_state",
         "trial",
+        "metadata",
     ]
 
     collection_name = "accounts"
@@ -781,7 +791,7 @@ class Account(NylasAPIObject):
         NylasAPIObject.__init__(self, Account, api)
 
     def as_json(self):
-        dct = NylasAPIObject.as_json(self)
+        dct = {"metadata": self.metadata}
         return dct
 
     def upgrade(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,13 @@ def mock_accounts(mocked_responses, api_url, account_id, client_id):
             return (200, {}, json.dumps([]))
         return (200, {}, json.dumps(accounts))
 
+    def update_callback(request):
+        response = accounts[0]
+        payload = json.loads(request.body)
+        if payload["metadata"]:
+            response["metadata"] = payload["metadata"]
+        return 200, {}, json.dumps(response)
+
     url_re = "{base}(/a/{client_id})?/accounts/?".format(
         base=api_url, client_id=client_id
     )
@@ -181,6 +188,12 @@ def mock_accounts(mocked_responses, api_url, account_id, client_id):
         re.compile(url_re),
         content_type="application/json",
         callback=list_callback,
+    )
+    mocked_responses.add_callback(
+        responses.PUT,
+        re.compile(url_re),
+        content_type="application/json",
+        callback=update_callback,
     )
 
 
@@ -391,6 +404,8 @@ def mock_message(mocked_responses, api_url, account_id):
                 for l in payload["labels"]
             ]
             base_msg["labels"] = labels
+        if "metadata" in payload:
+            base_msg["metadata"] = payload["metadata"]
         return (200, {}, json.dumps(base_msg))
 
     endpoint = re.compile(api_url + "/messages/1234")

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -87,3 +87,12 @@ def test_account_access(api_client):
     account3 = api_client.accounts.first()
     assert isinstance(account3, APIAccount)
     assert account1.as_json() == account2.as_json() == account3.as_json()
+
+
+@pytest.mark.usefixtures("mock_accounts")
+def test_account_metadata(api_client_with_client_id, monkeypatch):
+    monkeypatch.setattr(api_client_with_client_id, "is_opensource_api", lambda: False)
+    account1 = api_client_with_client_id.accounts[0]
+    account1["metadata"] = {"test": "value"}
+    account1.save()
+    assert account1["metadata"] == {"test": "value"}

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -144,3 +144,11 @@ def test_filter_messages_ts(mocked_responses, api_client):
     request = mocked_responses.calls[0].request
     url = URLObject(request.url)
     assert url.query_dict["received_before"] == "1275350400"
+
+
+@pytest.mark.usefixtures("mock_message", "mock_messages")
+def test_message_metadata(mocked_responses, api_client):
+    message = api_client.messages.first()
+    message["metadata"] = {"test": "value"}
+    message.save()
+    assert message.metadata == {"test": "value"}


### PR DESCRIPTION
# Description
The metadata feature first introduced for events has expended to `Calendar`, `Message` and `Account`. This PR adds support for this change. More information on the expansion of the metadata can be found here: https://developer.nylas.com/docs/developer-tools/api/metadata

# Usage

Adding Metadata to Calendar
```python
calendar = nylas.calendars.create()
calendar.name = "My New Calendar"
calendar.description = "Description of my new calendar"
calendar.location = "Location description"
calendar.timezone = "America/Los_Angeles"
calendar.metadata = {
  "event_type": "gathering"
}
calendar.save()

# Or you can update a calendar with metadata

calendar = nylas.calendars.first()

calendar.metadata = {
  "event_type": "gathering"
}
calendar.save()
```

Query Calendars by Metadata
```python
calendars = nylas.calendars.where(metadata_pair={event_type: "gathering"})
```

Adding Metadata to Message
```python
message = nylas.messages.first()

message.metadata = {
  "test": "true"
}
message.save()
```

Adding Metadata to Account
```python
account = api.accounts[0]

account.metadata = {
  "test": "true"
}
account.save()
```

Query Account by Metadata
```python
accounts = api.accounts.where(metadata_key="test");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
