### PR TITLE
[TSDK-483] Fix authentication for integrations

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -829,7 +829,7 @@ class APIClient(json.JSONEncoder):
                     client_id=self.client_id, client_secret=self.client_secret
                 )
                 authorization = "Basic {credential}".format(
-                    credential=b64encode(credential.encode("utf8"))
+                    credential=b64encode(credential.encode("utf8")).decode("utf8")
                 )
         else:
             if self.client_secret:

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -817,13 +817,13 @@ class APIClient(json.JSONEncoder):
 
     def _add_auth_header(self, auth_method):
         authorization = None
-        if auth_method is AuthMethod.BEARER:
+        if auth_method == AuthMethod.BEARER:
             authorization = (
                 "Bearer {token}".format(token=self.access_token)
                 if self.access_token
                 else None
             )
-        elif auth_method is AuthMethod.BASIC_CLIENT_ID_AND_SECRET:
+        elif auth_method == AuthMethod.BASIC_CLIENT_ID_AND_SECRET:
             if self.client_id and self.client_secret:
                 credential = "{client_id}:{client_secret}".format(
                     client_id=self.client_id, client_secret=self.client_secret

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ from urlobject import URLObject
 import responses
 from nylas.client import APIClient
 from nylas.client.restful_models import Contact
+from utils import AuthMethod
 
 
 def urls_equal(url1, url2):
@@ -345,3 +346,22 @@ def test_count(mocked_responses, api_client, api_url):
 
     contact_count = api_client.contacts.count()
     assert contact_count == 721
+
+
+def test_add_auth_header_bearer(api_client):
+    api_client.access_token = "access_token"
+    auth_header = api_client._add_auth_header(AuthMethod.BEARER)
+    assert auth_header == {"Authorization": "Bearer access_token"}
+
+
+def test_add_auth_header_basic_client_id_and_secret(api_client):
+    api_client.client_id = "client_id"
+    api_client.client_secret = "client_secret"
+    auth_header = api_client._add_auth_header(AuthMethod.BASIC_CLIENT_ID_AND_SECRET)
+    assert auth_header == {"Authorization": "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ="}
+
+
+def test_add_auth_header_basic(api_client):
+    api_client.client_secret = "client_secret"
+    auth_header = api_client._add_auth_header(AuthMethod.BASIC)
+    assert auth_header == {"Authorization": "Basic Y2xpZW50X3NlY3JldDo="}


### PR DESCRIPTION
# Description
In Python 2.7 the `'b'` prefix ahead of a string is ignored but in Python 3 it indicates a byte literal versus a string. So on Python 3 apps implementing our SDK they would encounter an error as the Nylas API is expecting a string instead of a byte string. Now we ensure that it gets decoded back into a string to ensure it works on Python 3.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
