### PR TITLE
[76796] Improved Application Detail support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Improved support for Application Details
+
 v5.4.0
 ----------------
 * Add job status support

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -878,9 +878,6 @@ class Account(NylasAPIObject):
     def downgrade(self):
         return self.api._call_resource_method(self, self.account_id, "downgrade", None)
 
-    def delete(self):
-        raise NotImplementedError
-
 
 class APIAccount(NylasAPIObject):
     attrs = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1734,6 +1734,40 @@ def mock_revoke_all_tokens(mocked_responses, api_url, account_id, client_id):
 
 
 @pytest.fixture
+def mock_application_details(mocked_responses, api_url, client_id):
+    application_details_url = "{base}/a/{client_id}".format(
+        base=api_url, client_id=client_id
+    )
+
+    def modify_endpoint(request):
+        return 200, {}, json.dumps(json.loads(request.body))
+
+    mocked_responses.add(
+        responses.GET,
+        application_details_url,
+        content_type="application/json",
+        status=200,
+        body=json.dumps(
+            {
+                "application_name": "My New App Name",
+                "icon_url": "http://localhost:5555/icon.png",
+                "redirect_uris": [
+                    "http://localhost:5555/login_callback",
+                    "localhost",
+                    "https://customerA.myapplication.com/login_callback",
+                ],
+            }
+        ),
+    )
+    mocked_responses.add_callback(
+        responses.PUT,
+        application_details_url,
+        content_type="application/json",
+        callback=modify_endpoint,
+    )
+
+
+@pytest.fixture
 def mock_ip_addresses(mocked_responses, api_url, client_id):
     ip_addresses_url = "{base}/a/{client_id}/ip_addresses".format(
         base=api_url, client_id=client_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,10 @@ def mock_accounts(mocked_responses, api_url, account_id, client_id):
             response["metadata"] = payload["metadata"]
         return 200, {}, json.dumps(response)
 
+    def delete_callback(request):
+        response = {"success": True}
+        return 200, {}, json.dumps(response)
+
     url_re = "{base}(/a/{client_id})?/accounts/?".format(
         base=api_url, client_id=client_id
     )
@@ -194,6 +198,12 @@ def mock_accounts(mocked_responses, api_url, account_id, client_id):
         re.compile(url_re),
         content_type="application/json",
         callback=update_callback,
+    )
+    mocked_responses.add_callback(
+        responses.DELETE,
+        re.compile(url_re),
+        content_type="application/json",
+        callback=delete_callback,
     )
 
 
@@ -322,8 +332,16 @@ def mock_folder(mocked_responses, api_url, account_id):
             folder.update(payload)
         return (200, {}, json.dumps(folder))
 
+    def delete_callback(request):
+        payload = {"successful": True}
+        return 200, {}, json.dumps(payload)
+
     mocked_responses.add_callback(
         responses.PUT, url, content_type="application/json", callback=request_callback
+    )
+
+    mocked_responses.add_callback(
+        responses.DELETE, url, content_type="application/json", callback=delete_callback
     )
 
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -96,3 +96,10 @@ def test_account_metadata(api_client_with_client_id, monkeypatch):
     account1["metadata"] = {"test": "value"}
     account1.save()
     assert account1["metadata"] == {"test": "value"}
+
+
+@pytest.mark.usefixtures("mock_accounts")
+def test_application_account_delete(api_client_with_client_id, monkeypatch):
+    monkeypatch.setattr(api_client_with_client_id, "is_opensource_api", lambda: False)
+    account1 = api_client_with_client_id.accounts[0]
+    api_client_with_client_id.accounts.delete(account1.id)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -96,3 +96,31 @@ def test_application_account_delete(api_client_with_client_id, monkeypatch):
     monkeypatch.setattr(api_client_with_client_id, "is_opensource_api", lambda: False)
     account1 = api_client_with_client_id.accounts[0]
     api_client_with_client_id.accounts.delete(account1.id)
+
+
+@pytest.mark.usefixtures("mock_application_details")
+def test_application_details(api_client_with_client_id, monkeypatch):
+    monkeypatch.setattr(api_client_with_client_id, "is_opensource_api", lambda: False)
+    app_data = api_client_with_client_id.application_details()
+    assert app_data["application_name"] == "My New App Name"
+    assert app_data["icon_url"] == "http://localhost:5555/icon.png"
+    assert app_data["redirect_uris"] == [
+        "http://localhost:5555/login_callback",
+        "localhost",
+        "https://customerA.myapplication.com/login_callback",
+    ]
+
+
+@pytest.mark.usefixtures("mock_application_details")
+def test_update_application_details(api_client_with_client_id, monkeypatch):
+    monkeypatch.setattr(api_client_with_client_id, "is_opensource_api", lambda: False)
+    updated_data = api_client_with_client_id.update_application_details(
+        application_name="New Name",
+        icon_url="https://myurl.com/icon.png",
+        redirect_uris=["https://redirect.com"],
+    )
+    assert updated_data["application_name"] == "New Name"
+    assert updated_data["icon_url"] == "https://myurl.com/icon.png"
+    assert updated_data["redirect_uris"] == [
+        "https://redirect.com",
+    ]

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -55,13 +55,6 @@ def test_account_upgrade(api_client, client_id):
     assert account.billing_state == "paid"
 
 
-def test_account_delete(api_client, monkeypatch):
-    monkeypatch.setattr(api_client, "is_opensource_api", lambda: False)
-    account = api_client.accounts.create()
-    with pytest.raises(NotImplementedError):
-        account.delete()
-
-
 @pytest.mark.usefixtures("mock_revoke_all_tokens", "mock_account")
 def test_revoke_all_tokens(api_client_with_client_id):
     assert api_client_with_client_id.access_token is not None


### PR DESCRIPTION
# Description
This PR adds support for 3 Application-related endpoints. The Python SDK now is able to get and update application details as well as delete an application account.

# Usage
To get application details:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET
)

app_data = nylas.application_details()
```

To update application details:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET
)

updated_app_data = nylas.update_application_details(
    application_name="New Name",
    icon_url="https://myurl.com/icon.png",
    redirect_uris=["https://redirect.com"],
)
```

To delete an account:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET
)

nylas.accounts.delete("{account_id}")
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
