### PR TITLE
[77881] Add missing `source` field in `Contact` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add missing `source` field in `Contact` class
+
 v5.4.1
 ----------------
 * Fix issue where keyword arguments calling `_update_resource` were not correctly resolving to URL params

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -580,6 +580,7 @@ class Contact(NylasAPIObject):
         "job_status_id",
         "manager_name",
         "office_location",
+        "source",
         "notes",
         "picture_url",
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1193,6 +1193,7 @@ def mock_contact(mocked_responses, account_id, api_url):
         "job_title": "QA Tester",
         "manager_name": "George",
         "office_location": "Over the Rainbow",
+        "source": "inbox",
         "notes": "This is a note",
         "picture_url": "{base}/contacts/{id}/picture".format(
             base=api_url, id="9hga75n6mdvq4zgcmhcn7hpys"

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -20,6 +20,7 @@ def test_get_contact(api_client):
     assert contact.given_name == "Given"
     assert contact.surname == "Sur"
     assert contact.birthday == date(1964, 10, 5)
+    assert contact.source == "inbox"
 
 
 @pytest.mark.usefixtures("mock_contacts")


### PR DESCRIPTION
# Description
This PR adds a missing field to the `Contact` class.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
