### PR TITLE
[76809] Add Delta support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ nylas-python Changelog
 
 Unreleased
 ----------------
+* Add Delta support
 * Omit `None` values from resulting `as_json()` object
 
 v5.5.1

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -13,6 +13,7 @@ from urlobject import URLObject
 import six
 from six.moves.urllib.parse import urlencode
 from nylas._client_sdk_version import __VERSION__
+from nylas.client.delta_collection import DeltaCollection
 from nylas.client.errors import MessageRejectedError, NylasApiError
 from nylas.client.restful_model_collection import RestfulModelCollection
 from nylas.client.restful_models import (
@@ -478,6 +479,10 @@ class APIClient(json.JSONEncoder):
     @property
     def components(self):
         return RestfulModelCollection(Component, self)
+
+    @property
+    def deltas(self):
+        return DeltaCollection(self)
 
     @property
     def neural(self):

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -532,7 +532,7 @@ class APIClient(json.JSONEncoder):
         headers=None,
         stream=False,
         path=None,
-        timeout=None,
+        stream_timeout=None,
         **filters
     ):
         """Get an individual REST resource"""
@@ -562,7 +562,9 @@ class APIClient(json.JSONEncoder):
 
         headers = headers or {}
         headers.update(session.headers)
-        response = session.get(url, headers=headers, stream=stream, timeout=timeout)
+        response = session.get(
+            url, headers=headers, stream=stream, timeout=stream_timeout
+        )
         return _validate(response)
 
     def _get_resource(self, cls, id, **filters):

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -525,7 +525,15 @@ class APIClient(json.JSONEncoder):
         return [cls.create(self, **x) for x in results if x is not None]
 
     def _get_resource_raw(
-        self, cls, id, extra=None, headers=None, stream=False, path=None, **filters
+        self,
+        cls,
+        id,
+        extra=None,
+        headers=None,
+        stream=False,
+        path=None,
+        timeout=None,
+        **filters
     ):
         """Get an individual REST resource"""
         if path is None:
@@ -554,7 +562,7 @@ class APIClient(json.JSONEncoder):
 
         headers = headers or {}
         headers.update(session.headers)
-        response = session.get(url, headers=headers, stream=stream)
+        response = session.get(url, headers=headers, stream=stream, timeout=timeout)
         return _validate(response)
 
     def _get_resource(self, cls, id, **filters):

--- a/nylas/client/delta_collection.py
+++ b/nylas/client/delta_collection.py
@@ -45,6 +45,9 @@ class DeltaCollection:
 
         Returns:
             Deltas: The API response containing the list of deltas
+
+        Raises:
+            ValueError: If both include_types and excluded_types are set
         """
 
         include_types, excluded_types = _validate_types(include_types, excluded_types)
@@ -138,6 +141,9 @@ class DeltaCollection:
 
         Returns:
             Deltas: The API response containing the list of deltas
+
+        Raises:
+            ValueError: If both include_types and excluded_types are set
         """
 
         delta = {}

--- a/nylas/client/delta_collection.py
+++ b/nylas/client/delta_collection.py
@@ -1,0 +1,6 @@
+class DeltaCollection:
+    path = "delta"
+
+    def __init__(self, api):
+        self.api = api
+

--- a/nylas/client/delta_collection.py
+++ b/nylas/client/delta_collection.py
@@ -1,5 +1,4 @@
 import json
-from json import JSONDecodeError
 
 from requests import ReadTimeout
 
@@ -168,11 +167,11 @@ class DeltaCollection:
             if raw_rsp:
                 buffer.extend(raw_rsp)
                 try:
-                    buffer_json = json.loads(buffer)
+                    buffer_json = json.loads(buffer.decode())
                     delta = Deltas.create(self.api, **buffer_json)
                     if emit_deltas:
                         callback(delta)
-                except JSONDecodeError:
+                except ValueError:
                     continue
 
         return delta

