### PR TITLE
Enable Nylas API v2.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add Outbox support
+* Enable Nylas API v2.5 support
 
 v5.6.0
 ----------------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -42,7 +42,7 @@ from nylas.utils import timestamp_from_dt, create_request_body
 
 DEBUG = environ.get("NYLAS_CLIENT_DEBUG")
 API_SERVER = "https://api.nylas.com"
-SUPPORTED_API_VERSION = "2.4"
+SUPPORTED_API_VERSION = "2.5"
 
 
 def _validate(response):


### PR DESCRIPTION
# Description
This PR enables Nylas API v2.5 on the Python SDK

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
