### PR TITLE
[75449] Fix bug where updating an Event results in an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Fix bug where updating an Event results in an API error
+
 v5.3.0
 ----------------
 * Add support for Scheduler API

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -663,6 +663,12 @@ class Event(NylasAPIObject):
             dct["when"] = dct["when"].copy()
             dct["when"].pop("object", None)
 
+        if dct.get("participants") and isinstance(dct.get("participants"), list):
+            # The status of a participant cannot be updated and, if the key is
+            # included, it will return an error from the API
+            for participant in dct.get("participants"):
+                participant.pop("status")
+
         return dct
 
     def rsvp(self, status, comment=None):

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -667,7 +667,7 @@ class Event(NylasAPIObject):
             # The status of a participant cannot be updated and, if the key is
             # included, it will return an error from the API
             for participant in dct.get("participants"):
-                participant.pop("status")
+                participant.pop("status", None)
 
         return dct
 


### PR DESCRIPTION
# Description
A recent API update caused updating an event using the SDK to return an error because the SDK sends a Participant's status on an Event update call. This PR omits this field when converting the Event object to a JSON.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
