### PR TITLE
Support new `calendars` field in free-busy/availability queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for `calendar` field in free-busy, availability, and consecutive availability queries
+
 v5.9.2
 ----------------
 * Add `enforce_read_only` parameter to overriding `as_json` functions

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -393,7 +393,7 @@ class APIClient(json.JSONEncoder):
     ):
         if isinstance(emails, six.string_types):
             emails = [[emails]]
-        elif isinstance(emails[0], list) is False:
+        elif len(emails) > 0 and isinstance(emails[0], list) is False:
             raise ValueError("'emails' must be a list of lists.")
         if isinstance(duration, timedelta):
             duration_minutes = int(duration.total_seconds() // 60)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -72,6 +72,13 @@ def _validate(response):
     return response
 
 
+def _validate_availability_query(query):
+    if (query.get("emails", None) is None or len(query["emails"]) == 0) and (
+        query.get("calendars", None) is None or len(query["calendars"]) == 0
+    ):
+        raise ValueError("Must set either 'emails' or 'calendars' in the query.")
+
+
 class APIClient(json.JSONEncoder):
     """API client for the Nylas API."""
 
@@ -290,6 +297,7 @@ class APIClient(json.JSONEncoder):
         if calendars is not None and len(calendars) > 0:
             data["calendars"] = calendars
 
+        _validate_availability_query(data)
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
@@ -366,6 +374,7 @@ class APIClient(json.JSONEncoder):
         if calendars is not None and len(calendars) > 0:
             data["calendars"] = calendars
 
+        _validate_availability_query(data)
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
@@ -422,6 +431,7 @@ class APIClient(json.JSONEncoder):
         if calendars is not None and len(calendars) > 0:
             data["calendars"] = calendars
 
+        _validate_availability_query(data)
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -270,7 +270,7 @@ class APIClient(json.JSONEncoder):
         _validate(resp).json()
         return resp.json()
 
-    def free_busy(self, emails, start_at, end_at):
+    def free_busy(self, emails, start_at, end_at, calendars=None):
         if isinstance(emails, six.string_types):
             emails = [emails]
         if isinstance(start_at, datetime):
@@ -287,6 +287,9 @@ class APIClient(json.JSONEncoder):
             "start_time": start_time,
             "end_time": end_time,
         }
+        if calendars is not None and len(calendars) > 0:
+            data["calendars"] = calendars
+
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
         return resp.json()
@@ -321,6 +324,7 @@ class APIClient(json.JSONEncoder):
         round_robin=None,
         free_busy=None,
         open_hours=None,
+        calendars=None,
     ):
         if isinstance(emails, six.string_types):
             emails = [emails]
@@ -359,6 +363,8 @@ class APIClient(json.JSONEncoder):
             data["round_robin"] = round_robin
         if event_collection_id is not None:
             data["event_collection_id"] = event_collection_id
+        if calendars is not None and len(calendars) > 0:
+            data["calendars"] = calendars
 
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)
@@ -374,6 +380,7 @@ class APIClient(json.JSONEncoder):
         buffer=None,
         free_busy=None,
         open_hours=None,
+        calendars=None,
     ):
         if isinstance(emails, six.string_types):
             emails = [[emails]]
@@ -412,6 +419,8 @@ class APIClient(json.JSONEncoder):
         }
         if buffer is not None:
             data["buffer"] = buffer
+        if calendars is not None and len(calendars) > 0:
+            data["calendars"] = calendars
 
         resp = self._request(HttpMethod.POST, url, json=data, cls=Calendar)
         _validate(resp)


### PR DESCRIPTION
# Description
In the free busy, availability, and consecutive availability endpoints of the Nylas Calendar API, there's a new field (`calendar`) that can be substituted for `emails` in the event that someone wants to check for availability/free-busy of other calendars within the same organization. 

# Usage
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

# Free busy with calendars
start_time = datetime.now()
end_time = datetime.now() + timedelta(hours = 24)
calendars = [{
  "account_id": "test_account_id",
  "calendar_ids": ["example_calendar_a", "example_calendar_b"]
}]

free_busy = nylas.free_busy("your_email@example.com", start_time, end_time, calendars)

# Availability with calendars
emails = ["one@example.com", "two@example.com", "three@example.com"]
start_time = datetime.now()
end_time = datetime.now() + timedelta(hours = 24)
duration = timedelta(minutes=30)
interval = timedelta(hours=1, minutes=30)
calendars = [{
  "account_id": "test_account_id",
  "calendar_ids": ["example_calendar_a", "example_calendar_b"]
}]

api_client.availability(emails, duration, interval, start_at, end_at, calendars=calendars)

# Consecutive availability with calendars
emails = [["one@example.com"], ["two@example.com", "three@example.com"]]
start_time = datetime.now()
end_time = datetime.now() + timedelta(hours = 24)
duration = timedelta(minutes=30)
interval = timedelta(hours=1, minutes=30)
calendars = [{
  "account_id": "test_account_id",
  "calendar_ids": ["example_calendar_a", "example_calendar_b"]
}]

api_client.consecutive_availability(emails, duration, interval, start_at, end_at, calendars=calendars)
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
