### PR TITLE
[77068] Fix passing `kwargs` to `_update_resource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Fix issue where keyword arguments calling `_update_resource` were not correctly resolving to URL params
+
 v5.4.0
 ----------------
 * Add job status support

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -619,7 +619,7 @@ class APIClient(json.JSONEncoder):
         return result.json()
 
     def _update_resource(self, cls, id, data, **kwargs):
-        result = self._put_resource(cls, id, data, kwargs)
+        result = self._put_resource(cls, id, data, **kwargs)
         return cls.create(self, **result)
 
     def _post_resource(self, cls, id, method_name, data, path=None):


### PR DESCRIPTION
# Description
When passing keyword arguments to a method that utilizes `_update_resource`, such as `Event.save()`, the keyword arguments were incorrectly being bubbled up resulting in them not formatting in the URL as URL parameters.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
