### PR TITLE
[80871] Add validation for `send_authorization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add validation for `send_authorization`
+
 v5.5.0
 ----------------
 * Add support for `Event` to ICS

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -193,9 +193,10 @@ class APIClient(json.JSONEncoder):
 
         resp = requests.post(
             self.access_token_url, data=urlencode(args), headers=headers
-        ).json()
+        )
+        results = _validate(resp).json()
 
-        self.access_token = resp["access_token"]
+        self.access_token = results["access_token"]
         return resp
 
     def token_for_code(self, code):

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -188,7 +188,7 @@ class APIClient(json.JSONEncoder):
 
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
-            "Accept": "text/plain",
+            "Accept": "application/json",
         }
 
         resp = requests.post(


### PR DESCRIPTION
# Description
This PR forces the `/oath/token` endpoint to return a JSON type and adds validation in case the API returns a non 200 response code and returns a properly formatted error code.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
