### PR TITLE
[TSDK-286] Improve usage of read only fields in models

### DIFF
--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -151,6 +151,8 @@ class RestfulModel(dict):
 
 
 class NylasAPIObject(RestfulModel):
+    read_only_attrs = {"id", "account_id", "object", "job_status_id"}
+
     def __init__(self, cls, api):
         RestfulModel.__init__(self, cls, api)
 
@@ -638,6 +640,7 @@ class Calendar(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, Calendar, api)
+        self.read_only_attrs.update({"is_primary", "read_only"})
 
     @property
     def events(self):
@@ -674,6 +677,16 @@ class Event(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, Event, api)
+        self.read_only_attrs.update(
+            {
+                "ical_uid",
+                "message_id",
+                "owner",
+                "status",
+                "master_event_id",
+                "original_start_time",
+            }
+        )
 
     def as_json(self):
         dct = NylasAPIObject.as_json(self)
@@ -804,6 +817,13 @@ class JobStatus(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, JobStatus, api)
+        self.read_only_attrs.update(
+            {
+                "action",
+                "status",
+                "original_data",
+            }
+        )
 
     def is_successful(self):
         return self.status == "successful"
@@ -871,13 +891,19 @@ class Component(NylasAPIObject):
         "created_at": "created_at",
         "updated_at": "updated_at",
     }
-    read_only_attrs = {"id", "public_application_id", "created_at", "updated_at"}
 
     collection_name = None
     api_root = "component"
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, Component, api)
+        self.read_only_attrs.update(
+            {
+                "public_application_id",
+                "created_at",
+                "updated_at",
+            }
+        )
 
     def as_json(self):
         dct = NylasAPIObject.as_json(self)
@@ -896,13 +922,13 @@ class Webhook(NylasAPIObject):
         "application_id",
         "version",
     )
-    read_only_attrs = {"id", "application_id", "version"}
 
     collection_name = "webhooks"
     api_root = "a"
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, Webhook, api)
+        self.read_only_attrs.update({"application_id", "version"})
 
     def as_json(self):
         dct = {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime, timedelta
 import pytest
 from urlobject import URLObject
-from requests import RequestException
 from nylas.client.restful_models import Event
 
 
@@ -15,15 +14,39 @@ def blank_event(api_client):
 
 
 @pytest.mark.usefixtures("mock_event_create_response")
-def test_event_crud(api_client):
+def test_event_crud(mocked_responses, api_client):
     event1 = blank_event(api_client)
+    event1.object = "should not send"
+    event1.account_id = "should not send"
+    event1.job_status_id = "should not send"
+    event1.ical_uid = "should not send"
+    event1.message_id = "should not send"
+    event1.owner = "should not send"
+    event1.status = "should not send"
+    event1.master_event_id = "should not send"
+    event1.original_start_time = "should not send"
     event1.save()
+    request = mocked_responses.calls[0].request
+    body = json.loads(request.body)
     assert event1.id == "cv4ei7syx10uvsxbs21ccsezf"
+    assert "title" in body
+    assert "object" not in body
+    assert "account_id" not in body
+    assert "job_status_id" not in body
+    assert "ical_uid" not in body
+    assert "message_id" not in body
+    assert "owner" not in body
+    assert "status" not in body
+    assert "master_event_id" not in body
+    assert "original_start_time" not in body
 
     event1.title = "blah"
     event1.save()
+    request = mocked_responses.calls[1].request
+    body = json.loads(request.body)
     assert event1.title == "loaded from JSON"
     assert event1.get("ignored") is None
+    assert "id" not in body
 
 
 @pytest.mark.usefixtures("mock_event_create_notify_response")


### PR DESCRIPTION
# Description
This PR improves our usage of read only fields, adding a general set of read only fields used by all API models, and read only fields for specific API models.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
