### PR TITLE
[TSDK-287] Fix Calendar availability functions not using the correct authentication method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add support for getting the number of queried objects (count view)
+* Fix Calendar availability functions not using the correct authentication method
 
 v5.7.0
 ----------------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -287,7 +287,7 @@ class APIClient(json.JSONEncoder):
             "start_time": start_time,
             "end_time": end_time,
         }
-        resp = self._request(HttpMethod.POST, url, json=data)
+        resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
 
@@ -357,7 +357,7 @@ class APIClient(json.JSONEncoder):
         if round_robin is not None:
             data["round_robin"] = round_robin
 
-        resp = self._request(HttpMethod.POST, url, json=data)
+        resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
 
@@ -410,7 +410,7 @@ class APIClient(json.JSONEncoder):
         if buffer is not None:
             data["buffer"] = buffer
 
-        resp = self._request(HttpMethod.POST, url, json=data)
+        resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
 


### PR DESCRIPTION
# Description
The Calendar availability functions were using an incorrect authentication method when requesting to the API

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
