### PR TITLE
[79420] Enable full payload response for exchanging the token for code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Enable full payload response for exchanging the token for code
+
 v5.4.2
 ----------------
 * Add support for `Event` to ICS

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -169,7 +169,16 @@ class APIClient(json.JSONEncoder):
         url = URLObject(self.authorize_url).add_query_params(args.items())
         return str(url)
 
-    def token_for_code(self, code):
+    def send_authorization(self, code):
+        """
+        Exchanges an authorization code for an access token.
+
+        Args:
+            code (str): The authorization code returned from authenticating the user
+
+        Returns:
+            dict: The response from the API containing the access token
+        """
         args = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -187,6 +196,10 @@ class APIClient(json.JSONEncoder):
         ).json()
 
         self.access_token = resp[u"access_token"]
+        return resp
+
+    def token_for_code(self, code):
+        self.send_authorization(code)
         return self.access_token
 
     def is_opensource_api(self):

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -195,7 +195,7 @@ class APIClient(json.JSONEncoder):
             self.access_token_url, data=urlencode(args), headers=headers
         ).json()
 
-        self.access_token = resp[u"access_token"]
+        self.access_token = resp["access_token"]
         return resp
 
     def token_for_code(self, code):

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -33,7 +33,7 @@ class NylasApiError(HTTPError):
     def __init__(self, response):
         try:
             response_json = json.loads(response.text)
-            error_message = u"%s %s. Reason: %s. Nylas Error Type: %s" % (
+            error_message = "%s %s. Reason: %s. Nylas Error Type: %s" % (
                 response.status_code,
                 response.reason,
                 response_json["message"],


### PR DESCRIPTION
# Description
This PR introduces a new method, `send_authorization` that will call the `/oauth/token` endpoint and returns the full payload that includes the access token within it.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
