### PR TITLE
[v6] Fix hasattr logic in RestfulModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+v6.0.0
+----------------
+* **BREAKING CHANGE:** `RestfulModel.__getattr__()` now throws an `AttributeError` if the attribute is not set on the object.
+
 v5.12.0
 ----------------
 * Add support for sending raw MIME messages

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -121,14 +121,14 @@ class RestfulModel(dict):
         # them to "from_" and "in_". The API still needs them in
         # their correct form though.
         reserved_keywords = ["from", "in"]
+        for attr in reserved_keywords:
+            if hasattr(self, "{}_".format(attr)):
+                dct[attr] = getattr(self, "{}_".format(attr))
         for attr in self.cls.attrs:
             if attr in self.read_only_attrs and enforce_read_only is True:
                 continue
             if hasattr(self, attr):
-                if attr in reserved_keywords:
-                    attr_value = getattr(self, "{}_".format(attr))
-                else:
-                    attr_value = getattr(self, attr)
+                attr_value = getattr(self, attr)
                 if attr_value is not None:
                     dct[attr] = attr_value
         for date_attr, iso_attr in self.cls.date_attrs.items():

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -50,7 +50,15 @@ class RestfulModel(dict):
 
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
-    __getattr__ = dict.get
+
+    def __getattr__(self, k):
+        try:
+            return self[k]
+        # Imitate default behaviour so builtin functions like 'hasattr' can function properly
+        except KeyError:
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(self.cls.__name__, k)
+            )
 
     @classmethod
     def create(cls, api, **kwargs):

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -233,12 +233,12 @@ class Message(NylasAPIObject):
     @property
     def folder(self):
         # Instantiate a Folder object from the API response
-        if self._folder:
+        if hasattr(self, "_folder"):
             return Folder.create(self.api, **self._folder)
 
     @property
     def labels(self):
-        if self._labels:
+        if hasattr(self, "_labels"):
             return [Label.create(self.api, **l) for l in self._labels]
         return []
 
@@ -391,13 +391,13 @@ class Thread(NylasAPIObject):
 
     @property
     def folders(self):
-        if self._folders:
+        if hasattr(self, "_folders"):
             return [Folder.create(self.api, **f) for f in self._folders]
         return []
 
     @property
     def labels(self):
-        if self._labels:
+        if hasattr(self, "_labels"):
             return [Label.create(self.api, **l) for l in self._labels]
         return []
 
@@ -407,7 +407,7 @@ class Thread(NylasAPIObject):
         for attr in self.cls.attrs:
             if hasattr(new_obj, attr):
                 setattr(self, attr, getattr(new_obj, attr))
-        return self.folder
+        return self.folders
 
     def update_labels(self, label_ids=None):
         label_ids = label_ids or []
@@ -568,6 +568,7 @@ class File(NylasAPIObject):
     collection_name = "files"
 
     def save(self):  # pylint: disable=arguments-differ
+        content_type = self.content_type if hasattr(self, "content_type") else None
         stream = getattr(self, "stream", None)
         if not stream:
             data = getattr(self, "data", None)
@@ -581,7 +582,7 @@ class File(NylasAPIObject):
             )
             raise FileUploadError(message)
 
-        file_info = (self.filename, stream, self.content_type, {})  # upload headers
+        file_info = (self.filename, stream, content_type, {})  # upload headers
 
         new_obj = self.api._create_resources(File, {"file": file_info})
         new_obj = new_obj[0]
@@ -771,7 +772,7 @@ class Event(NylasAPIObject):
             ValueError: If the event does not have calendar_id or when set
             RuntimeError: If the server returns an object without an ics string
         """
-        if not self.calendar_id or not self.when:
+        if not hasattr(self, "calendar_id") or not hasattr(self, "when"):
             raise ValueError(
                 "Cannot generate an ICS file for an event without a Calendar ID or when set"
             )
@@ -802,7 +803,7 @@ class Event(NylasAPIObject):
 
     def validate(self):
         if (
-            self.conferencing
+            hasattr(self, "conferencing")
             and "details" in self.conferencing
             and "autocreate" in self.conferencing
         ):
@@ -810,9 +811,9 @@ class Event(NylasAPIObject):
                 "Cannot set both 'details' and 'autocreate' in conferencing object."
             )
         if (
-            self.capacity
+            hasattr(self, "capacity")
             and self.capacity != -1
-            and self.participants
+            and hasattr(self, "participants")
             and len(self.participants) > self.capacity
         ):
             raise ValueError(
@@ -1068,7 +1069,7 @@ class Account(NylasAPIObject):
         if enforce_read_only is False:
             return NylasAPIObject.as_json(self, enforce_read_only)
         else:
-            return {"metadata": self.metadata}
+            return {"metadata": self.metadata if hasattr(self, "metadata") else {}}
 
     def upgrade(self):
         return self.api._call_resource_method(self, self.account_id, "upgrade", None)


### PR DESCRIPTION
# Description
⚠️ This is a breaking change ⚠️ 

This PR fixes the broken `hasattr` logic in the `RestfulModel` superclass. `RestfulModel` extends `dict` and sets `__getattr__` to `dict.get()` which never throws if a key is not found, it returns `None` as a default. This breaks the underlying `hasattr` function, because the way `hasattr` works is it calls `getattr` and if it throws a `ArgumentError` then it returns false (as described in #220). However, since `dict.get()` never errors out (returns None if not found), `hasattr` always returns true.

Now, we set `__getattr__` to `dict[key]` and throws an error if the key does not exist. This will have a cascading effect as it will no longer be safe to just access a variable like `object.attr` without checking `hasattr(object, 'attr')` first. This PR will resolve #220 and be released in the next major release as it is a breaking change.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
