### PR TITLE
TSDK-366 Hosted Authentication params added

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -147,13 +147,13 @@ class APIClient(json.JSONEncoder):
         self._access_token = value
 
     def authentication_url(
-            self,
-            redirect_uri,
-            login_hint="",
-            state="",
-            scopes=("email", "calendar", "contacts"),
-            provider="",
-            redirect_on_error=None
+        self,
+        redirect_uri,
+        login_hint="",
+        state="",
+        scopes=("email", "calendar", "contacts"),
+        provider="",
+        redirect_on_error=None,
     ):
         args = {
             "redirect_uri": redirect_uri,
@@ -167,7 +167,13 @@ class APIClient(json.JSONEncoder):
             if isinstance(scopes, str):
                 scopes = [scopes]
             args["scopes"] = ",".join(scopes)
-        if provider and provider in ['icloud', 'gmail', 'office365', 'exchange', 'imap']:
+        if provider and provider in [
+            "icloud",
+            "gmail",
+            "office365",
+            "exchange",
+            "imap",
+        ]:
             args["provider"] = provider
         if redirect_on_error is not None and isinstance(redirect_on_error, bool):
             args["redirect_on_error"] = "true" if redirect_on_error is True else "false"

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -169,7 +169,7 @@ class APIClient(json.JSONEncoder):
             args["scopes"] = ",".join(scopes)
         if provider and provider in ['icloud', 'gmail', 'office365', 'exchange', 'imap']:
             args["provider"] = provider
-        if redirect_on_error and isinstance(redirect_on_error, bool):
+        if redirect_on_error is not None and isinstance(redirect_on_error, bool):
             args["redirect_on_error"] = "true" if redirect_on_error is True else "false"
 
         url = URLObject(self.authorize_url).add_query_params(args.items())

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -147,11 +147,13 @@ class APIClient(json.JSONEncoder):
         self._access_token = value
 
     def authentication_url(
-        self,
-        redirect_uri,
-        login_hint="",
-        state="",
-        scopes=("email", "calendar", "contacts"),
+            self,
+            redirect_uri,
+            login_hint="",
+            state="",
+            scopes=("email", "calendar", "contacts"),
+            provider="",
+            redirect_on_error=None
     ):
         args = {
             "redirect_uri": redirect_uri,
@@ -165,6 +167,10 @@ class APIClient(json.JSONEncoder):
             if isinstance(scopes, str):
                 scopes = [scopes]
             args["scopes"] = ",".join(scopes)
+        if provider and provider in ['icloud', 'gmail', 'office365', 'exchange', 'imap']:
+            args["provider"] = provider
+        if redirect_on_error and isinstance(redirect_on_error, bool):
+            args["redirect_on_error"] = "true" if redirect_on_error is True else "false"
 
         url = URLObject(self.authorize_url).add_query_params(args.items())
         return str(url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,7 +135,6 @@ def test_client_authentication_url_scopes_none(api_client, api_url):
                 ("redirect_uri", "/redirect"),
                 ("response_type", "code"),
                 ("client_id", "None"),
-                ("scopes", "email"),
                 # no scopes parameter
             ]
         )
@@ -184,12 +183,12 @@ def test_client_authentication_url_invalid_param_values(api_client, api_url):
     actual = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="Google"))
     assert urls_equal(expected, actual)
 
-    expected.set_query_param("provider", "gmail")
+    expected2 = expected.set_query_param("provider", "gmail")
 
     actual2 = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="gmail",
                                                       redirect_on_error="true"))
 
-    assert urls_equal(expected, actual2)
+    assert urls_equal(expected2, actual2)
 
 
 def test_client_token_for_code(mocked_responses, api_client, api_url):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,12 +135,61 @@ def test_client_authentication_url_scopes_none(api_client, api_url):
                 ("redirect_uri", "/redirect"),
                 ("response_type", "code"),
                 ("client_id", "None"),
+                ("scopes", "email"),
                 # no scopes parameter
             ]
         )
     )
     actual = URLObject(api_client.authentication_url("/redirect", scopes=None))
     assert urls_equal(expected, actual)
+
+
+def test_client_authentication_url_optional_params(api_client, api_url):
+    expected = (
+        URLObject(api_url)
+        .with_path("/oauth/authorize")
+        .set_query_params(
+            [
+                ("login_hint", ""),
+                ("state", ""),
+                ("redirect_uri", "/redirect"),
+                ("response_type", "code"),
+                ("client_id", "None"),
+                ("scopes", "email"),
+                ("provider", "gmail"),
+                ("redirect_on_error", "false")
+            ]
+        )
+    )
+    actual = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="gmail",
+                                                     redirect_on_error=False))
+    assert urls_equal(expected, actual)
+
+
+def test_client_authentication_url_invalid_param_values(api_client, api_url):
+    expected = (
+        URLObject(api_url)
+        .with_path("/oauth/authorize")
+        .set_query_params(
+            [
+                ("login_hint", ""),
+                ("state", ""),
+                ("redirect_uri", "/redirect"),
+                ("response_type", "code"),
+                ("client_id", "None"),
+                ("scopes", "email"),
+            ]
+        )
+    )
+    actual = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="Google"))
+    assert urls_equal(expected, actual)
+
+    expected.set_query_param("provider", "gmail")
+
+    actual2 = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="gmail",
+                                                      redirect_on_error="true"))
+
+    assert urls_equal(expected, actual2)
 
 
 def test_client_token_for_code(mocked_responses, api_client, api_url):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -156,12 +156,15 @@ def test_client_authentication_url_optional_params(api_client, api_url):
                 ("client_id", "None"),
                 ("scopes", "email"),
                 ("provider", "gmail"),
-                ("redirect_on_error", "false")
+                ("redirect_on_error", "false"),
             ]
         )
     )
-    actual = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="gmail",
-                                                     redirect_on_error=False))
+    actual = URLObject(
+        api_client.authentication_url(
+            "/redirect", scopes="email", provider="gmail", redirect_on_error=False
+        )
+    )
     assert urls_equal(expected, actual)
 
 
@@ -180,13 +183,18 @@ def test_client_authentication_url_invalid_param_values(api_client, api_url):
             ]
         )
     )
-    actual = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="Google"))
+    actual = URLObject(
+        api_client.authentication_url("/redirect", scopes="email", provider="Google")
+    )
     assert urls_equal(expected, actual)
 
     expected2 = expected.set_query_param("provider", "gmail")
 
-    actual2 = URLObject(api_client.authentication_url("/redirect", scopes="email", provider="gmail",
-                                                      redirect_on_error="true"))
+    actual2 = URLObject(
+        api_client.authentication_url(
+            "/redirect", scopes="email", provider="gmail", redirect_on_error="true"
+        )
+    )
 
     assert urls_equal(expected2, actual2)
 


### PR DESCRIPTION
### Description
Hosted Authentication URL parameters were missing redirect_on_error and provider value. I have added them and created two tests for them as well

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
