### PR TITLE
[75826] Job Status support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased (dev)
+----------------
+* Add job status support
+
 v5.3.0
 ----------------
 * Add support for Scheduler API

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -30,6 +30,7 @@ from nylas.client.restful_models import (
     Label,
     Draft,
     Component,
+    JobStatus,
 )
 from nylas.client.neural_api_models import Neural
 from nylas.client.scheduler_restful_model_collection import (
@@ -424,6 +425,10 @@ class APIClient(json.JSONEncoder):
     @property
     def calendars(self):
         return RestfulModelCollection(Calendar, self)
+
+    @property
+    def job_statuses(self):
+        return RestfulModelCollection(JobStatus, self)
 
     @property
     def scheduler(self):

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -181,6 +181,7 @@ class Message(NylasAPIObject):
         "starred",
         "subject",
         "thread_id",
+        "job_status_id",
         "to",
         "unread",
         "starred",
@@ -284,7 +285,7 @@ class Message(NylasAPIObject):
 
 
 class Folder(NylasAPIObject):
-    attrs = ["id", "display_name", "name", "object", "account_id"]
+    attrs = ["id", "display_name", "name", "object", "account_id", "job_status_id"]
     collection_name = "folders"
 
     def __init__(self, api):
@@ -300,7 +301,7 @@ class Folder(NylasAPIObject):
 
 
 class Label(NylasAPIObject):
-    attrs = ["id", "display_name", "name", "object", "account_id"]
+    attrs = ["id", "display_name", "name", "object", "account_id", "job_status_id"]
     collection_name = "labels"
 
     def __init__(self, api):
@@ -465,6 +466,7 @@ class Draft(Message):
         "subject",
         "thread_id",
         "to",
+        "job_status_id",
         "unread",
         "version",
         "file_ids",
@@ -572,6 +574,7 @@ class Contact(NylasAPIObject):
         "nickname",
         "company_name",
         "job_title",
+        "job_status_id",
         "manager_name",
         "office_location",
         "notes",
@@ -608,6 +611,7 @@ class Calendar(NylasAPIObject):
         "account_id",
         "name",
         "description",
+        "job_status_id"
         "metadata",
         "read_only",
         "object",
@@ -638,6 +642,7 @@ class Event(NylasAPIObject):
         "recurrence",
         "status",
         "master_event_id",
+        "job_status_id",
         "owner",
         "original_start_time",
         "object",

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -611,7 +611,7 @@ class Calendar(NylasAPIObject):
         "account_id",
         "name",
         "description",
-        "job_status_id"
+        "job_status_id",
         "metadata",
         "read_only",
         "object",
@@ -718,6 +718,26 @@ class RoomResource(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, RoomResource, api)
+
+
+class JobStatus(NylasAPIObject):
+    attrs = [
+        "id",
+        "account_id",
+        "job_status_id",
+        "action",
+        "object",
+        "status",
+        "original_data",
+    ]
+    datetime_attrs = {"created_at": "created_at"}
+    collection_name = "job-statuses"
+
+    def __init__(self, api):
+        NylasAPIObject.__init__(self, JobStatus, api)
+
+    def is_successful(self):
+        return self.status == "successful"
 
 
 class Scheduler(NylasAPIObject):

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -58,6 +58,7 @@ class RestfulModel(dict):
             object_type
             and object_type != cls_object_type
             and object_type != "account"
+            and cls_object_type != "jobstatus"
             and not _is_subclass(cls, object_type)
         ):
             # We were given a specific object type and we're trying to
@@ -65,6 +66,8 @@ class RestfulModel(dict):
             # and labels API.)
             # We need a special case for accounts because the /accounts API
             # is different between the open source and hosted API.
+            # And a special case for job status because the object refers to
+            # the type of objects' job status
             return
         obj = cls(api)  # pylint: disable=no-value-for-parameter
         obj.cls = cls

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1640,7 +1640,7 @@ def mock_job_statuses(mocked_responses, api_url):
             "id": "test_id",
             "job_status_id": "test_job_status_id",
             "object": "message",
-            "status": "successful"
+            "status": "successful",
         },
         {
             "account_id": "test_account_id",
@@ -1649,7 +1649,7 @@ def mock_job_statuses(mocked_responses, api_url):
             "id": "test_id_2",
             "job_status_id": "test_job_status_id_2",
             "object": "event",
-            "status": "successful"
+            "status": "successful",
         },
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1631,6 +1631,39 @@ def mock_resources(mocked_responses, api_url):
 
 
 @pytest.fixture
+def mock_job_statuses(mocked_responses, api_url):
+    job_status = [
+        {
+            "account_id": "test_account_id",
+            "action": "save_draft",
+            "created_at": 1622846160,
+            "id": "test_id",
+            "job_status_id": "test_job_status_id",
+            "object": "message",
+            "status": "successful"
+        },
+        {
+            "account_id": "test_account_id",
+            "action": "update_event",
+            "created_at": 1622846160,
+            "id": "test_id_2",
+            "job_status_id": "test_job_status_id_2",
+            "object": "event",
+            "status": "successful"
+        },
+    ]
+
+    endpoint = re.compile(api_url + "/job-statuses")
+    mocked_responses.add(
+        responses.GET,
+        endpoint,
+        body=json.dumps(job_status),
+        status=200,
+        content_type="application/json",
+    )
+
+
+@pytest.fixture
 def mock_account_management(mocked_responses, api_url, account_id, client_id):
     account = {
         "account_id": account_id,

--- a/tests/test_job_status.py
+++ b/tests/test_job_status.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+import pytest
+from nylas.client.restful_models import JobStatus
+
+
+@pytest.mark.usefixtures("mock_job_statuses")
+def test_first_job_status(api_client):
+    job_status = api_client.job_statuses.first()
+    assert isinstance(job_status, JobStatus)
+
+
+@pytest.mark.usefixtures("mock_job_statuses")
+def test_all_job_status(api_client):
+    job_statuses = api_client.job_statuses.all()
+    assert len(job_statuses) == 2
+    for job_status in job_statuses:
+        assert isinstance(job_status, JobStatus)
+
+
+@pytest.mark.usefixtures("mock_job_statuses")
+def test_job_status(api_client):
+    job_status = api_client.job_statuses.first()
+    assert job_status["account_id"] == "test_account_id"
+    assert job_status["action"] == "save_draft"
+    assert job_status["id"] == "test_id"
+    assert job_status["job_status_id"] == "test_job_status_id"
+    assert job_status["object"] == "message"
+    assert job_status["status"] == "successful"
+    assert job_status["created_at"] == datetime(2021, 6, 4, 22, 36)
+
+
+@pytest.mark.usefixtures("mock_job_statuses")
+def test_job_status_is_successful(api_client):
+    job_status = api_client.job_statuses.first()
+    assert job_status.is_successful() is True
+
+
+@pytest.mark.usefixtures("mock_job_statuses")
+def test_job_status_is_successful_false(api_client):
+    job_status = api_client.job_statuses.first()
+    job_status.status = "failed"
+    assert job_status.is_successful() is False


### PR DESCRIPTION
# Description
This PR adds support for job statuses within supported models, as well as the `/job-statuses` endpoint.

# Usage
To view all Job statuses
```ruby
job_statuses = nylas.job_statuses.all()
```

To view a specific Job status
```ruby
job_status = nylas.job_statuses.get("JOB_STATUS_ID")
```

To get a boolean value representing Job status success/failure
```ruby
job_status = nylas.job_statuses.get("JOB_STATUS_ID")
job_status.is_successful()
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
