### PR TITLE
Add support for sending raw MIME messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for sending raw MIME messages
+
 v5.11.0
 ----------------
 * Add support for calendar colors (for Microsoft calendars)

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -33,6 +33,7 @@ from nylas.client.restful_models import (
     Component,
     JobStatus,
     Webhook,
+    Send,
 )
 from nylas.client.neural_api_models import Neural
 from nylas.client.scheduler_restful_model_collection import (
@@ -640,6 +641,11 @@ class APIClient(json.JSONEncoder):
 
         if cls == File:
             response = self._request(HttpMethod.POST, url, cls=cls, files=data)
+        elif cls == Send and type(data) is not dict:
+            headers = {"Content-Type": "message/rfc822"}
+            response = self._request(
+                HttpMethod.POST, url, cls=cls, headers=headers, data=data
+            )
         else:
             converted_data = create_request_body(data, cls.datetime_attrs)
             headers = {"Content-Type": "application/json"}

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -514,6 +514,18 @@ class Draft(Message):
         if file.id in self.file_ids:
             self.file_ids.remove(file.id)
 
+    def send_raw(self, mime_message):
+        """
+        Send a raw MIME message
+
+        Args:
+            mime_message (str): The raw MIME message to send
+
+        Returns:
+            Message: The sent message
+        """
+        return self.api._create_resource(Send, mime_message)
+
     def send(self):
         if not self.id:
             data = self.as_json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -739,6 +739,42 @@ def mock_draft_sent_response(mocked_responses, api_url):
 
 
 @pytest.fixture
+def mock_draft_raw_response(mocked_responses, api_url):
+    body = {
+        "bcc": [],
+        "body": "",
+        "cc": [],
+        "date": 1438684486,
+        "events": [],
+        "files": [],
+        "folder": None,
+        "from": [{"email": "benb@nylas.com"}],
+        "id": "2h111aefv8pzwzfykrn7hercj",
+        "namespace_id": "384uhp3aj8l7rpmv9s2y2rukn",
+        "object": "draft",
+        "reply_to": [],
+        "reply_to_message_id": None,
+        "snippet": "",
+        "starred": False,
+        "subject": "Stay polish, stay hungary",
+        "thread_id": "clm33kapdxkposgltof845v9s",
+        "to": [{"email": "helena@nylas.com", "name": "Helena Handbasket"}],
+        "unread": False,
+        "version": 0,
+    }
+
+    def callback(request):
+        return 200, {}, json.dumps(body)
+
+    mocked_responses.add_callback(
+        responses.POST,
+        api_url + "/send",
+        callback=callback,
+        content_type="application/json",
+    )
+
+
+@pytest.fixture
 def mock_draft_send_unsaved_response(mocked_responses, api_url):
     def callback(request):
         payload = json.loads(request.body)

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -86,6 +86,27 @@ def test_send_draft_with_tracking(mocked_responses, api_client):
     assert send_payload["tracking"] == tracking
 
 
+@pytest.mark.usefixtures("mock_draft_raw_response")
+def test_send_draft_raw_mime(mocked_responses, api_client):
+    raw_mime = """MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Subject: With Love, From Nylas
+From: You <mostafa.r.nylas@gmail.com>
+To: My Nylas Friend <mostafa.r.nylas@gmail.com>
+
+This email was sent via raw MIME using the Nylas email API. Visit https://nylas.com for details.
+"""
+    draft = api_client.drafts.create()
+    draft.send_raw(raw_mime)
+
+    send_payload = mocked_responses.calls[-1].request
+    assert type(send_payload.body) == str
+    assert send_payload.body == raw_mime
+    assert send_payload.path_url == "/send"
+    assert send_payload.method == "POST"
+    assert send_payload.headers["Content-Type"] == "message/rfc822"
+
+
 @pytest.mark.usefixtures("mock_files")
 def test_draft_attachment(api_client):
     draft = api_client.drafts.create()


### PR DESCRIPTION
# Description
This PR adds support for sending raw MIME messages.

# Usage
```python
from nylas import APIClient
nylas = APIClient(
    CLIENT_ID,
    CLIENT_SECRET,
    ACCESS_TOKEN
)

raw_mime = """MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Subject: With Love, From Nylas
From: You <example@gmail.com>
To: My Nylas Friend <recipient@gmail.com>

This email was sent via raw MIME using the Nylas email API. Visit https://nylas.com for details.
"""

draft = nylas.drafts.create()

# Send the raw MIME
msg = draft.send_raw(raw_mime)
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
