### PR TITLE
Added count method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ local/
 
 pip-selfcheck.json
 tests/output
+local.env
+examples/test.py
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for getting the number of queried objects (count view)
+
 v5.7.0
 ----------------
 * Add Outbox support

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -64,8 +64,16 @@ class RestfulModelCollection(object):
         return self._range(self.filters["offset"], limit)
 
     def count(self):
+        """
+        Get the number of objects in the collection being queried
+
+        Returns:
+            int: The number of objects in the collection being queried
+        """
         self.filters["view"] = "count"
-        response = self.api._get_resource_raw(self.model_class, resource_id=None, **self.filters).json()
+        response = self.api._get_resource_raw(
+            self.model_class, resource_id=None, **self.filters
+        ).json()
         return response["count"]
 
     def where(self, filter=None, **filters):

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -63,6 +63,11 @@ class RestfulModelCollection(object):
             limit = self.filters["limit"]
         return self._range(self.filters["offset"], limit)
 
+    def count(self):
+        self.filters["view"] = "count"
+        response = self.api._get_resource_raw(self.model_class, resource_id=None, **self.filters).json()
+        return response["count"]
+
     def where(self, filter=None, **filters):
         # Some API parameters like "from" and "in" also are
         # Python reserved keywords. To work around this, we rename

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -276,3 +276,16 @@ def test_pagination(mocked_responses, api_client, api_url):
 
     contacts = list(api_client.contacts.where(limit=75))
     assert len(contacts) == 75
+
+
+def test_count(mocked_responses, api_client, api_url):
+    count_data = {"count": 721}
+    mocked_responses.add(
+        responses.GET,
+        api_url + "/contacts",
+        content_type="application/json",
+        body=json.dumps(count_data),
+    )
+
+    contact_count = api_client.contacts.count()
+    assert contact_count == 721


### PR DESCRIPTION
# NOTE
This PR has already been approved (#211) but just re-merging due to needing to squash + merge.

# Description
This PR adds support for the `count` view, returning the number of objects in the collection being queried.

# Usage
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

total_contacts = nylas.contacts.count()

# We also support filtering in conjunction with count
emails_from_support = nylas.messages.where(from_="support@nylas.com").count()
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
