### PR TITLE
Add support for calendar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for calendar colors (for Microsoft calendars)
+
 v5.10.2
 ----------------
 * Update package setup to be compatible with PEP 517

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -630,6 +630,7 @@ class Calendar(NylasAPIObject):
         "account_id",
         "name",
         "description",
+        "hex_color",
         "job_status_id",
         "metadata",
         "read_only",
@@ -640,7 +641,7 @@ class Calendar(NylasAPIObject):
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, Calendar, api)
-        self.read_only_attrs.update({"is_primary", "read_only"})
+        self.read_only_attrs.update({"is_primary", "read_only", "hex_color"})
 
     @property
     def events(self):


### PR DESCRIPTION
# Description
This PR adds support for the new colors field in the Calendar model. Please note that this field is read only, and for Microsoft calendars only.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
