### PR TITLE
[80305] Fix `native-authentication-gmail` example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Fix `native-authentication-gmail` example app
+
 v5.5.0
 ----------------
 * Add support for `Event` to ICS

--- a/examples/native-authentication-gmail/server.py
+++ b/examples/native-authentication-gmail/server.py
@@ -66,6 +66,8 @@ if cfg_needs_replacing:
 # Use Flask-Dance to automatically set up the OAuth endpoints for Google.
 # For more information, check out the documentation: http://flask-dance.rtfd.org
 google_bp = make_google_blueprint(
+    client_id=app.config["GOOGLE_OAUTH_CLIENT_ID"],
+    client_secret=app.config["GOOGLE_OAUTH_CLIENT_SECRET"],
     scope=[
         "openid",
         "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
# Description
`client_id` and `client_secret` should be present for `make_google_blueprint` to succeed, as reported by @[GroveIV](https://github.com/GroveIV)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
