### PR TITLE
Add new custom error for 429 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add support for calendar colors (for Microsoft calendars)
+* Add support for rate limit errors
 
 v5.10.2
 ----------------

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -13,7 +13,7 @@ import six
 from six.moves.urllib.parse import urlencode
 from nylas._client_sdk_version import __VERSION__
 from nylas.client.delta_collection import DeltaCollection
-from nylas.client.errors import MessageRejectedError, NylasApiError
+from nylas.client.errors import MessageRejectedError, NylasApiError, RateLimitError
 from nylas.client.outbox_models import Outbox
 from nylas.client.restful_model_collection import RestfulModelCollection
 from nylas.client.restful_models import (
@@ -66,6 +66,8 @@ def _validate(response):
         # we will handle it separate and handle a _different_ exception
         # so that users don't think they need to pay.
         raise MessageRejectedError(response)
+    elif response.status_code == 429:
+        raise RateLimitError(response)
     elif response.status_code >= 400:
         raise NylasApiError(response)
 

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -42,3 +42,22 @@ class NylasApiError(HTTPError):
             super(NylasApiError, self).__init__(error_message, response=response)
         except (ValueError, KeyError):
             super(NylasApiError, self).__init__(response.text, response=response)
+
+
+class RateLimitError(NylasApiError):
+    """
+    Error class for 429 rate limit errors
+    This class provides details about the rate limit returned from the server
+    """
+
+    RATE_LIMIT_LIMIT_HEADER = "X-RateLimit-Limit"
+    RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset"
+
+    def __init__(self, response):
+        try:
+            headers = json.loads(response.headers)
+            self.rate_limit = headers[self.RATE_LIMIT_LIMIT_HEADER]
+            self.rate_limit_reset = headers[self.RATE_LIMIT_RESET_HEADER]
+            super(RateLimitError, self).__init__(response)
+        except (ValueError, KeyError):
+            super(RateLimitError, self).__init__(response)

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -55,8 +55,8 @@ class RateLimitError(NylasApiError):
 
     def __init__(self, response):
         try:
-            self.rate_limit = response.headers[self.RATE_LIMIT_LIMIT_HEADER]
-            self.rate_limit_reset = response.headers[self.RATE_LIMIT_RESET_HEADER]
+            self.rate_limit = int(response.headers[self.RATE_LIMIT_LIMIT_HEADER])
+            self.rate_limit_reset = int(response.headers[self.RATE_LIMIT_RESET_HEADER])
             super(RateLimitError, self).__init__(response)
         except (ValueError, KeyError):
             super(RateLimitError, self).__init__(response)

--- a/nylas/client/errors.py
+++ b/nylas/client/errors.py
@@ -55,9 +55,8 @@ class RateLimitError(NylasApiError):
 
     def __init__(self, response):
         try:
-            headers = json.loads(response.headers)
-            self.rate_limit = headers[self.RATE_LIMIT_LIMIT_HEADER]
-            self.rate_limit_reset = headers[self.RATE_LIMIT_RESET_HEADER]
+            self.rate_limit = response.headers[self.RATE_LIMIT_LIMIT_HEADER]
+            self.rate_limit_reset = response.headers[self.RATE_LIMIT_RESET_HEADER]
             super(RateLimitError, self).__init__(response)
         except (ValueError, KeyError):
             super(RateLimitError, self).__init__(response)

--- a/tests/test_send_error_handling.py
+++ b/tests/test_send_error_handling.py
@@ -59,9 +59,7 @@ def test_handle_quota_exceeded(mocked_responses, api_client, api_url):
 def test_handle_quota_exceeded_no_headers(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = "Daily sending quota exceeded"
-    mock_sending_error(
-        429, error_message, mocked_responses, api_url=api_url
-    )
+    mock_sending_error(429, error_message, mocked_responses, api_url=api_url)
     with pytest.raises(RateLimitError) as exc:
         draft.send()
     assert "Too Many Requests" in str(exc.value)

--- a/tests/test_send_error_handling.py
+++ b/tests/test_send_error_handling.py
@@ -51,6 +51,8 @@ def test_handle_quota_exceeded(mocked_responses, api_client, api_url):
     with pytest.raises(RateLimitError) as exc:
         draft.send()
     assert "Too Many Requests" in str(exc.value)
+    assert exc.value.rate_limit == 500
+    assert exc.value.rate_limit_reset == 10
 
 
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")

--- a/tests/test_send_error_handling.py
+++ b/tests/test_send_error_handling.py
@@ -56,6 +56,18 @@ def test_handle_quota_exceeded(mocked_responses, api_client, api_url):
 
 
 @pytest.mark.usefixtures("mock_account", "mock_save_draft")
+def test_handle_quota_exceeded_no_headers(mocked_responses, api_client, api_url):
+    draft = api_client.drafts.create()
+    error_message = "Daily sending quota exceeded"
+    mock_sending_error(
+        429, error_message, mocked_responses, api_url=api_url
+    )
+    with pytest.raises(RateLimitError) as exc:
+        draft.send()
+    assert "Too Many Requests" in str(exc.value)
+
+
+@pytest.mark.usefixtures("mock_account", "mock_save_draft")
 def test_handle_service_unavailable(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = "The server unexpectedly closed the connection"

--- a/tests/test_send_error_handling.py
+++ b/tests/test_send_error_handling.py
@@ -27,7 +27,7 @@ def mock_sending_error(
         content_type="application/json",
         status=http_code,
         body=response_body,
-        headers=headers
+        headers=headers,
     )
 
 
@@ -45,7 +45,9 @@ def test_handle_quota_exceeded(mocked_responses, api_client, api_url):
     draft = api_client.drafts.create()
     error_message = "Daily sending quota exceeded"
     error_headers = {"X-RateLimit-Limit": "500", "X-RateLimit-Reset": "10"}
-    mock_sending_error(429, error_message, mocked_responses, api_url=api_url, headers=error_headers)
+    mock_sending_error(
+        429, error_message, mocked_responses, api_url=api_url, headers=error_headers
+    )
     with pytest.raises(RateLimitError) as exc:
         draft.send()
     assert "Too Many Requests" in str(exc.value)


### PR DESCRIPTION
# Description
This PR adds support for rate limit 429 headers from the API.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
