### PR TITLE
Remove sys.exit in setup.py for PEP 517 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,4 +118,4 @@ No more headaches building unique integrations against archaic and outdated IMAP
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
Nylas is having some issues being installed by poetry 1.2. Poetry uses the PEP 517 standard for installing dependencies. This results in nylas being installed with a pip command that looks like `pip install --use-pep517 nylas`

If you run that, you'll get an error:

```bash
% pip install --use-pep517 --no-deps git+https://github.com/nylas/nylas-python
Collecting git+https://github.com/nylas/nylas-python
  Cloning https://github.com/nylas/nylas-python to /private/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/pip-req-build-ipxrxw5o
  Running command git clone --filter=blob:none --quiet https://github.com/nylas/nylas-python /private/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/pip-req-build-ipxrxw5o
  warning: templates not found in /Users/aburgel/.git-templates
  Resolved https://github.com/nylas/nylas-python to commit 394f0a42a245436067ee83cbac3e77b1307d79bd
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/tmppiwd8qz6/output.json'
```

Removing the sys.exit call will fix this:

```bash
% pip install --use-pep517 --no-deps git+https://github.com/aburgel/nylas-python@patch-1
Collecting git+https://github.com/aburgel/nylas-python@patch-1
  Cloning https://github.com/aburgel/nylas-python (to revision patch-1) to /private/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/pip-req-build-gh_mjgzi
  Running command git clone --filter=blob:none --quiet https://github.com/aburgel/nylas-python /private/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/pip-req-build-gh_mjgzi
  warning: templates not found in /Users/aburgel/.git-templates
  Running command git checkout -b patch-1 --track origin/patch-1
  Switched to a new branch 'patch-1'
  branch 'patch-1' set up to track 'origin/patch-1'.
  Resolved https://github.com/aburgel/nylas-python to commit b335cd4b4ee399d2da8d48593238e5bd871891ff
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: nylas
  Building wheel for nylas (pyproject.toml) ... done
  Created wheel for nylas: filename=nylas-5.10.1-py3-none-any.whl size=69251 sha256=2eed0147e766acfd2d01a14f842102553037ee0af103f1ef7e526274a6d3ef10
  Stored in directory: /private/var/folders/n3/xvyvp0rx0z165cfcm1dcd0fh0000gn/T/pip-ephem-wheel-cache-1im878dr/wheels/b1/79/0c/fb90091d6279f4808983873f497ae6d7b85e4f2cd1bc80e7cd
Successfully built nylas
Installing collected packages: nylas
Successfully installed nylas-5.10.1
```

I'm not entirely sure why this happens, but this pip issue has some details: https://github.com/pypa/pip/issues/6520.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
