### PR TITLE
Add option to include readonly params in `as_json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add option to include read only params in `as_json`
+
 v5.9.0
 ----------------
 * Add support for collective and group events

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -106,7 +106,7 @@ class RestfulModel(dict):
 
         return obj
 
-    def as_json(self):
+    def as_json(self, enforce_read_only=True):
         dct = {}
         # Some API parameters like "from" and "in" also are
         # Python reserved keywords. To work around this, we rename
@@ -114,7 +114,7 @@ class RestfulModel(dict):
         # their correct form though.
         reserved_keywords = ["from", "in"]
         for attr in self.cls.attrs:
-            if attr in self.read_only_attrs:
+            if attr in self.read_only_attrs and enforce_read_only is True:
                 continue
             if hasattr(self, attr):
                 if attr in reserved_keywords:
@@ -124,17 +124,17 @@ class RestfulModel(dict):
                 if attr_value is not None:
                     dct[attr] = attr_value
         for date_attr, iso_attr in self.cls.date_attrs.items():
-            if date_attr in self.read_only_attrs:
+            if date_attr in self.read_only_attrs and enforce_read_only is True:
                 continue
             if self.get(date_attr):
                 dct[iso_attr] = self[date_attr].strftime("%Y-%m-%d")
         for dt_attr, ts_attr in self.cls.datetime_attrs.items():
-            if dt_attr in self.read_only_attrs:
+            if dt_attr in self.read_only_attrs and enforce_read_only is True:
                 continue
             if self.get(dt_attr):
                 dct[ts_attr] = timestamp_from_dt(self[dt_attr])
         for attr, value_attr in self.cls.typed_dict_attrs.items():
-            if attr in self.read_only_attrs:
+            if attr in self.read_only_attrs and enforce_read_only is True:
                 continue
             typed_dict = getattr(self, attr)
             if value_attr:


### PR DESCRIPTION
# Description
Add a new option to `as_json` to convert a Nylas object to JSON ignoring API rules for read only params

# Usage
To include read only values in the `as_json` call, just pass in `False` for `enforce_read_only`:
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

# Return an event by specifying its id
event = nylas.events.get('{id}')

# Return a JSON representation of the Event, including ready only parameters
event_json = event.as_json(False)
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
