### PR TITLE
[74538] Add is_primary field for Calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Add `is_primary` field to Calendar
+
 v5.3.0
 ----------------
 * Add support for Scheduler API

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -610,6 +610,7 @@ class Calendar(NylasAPIObject):
         "description",
         "metadata",
         "read_only",
+        "is_primary",
         "object",
     ]
     collection_name = "calendars"


### PR DESCRIPTION
# Description
The SDK was missing the `is_primary` field for Calendar, this PR adds the field in.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
