### PR TITLE
Add support for `limit` and `offset` for message/thread search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add Outbox support
+* Add support for `limit` and `offset` for message/thread search
 * Enable Nylas API v2.5 support
 * Fix `Draft` not sending metadata
 

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -96,7 +96,7 @@ class RestfulModelCollection(object):
     def delete(self, id, data=None, **kwargs):
         return self.api._delete_resource(self.model_class, id, data=data, **kwargs)
 
-    def search(self, q):  # pylint: disable=invalid-name
+    def search(self, q, limit=None, offset=None):  # pylint: disable=invalid-name
         from nylas.client.restful_models import (
             Message,
             Thread,
@@ -104,6 +104,10 @@ class RestfulModelCollection(object):
 
         if self.model_class is Thread or self.model_class is Message:
             kwargs = {"q": q}
+            if limit is not None:
+                kwargs["limit"] = limit
+            if offset is not None:
+                kwargs["offset"] = offset
             return self.api._get_resources(self.model_class, extra="search", **kwargs)
         else:
             raise Exception("Searching is only allowed on Thread and Message models")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1023,7 +1023,7 @@ def mock_message_search_response(mocked_responses, api_url):
 
     mocked_responses.add(
         responses.GET,
-        api_url + "/messages/search?q=Pinot",
+        re.compile(api_url + "/messages/search\?q=Pinot.*"),
         body=response_body,
         status=200,
         content_type="application/json",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,6 +17,13 @@ def test_search_messages(api_client):
 
 
 @pytest.mark.usefixtures("mock_message_search_response")
+def test_search_messages_with_limit_offset(mocked_responses, api_client):
+    api_client.messages.search("Pinot", limit=10, offset=0)
+    request = mocked_responses.calls[0].request
+    assert request.path_url == "/messages/search?q=Pinot&limit=10&offset=0"
+
+
+@pytest.mark.usefixtures("mock_message_search_response")
 def test_search_drafts(api_client):
     with pytest.raises(Exception):
         api_client.drafts.search("Pinot")


### PR DESCRIPTION
# Description
This PR adds limit and offset as parameters for message/thread search.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
