### PR TITLE
use http basic auth for /oauth/revoke endpoint

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -231,7 +231,7 @@ class APIClient(json.JSONEncoder):
         return _validate(resp).json()
 
     def revoke_token(self):
-        resp = self.session.post(self.revoke_url)
+        resp = requests.post(self.revoke_url, auth=(self.access_token, None))
         _validate(resp)
         self.auth_token = None
         self.access_token = None


### PR DESCRIPTION
Current implementation will always return a 401. Use basic auth per the Nylas docs: https://developer.nylas.com/docs/api#post/oauth/revoke

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.