--- a/nylas/client/delta_collection.py
+++ b/nylas/client/delta_collection.py
@@ -22,6 +22,7 @@ class DeltaCollection:
         Raises:
             RuntimeError: If the server returns an object without a cursor
         """
+
         response = self.api._post_resource(
             Delta, "latest_cursor", None, None, path=self.path
         )
@@ -32,19 +33,29 @@ class DeltaCollection:
 
         return response["cursor"]
 
-    def since(self, cursor):
+    def since(self, cursor, view=None, include_types=None, excluded_types=None):
         """
         Get a list of delta cursors since a specified cursor
 
         Args:
             cursor (str): The first cursor to request from
+            view (str): Value representing if delta expands thread and message objects.
+            include_types (list[str] | str): The objects to exclusively include in the returned deltas. Note you cannot set both included and excluded types.
+            excluded_types (list[str] | str): The objects to exclude in the returned deltas. Note you cannot set both included and excluded types.
 
         Returns:
-            Deltas: String for writing directly into an ICS file
+            Deltas: The API response containing the list of deltas
         """
 
+        include_types, excluded_types = _validate_types(include_types, excluded_types)
         response = self.api._get_resource_raw(
-            Delta, None, path=self.path, cursor=cursor
+            Delta,
+            None,
+            path=self.path,
+            cursor=cursor,
+            view=view,
+            include_types=include_types,
+            excluded_types=excluded_types,
         ).json()
         return Deltas.create(self.api, **response)
 

--- a/nylas/client/delta_collection.py
+++ b/nylas/client/delta_collection.py
@@ -1,6 +1,44 @@
+from nylas.client.delta_models import Delta, Deltas
+
+
 class DeltaCollection:
     path = "delta"
 
     def __init__(self, api):
         self.api = api
 
+    def latest_cursor(self):
+        """
+        Returns the latest delta cursor
+
+        Returns:
+            str: The latest cursor
+
+        Raises:
+            RuntimeError: If the server returns an object without a cursor
+        """
+        response = self.api._post_resource(
+            Delta, "latest_cursor", None, None, path=self.path
+        )
+        if "cursor" not in response:
+            raise RuntimeError(
+                "Unexpected response from the API server. Returned 200 but no 'cursor' string found."
+            )
+
+        return response["cursor"]
+
+    def since(self, cursor):
+        """
+        Get a list of delta cursors since a specified cursor
+
+        Args:
+            cursor (str): The first cursor to request from
+
+        Returns:
+            Deltas: String for writing directly into an ICS file
+        """
+
+        response = self.api._get_resource_raw(
+            Delta, None, path=self.path, cursor=cursor
+        ).json()
+        return Deltas.create(self.api, **response)

--- a/nylas/client/delta_models.py
+++ b/nylas/client/delta_models.py
@@ -1,0 +1,73 @@
+from nylas.client.restful_models import (
+    RestfulModel,
+    NylasAPIObject,
+    Contact,
+    File,
+    Message,
+    Draft,
+    Thread,
+    Event,
+    Folder,
+    Label,
+)
+
+
+class Deltas(RestfulModel):
+    attrs = [
+        "cursor_start",
+        "cursor_end",
+        "_deltas",
+    ]
+    read_only_attrs = tuple(attrs)
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, Deltas, api)
+
+    @property
+    def deltas(self):
+        """
+        Instantiate a Delta object from the API response
+
+        Returns:
+            list[Delta]: List of Delta instantiated objects
+        """
+        if self._deltas:
+            deltas = []
+            for delta in self._deltas:
+                deltas.append(Delta.create(self.api, **delta))
+            return deltas
+
+
+class Delta(RestfulModel):
+    attrs = [
+        "id",
+        "cursor",
+        "event",
+        "object",
+        "_attributes",
+    ]
+    read_only_attrs = tuple(attrs)
+    class_mapping = {
+        "contact": Contact,
+        "file": File,
+        "message": Message,
+        "draft": Draft,
+        "thread": Thread,
+        "event": Event,
+        "folder": Folder,
+        "label": Label,
+    }
+
+    def __init__(self, api):
+        RestfulModel.__init__(self, Delta, api)
+
+    @property
+    def attributes(self):
+        """
+        Instantiate the object provided in the Delta
+
+        Returns:
+            NylasAPIObject: The object of NylasAPIObject type represented in the Delta
+        """
+        if self._attributes and self.object and self.object in self.class_mapping:
+            return self.class_mapping[self.object].create(self.api, **self._attributes)

--- a/nylas/client/delta_models.py
+++ b/nylas/client/delta_models.py
@@ -13,11 +13,11 @@ from nylas.client.restful_models import (
 
 
 class Deltas(RestfulModel):
-    attrs = [
+    attrs = (
         "cursor_start",
         "cursor_end",
         "_deltas",
-    ]
+    )
     read_only_attrs = tuple(attrs)
 
     def __init__(self, api):
@@ -39,13 +39,13 @@ class Deltas(RestfulModel):
 
 
 class Delta(RestfulModel):
-    attrs = [
+    attrs = (
         "id",
         "cursor",
         "event",
         "object",
         "_attributes",
-    ]
+    )
     read_only_attrs = tuple(attrs)
     class_mapping = {
         "contact": Contact,

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -54,11 +54,14 @@ class RestfulModel(dict):
     def create(cls, api, **kwargs):
         object_type = kwargs.get("object")
         cls_object_type = getattr(cls, "object_type", cls.__name__.lower())
+        # These are classes that should bypass the check below because they
+        # often represent other types (e.g. a delta's object type might be event)
+        class_check_whitelist = ["jobstatus", "delta"]
         if (
             object_type
             and object_type != cls_object_type
             and object_type != "account"
-            and cls_object_type != "jobstatus"
+            and cls_object_type not in class_check_whitelist
             and not _is_subclass(cls, object_type)
         ):
             # We were given a specific object type and we're trying to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2141,3 +2141,191 @@ def mock_clean_conversation(mocked_responses, api_url, account_id):
         content_type="application/json",
         callback=file_callback,
     )
+
+
+@pytest.fixture
+def mock_deltas_since(mocked_responses, api_url):
+    deltas = {
+        "cursor_start": "start_cursor",
+        "cursor_end": "end_cursor",
+        "deltas": [
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "given_name": "First",
+                    "surname": "Last",
+                    "id": "id-1234",
+                    "object": "contact",
+                },
+                "cursor": "contact_cursor",
+                "event": "create",
+                "id": "delta-1",
+                "object": "contact",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "content_type": "text/plain",
+                    "filename": "sample.txt",
+                    "id": "id-1234",
+                    "object": "file",
+                    "size": 123,
+                },
+                "cursor": "file_cursor",
+                "event": "create",
+                "id": "delta-2",
+                "object": "file",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "to": [{"email": "foo", "name": "bar"}],
+                    "subject": "foo",
+                    "id": "id-1234",
+                    "object": "message",
+                },
+                "cursor": "message_cursor",
+                "event": "create",
+                "id": "delta-3",
+                "object": "message",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "to": [{"email": "foo", "name": "bar"}],
+                    "subject": "foo",
+                    "id": "id-1234",
+                    "object": "draft",
+                },
+                "cursor": "draft_cursor",
+                "event": "create",
+                "id": "delta-4",
+                "object": "draft",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "subject": "Subject",
+                    "id": "id-1234",
+                    "object": "thread",
+                },
+                "cursor": "thread_cursor",
+                "event": "create",
+                "id": "delta-5",
+                "object": "thread",
+            },
+            {
+                "attributes": {
+                    "id": "id-1234",
+                    "title": "test event",
+                    "when": {"time": 1409594400, "object": "time"},
+                    "participants": [
+                        {
+                            "name": "foo",
+                            "email": "bar",
+                            "status": "noreply",
+                            "comment": "This is a comment",
+                            "phone_number": "416-000-0000",
+                        },
+                    ],
+                    "ical_uid": "id-5678",
+                    "master_event_id": "master-1234",
+                    "original_start_time": 1409592400,
+                },
+                "cursor": "event_cursor",
+                "event": "create",
+                "id": "delta-6",
+                "object": "event",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "id": "id-1234",
+                    "object": "folder",
+                    "name": "inbox",
+                    "display_name": "name",
+                },
+                "cursor": "folder_cursor",
+                "event": "create",
+                "id": "delta-7",
+                "object": "folder",
+            },
+            {
+                "attributes": {
+                    "account_id": "aid-5678",
+                    "id": "id-1234",
+                    "object": "label",
+                    "name": "inbox",
+                },
+                "cursor": "label_cursor",
+                "event": "create",
+                "id": "delta-8",
+                "object": "label",
+            },
+        ],
+    }
+
+    def callback(request):
+        return 200, {}, json.dumps(deltas)
+
+    mocked_responses.add_callback(
+        responses.GET,
+        "{base}/delta".format(base=api_url),
+        callback=callback,
+        content_type="application/json",
+    )
+
+
+@pytest.fixture
+def mock_delta_cursor(mocked_responses, api_url):
+    def callback(request):
+        return 200, {}, json.dumps({"cursor": "cursor"})
+
+    mocked_responses.add_callback(
+        responses.POST,
+        "{base}/delta/latest_cursor".format(base=api_url),
+        callback=callback,
+        content_type="application/json",
+    )
+
+
+@pytest.fixture
+def mock_delta_stream(mocked_responses, api_url):
+    delta = {
+        "attributes": {
+            "account_id": "aid-5678",
+            "given_name": "First",
+            "surname": "Last",
+            "id": "id-1234",
+            "object": "contact",
+        },
+        "cursor": "contact_cursor",
+        "event": "create",
+        "id": "delta-1",
+        "object": "contact",
+    }
+
+    def stream_callback(request):
+        return 200, {}, json.dumps(delta)
+
+    def longpoll_callback(request):
+        response = {
+            "cursor_start": "start_cursor",
+            "cursor_end": "end_cursor",
+            "deltas": [delta],
+        }
+        return 200, {}, json.dumps(response)
+
+    mocked_responses.add_callback(
+        responses.GET,
+        "{base}/delta/streaming".format(base=api_url),
+        callback=stream_callback,
+        content_type="application/json",
+    )
+
+    mocked_responses.add_callback(
+        responses.GET,
+        "{base}/delta/longpoll".format(base=api_url),
+        callback=longpoll_callback,
+        content_type="application/json",
+    )

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,158 @@
+import pytest
+from urlobject import URLObject
+
+from nylas.client.delta_models import Deltas, Delta
+from nylas.client.restful_models import (
+    Contact,
+    File,
+    Message,
+    Draft,
+    Thread,
+    Event,
+    Folder,
+    Label,
+)
+
+
+@pytest.mark.usefixtures("mock_deltas_since")
+def test_deltas_since(mocked_responses, api_client):
+    deltas = api_client.deltas.since("cursor")
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta"
+    assert URLObject(request.url).query_dict == {"cursor": "cursor"}
+    assert request.method == "GET"
+    assert isinstance(deltas, Deltas)
+    assert deltas.cursor_start == "start_cursor"
+    assert deltas.cursor_end == "end_cursor"
+    assert len(deltas.deltas) == 8
+    assert isinstance(deltas.deltas[0].attributes, Contact)
+    assert deltas.deltas[0].cursor == "contact_cursor"
+    assert deltas.deltas[0].event == "create"
+    assert deltas.deltas[0].id == "delta-1"
+    assert deltas.deltas[0].object == "contact"
+    assert isinstance(deltas.deltas[1].attributes, File)
+    assert deltas.deltas[1].cursor == "file_cursor"
+    assert deltas.deltas[1].event == "create"
+    assert deltas.deltas[1].id == "delta-2"
+    assert deltas.deltas[1].object == "file"
+    assert isinstance(deltas.deltas[2].attributes, Message)
+    assert deltas.deltas[2].cursor == "message_cursor"
+    assert deltas.deltas[2].event == "create"
+    assert deltas.deltas[2].id == "delta-3"
+    assert deltas.deltas[2].object == "message"
+    assert isinstance(deltas.deltas[3].attributes, Draft)
+    assert deltas.deltas[3].cursor == "draft_cursor"
+    assert deltas.deltas[3].event == "create"
+    assert deltas.deltas[3].id == "delta-4"
+    assert deltas.deltas[3].object == "draft"
+    assert isinstance(deltas.deltas[4].attributes, Thread)
+    assert deltas.deltas[4].cursor == "thread_cursor"
+    assert deltas.deltas[4].event == "create"
+    assert deltas.deltas[4].id == "delta-5"
+    assert deltas.deltas[4].object == "thread"
+    assert isinstance(deltas.deltas[5].attributes, Event)
+    assert deltas.deltas[5].cursor == "event_cursor"
+    assert deltas.deltas[5].event == "create"
+    assert deltas.deltas[5].id == "delta-6"
+    assert deltas.deltas[5].object == "event"
+    assert isinstance(deltas.deltas[6].attributes, Folder)
+    assert deltas.deltas[6].cursor == "folder_cursor"
+    assert deltas.deltas[6].event == "create"
+    assert deltas.deltas[6].id == "delta-7"
+    assert deltas.deltas[6].object == "folder"
+    assert isinstance(deltas.deltas[7].attributes, Label)
+    assert deltas.deltas[7].cursor == "label_cursor"
+    assert deltas.deltas[7].event == "create"
+    assert deltas.deltas[7].id == "delta-8"
+    assert deltas.deltas[7].object == "label"
+
+
+@pytest.mark.usefixtures("mock_delta_cursor")
+def test_delta_cursor(mocked_responses, api_client):
+    cursor = api_client.deltas.latest_cursor()
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta/latest_cursor"
+    assert request.method == "POST"
+    assert cursor == "cursor"
+
+
+def evaluate_contact_delta(delta):
+    assert isinstance(delta, Delta)
+    assert isinstance(delta.attributes, Contact)
+    assert delta.cursor == "contact_cursor"
+    assert delta.event == "create"
+    assert delta.id == "delta-1"
+    assert delta.object == "contact"
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_streaming(mocked_responses, api_client):
+    streaming = api_client.deltas.stream("cursor")
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta/streaming"
+    assert URLObject(request.url).query_dict == {"cursor": "cursor"}
+    assert request.method == "GET"
+    assert len(streaming) == 1
+    evaluate_contact_delta(streaming[0])
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_longpoll(mocked_responses, api_client):
+    longpoll = api_client.deltas.longpoll("cursor", 30)
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta/longpoll"
+    assert URLObject(request.url).query_dict == {"cursor": "cursor", "timeout": "30"}
+    assert request.method == "GET"
+    assert isinstance(longpoll, Deltas)
+    assert longpoll.cursor_start == "start_cursor"
+    assert longpoll.cursor_end == "end_cursor"
+    assert len(longpoll.deltas) == 1
+    evaluate_contact_delta(longpoll.deltas[0])
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_callback(mocked_responses, api_client):
+    api_client.deltas.stream("cursor", callback=evaluate_contact_delta)
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_optional_params(mocked_responses, api_client):
+    api_client.deltas.longpoll(
+        "cursor", 30, view="expanded", include_types=["event", "file"]
+    )
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta/longpoll"
+    assert URLObject(request.url).query_dict == {
+        "cursor": "cursor",
+        "timeout": "30",
+        "view": "expanded",
+        "include_types": "event,file",
+    }
+    assert request.method == "GET"
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_type_string(mocked_responses, api_client):
+    api_client.deltas.longpoll("cursor", 30, view="expanded", excluded_types="event")
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/delta/longpoll"
+    assert URLObject(request.url).query_dict == {
+        "cursor": "cursor",
+        "timeout": "30",
+        "view": "expanded",
+        "excluded_types": "event",
+    }
+    assert request.method == "GET"
+
+
+@pytest.mark.usefixtures("mock_delta_stream")
+def test_delta_set_both_types_raise_error(api_client):
+    with pytest.raises(ValueError) as excinfo:
+        api_client.deltas.longpoll(
+            "cursor",
+            30,
+            view="expanded",
+            excluded_types="event",
+            include_types="file",
+        )
+    assert "You cannot set both include_types and excluded_types" in str(excinfo)


### PR DESCRIPTION
# Description
This PR adds support for Deltas.

# Usage
To get the latest cursor:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

cursor = nylas.deltas.latest_cursor()
```

To return a set of delta cursors since a specific cursor:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

delta_response = nylas.deltas.since("{CURSOR}")

# The returned type is of Deltas
cursor_start = delta_response.cursor_start
cursor_end = delta_response.cursor_end
list_of_deltas = delta_response.deltas

# Deltas.deltas contains a list of Delta objects
delta = list_of_deltas[0]
delta_cursor = delta.cursor
delta_event = delta.event
delta_id = delta.id
delta_object = delta.object

# The enclosed Delta.attributes instantiates the object provided in the Delta (Contact, File, etc.)
delta_attributes = delta.attributes

# You can also pass in other optional arguments:
# view: string - This type of view to return within the delta objects
# include_types: string[] | string - The list of types to include in the query ('file', 'event', etc.)
# exclude_types: string[] | string - The list of types to exclude in the query ('file', 'event', etc.)

nylas.deltas.since(cursor, view="expanded", include_types=["event", "file"])
```

To stream for delta cursors since a specific cursor:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

# By default, the streaming function will listen indefinitely until the connection drops
# and upon reaching the end it will return an array of delta objects captured

streamed_deltas = nylas.deltas.stream(cursor)

# Optionally, you can pass in a reference to a function that would be called on every Delta

def on_delta_received(delta):
    print(delta)

nylas.deltas.stream(cursor, callback=on_delta_received)

# Furthermore, you can pass in an argument for timeout if you want to cut off the stream after a certain number of seconds

nylas.deltas.stream(cursor, callback=on_delta_received, timeout=180)

# You can also pass in other optional arguments:
# view: string - This type of view to return within the delta objects
# include_types: string[] | string - The list of types to include in the query ('file', 'event', etc.)
# exclude_types: string[] | string - The list of types to exclude in the query ('file', 'event', etc.)

nylas.deltas.stream(cursor, callback=on_delta_received, view="expanded", include_types=["event", "file"])
```

To long-poll for delta cursors since a specific cursor:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

# By default, the streaming function will listen until until the timeout is reached
# and upon reaching the end it will return a Deltas object

longpoll_deltas = nylas.deltas.longpoll(cursor, timeout=30) # timeout is in seconds

# Optionally, you can pass in a reference to a function that would be called when the Deltas response is returned

def on_deltas_received(deltas):
    print(deltas)

nylas.deltas.longpoll(cursor, callback=on_deltas_received)

# You can also pass in other optional arguments:
# view: string - This type of view to return within the delta objects
# include_types: string[] | string - The list of types to include in the query ('file', 'event', etc.)
# exclude_types: string[] | string - The list of types to exclude in the query ('file', 'event', etc.)

nylas.deltas.longpoll(cursor, callback=on_delta_received, view="expanded", include_types=["event", "file"])
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
