### PR TITLE
Enable Nylas API v2.4 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Enable Nylas API v2.4 support
+
 v5.5.0
 ----------------
 * Add support for `Event` to ICS

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -40,7 +40,7 @@ from nylas.utils import timestamp_from_dt, create_request_body
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
-SUPPORTED_API_VERSION = "2.2"
+SUPPORTED_API_VERSION = "2.4"
 
 
 def _validate(response):


### PR DESCRIPTION
# Description
This PR enables Nylas API v2.4 support.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
