### PR TITLE
Add `enforce_read_only` parameter to overriding `as_json` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add `enforce_read_only` parameter to overriding `as_json` functions
+
 v5.9.1
 ----------------
 * Add option to include read only params in `as_json`

--- a/nylas/client/authentication_models.py
+++ b/nylas/client/authentication_models.py
@@ -53,8 +53,11 @@ class Integration(NylasAPIObject):
 
         return obj
 
-    def as_json(self):
-        dct = super(Integration, self).as_json()
+    def as_json(self, enforce_read_only=True):
+        dct = super(Integration, self).as_json(enforce_read_only)
+        if enforce_read_only is False:
+            return dct
+
         if not self.id:
             if isinstance(self.provider, Authentication.Provider):
                 dct["provider"] = self.provider.value
@@ -108,8 +111,11 @@ class Grant(NylasAPIObject):
         obj = super(Grant, cls).create(api, **kwargs)
         return obj
 
-    def as_json(self):
-        dct = super(Grant, self).as_json()
+    def as_json(self, enforce_read_only=True):
+        dct = super(Grant, self).as_json(enforce_read_only)
+        if enforce_read_only is False:
+            return dct
+
         # provider and state can not be updated
         if self.id:
             del dct["provider"]

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -691,8 +691,11 @@ class Event(NylasAPIObject):
             }
         )
 
-    def as_json(self):
-        dct = NylasAPIObject.as_json(self)
+    def as_json(self, enforce_read_only=True):
+        dct = NylasAPIObject.as_json(self, enforce_read_only)
+        if enforce_read_only is False:
+            return dct
+
         # Filter some parameters we got from the API
         if dct.get("when"):
             # Currently, the event (self) and the dict (dct) share the same
@@ -920,8 +923,11 @@ class Component(NylasAPIObject):
             }
         )
 
-    def as_json(self):
-        dct = NylasAPIObject.as_json(self)
+    def as_json(self, enforce_read_only=True):
+        dct = NylasAPIObject.as_json(self, enforce_read_only)
+        if enforce_read_only is False:
+            return dct
+
         # "type" cannot be modified after created
         if self.id:
             dct.pop("type")
@@ -945,13 +951,13 @@ class Webhook(NylasAPIObject):
         NylasAPIObject.__init__(self, Webhook, api)
         self.read_only_attrs.update({"application_id", "version"})
 
-    def as_json(self):
+    def as_json(self, enforce_read_only=True):
         dct = {}
         # Only 'state' can get updated
-        if self.id:
+        if self.id and enforce_read_only is True:
             dct["state"] = self.state
         else:
-            dct = NylasAPIObject.as_json(self)
+            dct = NylasAPIObject.as_json(self, enforce_read_only)
         return dct
 
     class Trigger(str, Enum):
@@ -1035,9 +1041,11 @@ class Account(NylasAPIObject):
     def __init__(self, api):
         NylasAPIObject.__init__(self, Account, api)
 
-    def as_json(self):
-        dct = {"metadata": self.metadata}
-        return dct
+    def as_json(self, enforce_read_only=True):
+        if enforce_read_only is False:
+            return NylasAPIObject.as_json(self, enforce_read_only)
+        else:
+            return {"metadata": self.metadata}
 
     def upgrade(self):
         return self.api._call_resource_method(self, self.account_id, "upgrade", None)
@@ -1063,10 +1071,6 @@ class APIAccount(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, APIAccount, api)
-
-    def as_json(self):
-        dct = NylasAPIObject.as_json(self)
-        return dct
 
 
 class SingletonAccount(APIAccount):

--- a/nylas/client/scheduler_models.py
+++ b/nylas/client/scheduler_models.py
@@ -47,7 +47,7 @@ class SchedulerBookingRequest(RestfulModel):
     def __init__(self, api):
         RestfulModel.__init__(self, SchedulerBookingRequest, api)
 
-    def as_json(self):
+    def as_json(self, enforce_read_only=True):
         dct = RestfulModel.as_json(self)
         if "additional_values" not in dct or dct["additional_values"] is None:
             dct["additional_values"] = {}


### PR DESCRIPTION
# Description
In the last release we added `enforce_read_only` to the `as_json` function (#222) but only on the top level one. Some models overrided this function but was missing this parameter, so this adds it in.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
