### PR TITLE
[76804] Event to ICS Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for `Event` to ICS
+
 v5.4.1
 ----------------
 * Fix issue where keyword arguments calling `_update_resource` were not correctly resolving to URL params

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -648,18 +648,20 @@ class APIClient(json.JSONEncoder):
         if path is None:
             path = cls.collection_name
         path = "/{}".format(path) if path else ""
+        id = "/{}".format(id) if id else ""
+        method = "/{}".format(method_name) if method_name else ""
         if not cls.api_root:
-            url_path = "{name}/{id}/{method}".format(
-                name=path, id=id, method=method_name
+            url_path = "{name}{id}{method}".format(
+                name=path, id=id, method=method
             )
         else:
             # Management method.
-            url_path = "/{prefix}/{client_id}{path}/{id}/{method}".format(
+            url_path = "/{prefix}/{client_id}{path}{id}{method}".format(
                 prefix=cls.api_root,
                 client_id=self.client_id,
                 path=path,
                 id=id,
-                method=method_name,
+                method=method,
             )
 
         url = URLObject(self.api_server).with_path(url_path)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -651,9 +651,7 @@ class APIClient(json.JSONEncoder):
         id = "/{}".format(id) if id else ""
         method = "/{}".format(method_name) if method_name else ""
         if not cls.api_root:
-            url_path = "{name}{id}{method}".format(
-                name=path, id=id, method=method
-            )
+            url_path = "{name}{id}{method}".format(name=path, id=id, method=method)
         else:
             # Management method.
             url_path = "/{prefix}/{client_id}{path}{id}{method}".format(

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -746,7 +746,6 @@ class Event(NylasAPIObject):
             "Unexpected response from the API server. Returned 200 but no 'ics' string found."
         )
 
-
     def save(self, **kwargs):
         if (
             self.conferencing

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -738,13 +738,13 @@ class Event(NylasAPIObject):
         if ics_options:
             payload["ics_options"] = ics_options
 
-        response = self.api._post_resource(
-            Event, None, "to-ics", payload
-        )
+        response = self.api._post_resource(Event, None, "to-ics", payload)
         try:
             return response["ics"]
         except KeyError:
-            raise RuntimeError("Unexpected response from the API server. Returned 200 but no 'ics' string found.")
+            raise RuntimeError(
+                "Unexpected response from the API server. Returned 200 but no 'ics' string found."
+            )
 
     def save(self, **kwargs):
         if (

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -700,14 +700,17 @@ class Event(NylasAPIObject):
         result = response.json()
         return Event.create(self, **result)
 
-    def generate_ics(self, ics_options=None):
+    def generate_ics(self, ical_uid=None, method=None, prodid=None):
         """
         Generate an ICS file server-side, from an Event
 
-        :param ics_options: Optional configuration for the ICS file
-        :type ics_options: ICSOptions
-        :return: String for writing directly into an ICS file
-        :rtype: str
+        Args:
+            ical_uid (str): Unique identifier used events across calendaring systems
+            method (str): Description of invitation and response methods for attendees
+            prodid (str): Company-specific unique product identifier
+
+        Returns:
+            str: String for writing directly into an ICS file
         """
         if not self.calendar_id or not self.when:
             raise ValueError(
@@ -715,13 +718,21 @@ class Event(NylasAPIObject):
             )
 
         payload = {}
+        ics_options = {}
         if self.id:
             payload["event_id"] = self.id
         else:
             payload = self.as_json()
 
+        if ical_uid:
+            ics_options["ical_uid"] = ical_uid
+        if method:
+            ics_options["method"] = method
+        if prodid:
+            ics_options["prodid"] = prodid
+
         if ics_options:
-            payload["ics_options"] = ics_options.as_json()
+            payload["ics_options"] = ics_options
 
         response = self.api._post_resource(
             Event, None, "to-ics", payload

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -711,6 +711,10 @@ class Event(NylasAPIObject):
 
         Returns:
             str: String for writing directly into an ICS file
+
+        Raises:
+            ValueError: If the event does not have calendar_id or when set
+            RuntimeError: If the server returns an object without an ics string
         """
         if not self.calendar_id or not self.when:
             raise ValueError(
@@ -737,7 +741,10 @@ class Event(NylasAPIObject):
         response = self.api._post_resource(
             Event, None, "to-ics", payload
         )
-        return response["ics"]
+        try:
+            return response["ics"]
+        except KeyError:
+            raise RuntimeError("Unexpected response from the API server. Returned 200 but no 'ics' string found.")
 
     def save(self, **kwargs):
         if (

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -740,12 +740,12 @@ class Event(NylasAPIObject):
             payload["ics_options"] = ics_options
 
         response = self.api._post_resource(Event, None, "to-ics", payload)
-        try:
+        if "ics" in response:
             return response["ics"]
-        except KeyError:
-            raise RuntimeError(
-                "Unexpected response from the API server. Returned 200 but no 'ics' string found."
-            )
+        raise RuntimeError(
+            "Unexpected response from the API server. Returned 200 but no 'ics' string found."
+        )
+
 
     def save(self, **kwargs):
         if (

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -700,6 +700,34 @@ class Event(NylasAPIObject):
         result = response.json()
         return Event.create(self, **result)
 
+    def generate_ics(self, ics_options=None):
+        """
+        Generate an ICS file server-side, from an Event
+
+        :param ics_options: Optional configuration for the ICS file
+        :type ics_options: ICSOptions
+        :return: String for writing directly into an ICS file
+        :rtype: str
+        """
+        if not self.calendar_id or not self.when:
+            raise ValueError(
+                "Cannot generate an ICS file for an event without a Calendar ID or when set"
+            )
+
+        payload = {}
+        if self.id:
+            payload["event_id"] = self.id
+        else:
+            payload = self.as_json()
+
+        if ics_options:
+            payload["ics_options"] = ics_options.as_json()
+
+        response = self.api._post_resource(
+            Event, None, "to-ics", payload
+        )
+        return response["ics"]
+
     def save(self, **kwargs):
         if (
             self.conferencing

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -848,6 +848,20 @@ class Namespace(NylasAPIObject):
         return RestfulModelCollection(cls, self.api, self.id, **filters)
 
 
+class ICSOptions(RestfulModel):
+    attrs = [
+        "ical_uid",
+        "method",
+        "prodid",
+    ]
+
+    collection_name = None
+    api_root = None
+
+    def __init__(self):
+        RestfulModel.__init__(self, ICSOptions, None)
+
+
 class Account(NylasAPIObject):
     api_root = "a"
 

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -887,20 +887,6 @@ class Namespace(NylasAPIObject):
         return RestfulModelCollection(cls, self.api, self.id, **filters)
 
 
-class ICSOptions(RestfulModel):
-    attrs = [
-        "ical_uid",
-        "method",
-        "prodid",
-    ]
-
-    collection_name = None
-    api_root = None
-
-    def __init__(self):
-        RestfulModel.__init__(self, ICSOptions, None)
-
-
 class Account(NylasAPIObject):
     api_root = "a"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -832,6 +832,13 @@ def mock_event_create_response(mocked_responses, api_url, message_body):
 
 
 @pytest.fixture
+def mock_event_generate_ics(mocked_responses, api_url, message_body):
+    mocked_responses.add(
+        responses.POST, api_url + "/events/to-ics", body=json.dumps({"ics": ""})
+    )
+
+
+@pytest.fixture
 def mock_scheduler_create_response(mocked_responses, api_url, message_body):
     def callback(_request):
         try:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -570,9 +570,9 @@ def test_generate_ics_no_event_id(mocked_responses, api_client):
     assert ics_request.path_url == "/events/to-ics"
     assert ics_request.method == "POST"
     assert json.loads(ics_request.body) == {
-        'calendar_id': 'calendar_id',
-        'title': 'Paris-Brest',
-        'when': {'end_time': 1409594400, 'start_time': 1409594400}
+        "calendar_id": "calendar_id",
+        "title": "Paris-Brest",
+        "when": {"end_time": 1409594400, "start_time": 1409594400},
     }
 
 
@@ -580,7 +580,9 @@ def test_generate_ics_no_event_id(mocked_responses, api_client):
 def test_generate_ics_options(mocked_responses, api_client):
     event = blank_event(api_client)
     event.save()
-    ics = event.generate_ics(ical_uid="test_uuid", method="request", prodid="test_prodid")
+    ics = event.generate_ics(
+        ical_uid="test_uuid", method="request", prodid="test_prodid"
+    )
     ics_request = mocked_responses.calls[1].request
     assert len(mocked_responses.calls) == 2
     assert event.id == "cv4ei7syx10uvsxbs21ccsezf"
@@ -591,8 +593,8 @@ def test_generate_ics_options(mocked_responses, api_client):
         "ics_options": {
             "ical_uid": "test_uuid",
             "method": "request",
-            "prodid": "test_prodid"
-        }
+            "prodid": "test_prodid",
+        },
     }
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -558,7 +558,6 @@ def test_generate_ics_existing_event(mocked_responses, api_client):
     assert ics_request.path_url == "/events/to-ics"
     assert ics_request.method == "POST"
     assert json.loads(ics_request.body) == {"event_id": "cv4ei7syx10uvsxbs21ccsezf"}
-    assert isinstance(ics, str)
 
 
 @pytest.mark.usefixtures("mock_event_create_response", "mock_event_generate_ics")
@@ -575,7 +574,6 @@ def test_generate_ics_no_event_id(mocked_responses, api_client):
         'title': 'Paris-Brest',
         'when': {'end_time': 1409594400, 'start_time': 1409594400}
     }
-    assert isinstance(ics, str)
 
 
 @pytest.mark.usefixtures("mock_event_create_response", "mock_event_generate_ics")
@@ -596,7 +594,6 @@ def test_generate_ics_options(mocked_responses, api_client):
             "prodid": "test_prodid"
         }
     }
-    assert isinstance(ics, str)
 
 
 @pytest.mark.usefixtures("mock_event_create_response", "mock_event_generate_ics")


### PR DESCRIPTION
# Description
This PR enables support for [generating an ICS file from an Event](https://developer.nylas.com/docs/api/#post/events/to-ics).

# Usage
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)
example_event = nylas.events.get('{id}')

# Generate an ICS from an event
ics = example_event.generate_ics()

# You can also pass ICS Options for more configuration
ics = example_event.generate_ics(
  ical_uid="test_uuid",
  method="add",
  prodid="test_prodid"
)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
