### PR TITLE
Change config file to match new Flask rules

### DIFF
--- a/examples/hosted-oauth/config.json
+++ b/examples/hosted-oauth/config.json
@@ -1,5 +1,0 @@
-{
-  "SECRET_KEY": "replace me with a random string",
-  "NYLAS_OAUTH_CLIENT_ID": "replace me with the client ID from Nylas",
-  "NYLAS_OAUTH_CLIENT_SECRET": "replace me with the client secret from Nylas"
-}

--- a/examples/hosted-oauth/config.py
+++ b/examples/hosted-oauth/config.py
@@ -1,4 +1,3 @@
-SECRET_KEY= "replace me with a random string",
-NYLAS_OAUTH_CLIENT_ID= "replace me with the client ID from Nylas",
-NYLAS_OAUTH_CLIENT_SECRET= "replace me with the client secret from Nylas"
-
+SECRET_KEY = ("replace me with a random string",)
+NYLAS_OAUTH_CLIENT_ID = ("replace me with the client ID from Nylas",)
+NYLAS_OAUTH_CLIENT_SECRET = "replace me with the client secret from Nylas"

--- a/examples/hosted-oauth/config.py
+++ b/examples/hosted-oauth/config.py
@@ -1,0 +1,4 @@
+SECRET_KEY= "replace me with a random string",
+NYLAS_OAUTH_CLIENT_ID= "replace me with the client ID from Nylas",
+NYLAS_OAUTH_CLIENT_SECRET= "replace me with the client secret from Nylas"
+

--- a/examples/hosted-oauth/server.py
+++ b/examples/hosted-oauth/server.py
@@ -40,7 +40,7 @@ except ImportError:
 # For more information, check out the documentation: http://flask.pocoo.org
 # Create a Flask app, and load the configuration file.
 app = Flask(__name__)
-app.config.from_pyfile('config.py')
+app.config.from_pyfile("config.py")
 
 # Check for dummy configuration values.
 # If you are building your own application based on this example,

--- a/examples/hosted-oauth/server.py
+++ b/examples/hosted-oauth/server.py
@@ -40,7 +40,7 @@ except ImportError:
 # For more information, check out the documentation: http://flask.pocoo.org
 # Create a Flask app, and load the configuration file.
 app = Flask(__name__)
-app.config.from_json("config.json")
+app.config.from_pyfile('config.py')
 
 # Check for dummy configuration values.
 # If you are building your own application based on this example,


### PR DESCRIPTION
# Description
In Flask 2.1 onwards the method used to set up the config file is no longer available. So it will break. I replaced it with the config option where you load from a file. Then I set up config.json to be config.py so that it will work. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.