### PR TITLE
[TSDK-263] Add new authentication method field to Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------------
 * Add Outbox support
 * Add support for `limit` and `offset` for message/thread search
+* Add `authentication_type` field to `Account`
 * Enable Nylas API v2.5 support
 * Fix `Draft` not sending metadata
 

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -978,6 +978,7 @@ class Account(NylasAPIObject):
         "namespace_id",
         "provider",
         "sync_state",
+        "authentication_type",
         "trial",
         "metadata",
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1800,6 +1800,7 @@ def mock_account_management(mocked_responses, api_url, account_id, client_id):
         "provider": "gmail",
         "organization_unit": "label",
         "billing_state": "paid",
+        "authentication_type": "password",
     }
     paid_response = json.dumps(account)
     account["billing_state"] = "cancelled"


### PR DESCRIPTION
# Description
This PR adds support for new `authentication_method` field in `Account`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
