### PR TITLE
Fix Draft not sending metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add Outbox support
+* Fix `Draft` not sending metadata
 
 v5.6.0
 ----------------

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -484,6 +484,7 @@ class Draft(Message):
         "starred",
         "snippet",
         "tracking",
+        "metadata",
     ]
     datetime_attrs = {"last_modified_at": "date"}
     collection_name = "drafts"


### PR DESCRIPTION
# Description
This PR fixes an issue where Drafts were not saving metadata when sending.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
