### PR TITLE
[v6] Add defaults for Content-Type and Aceept headers for outgoing API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+v6.0.0
+----------------
+* Add defaults for Content-Type and Aceept headers for outgoing API requests
+
 v5.12.0
 ----------------
 * Add support for sending raw MIME messages

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -205,10 +205,7 @@ class APIClient(json.JSONEncoder):
             "code": code,
         }
 
-        headers = {
-            "Content-type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        }
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
 
         resp = self._request(
             HttpMethod.POST,
@@ -249,10 +246,8 @@ class APIClient(json.JSONEncoder):
         if redirect_uris is not None:
             data["redirect_uris"] = redirect_uris
 
-        headers = {"Content-Type": "application/json"}
-        headers.update(self.admin_session.headers)
         resp = self.admin_session.put(
-            application_details_url, json=data, headers=headers
+            application_details_url, json=data, headers=self.admin_session.headers
         )
         return _validate(resp).json()
 
@@ -270,9 +265,9 @@ class APIClient(json.JSONEncoder):
         if keep_access_token is not None:
             data["keep_access_token"] = keep_access_token
 
-        headers = {"Content-Type": "application/json"}
-        headers.update(self.admin_session.headers)
-        resp = self.admin_session.post(revoke_all_url, json=data, headers=headers)
+        resp = self.admin_session.post(
+            revoke_all_url, json=data, headers=self.admin_session.headers
+        )
         _validate(resp).json()
         if keep_access_token != self.access_token:
             self.auth_token = None
@@ -288,10 +283,10 @@ class APIClient(json.JSONEncoder):
         token_info_url = self.token_info_url.format(
             client_id=self.client_id, account_id=self.account.id
         )
-        headers = {"Content-Type": "application/json"}
-        headers.update(self.admin_session.headers)
         resp = self.admin_session.post(
-            token_info_url, headers=headers, json={"access_token": self.access_token}
+            token_info_url,
+            headers=self.admin_session.headers,
+            json={"access_token": self.access_token},
         )
         _validate(resp).json()
         return resp.json()
@@ -652,10 +647,7 @@ class APIClient(json.JSONEncoder):
             )
         else:
             converted_data = create_request_body(data, cls.datetime_attrs)
-            headers = {"Content-Type": "application/json"}
-            response = self._request(
-                HttpMethod.POST, url, cls=cls, headers=headers, json=converted_data
-            )
+            response = self._request(HttpMethod.POST, url, cls=cls, json=converted_data)
 
         result = _validate(response).json()
         if cls.collection_name == "send":
@@ -677,10 +669,7 @@ class APIClient(json.JSONEncoder):
             converted_data = [
                 create_request_body(datum, cls.datetime_attrs) for datum in data
             ]
-            headers = {"Content-Type": "application/json"}
-            response = self._request(
-                HttpMethod.POST, url, cls=cls, headers=headers, json=converted_data
-            )
+            response = self._request(HttpMethod.POST, url, cls=cls, json=converted_data)
 
         results = _validate(response).json()
         return [cls.create(self, **x) for x in results]

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -122,6 +122,8 @@ class APIClient(json.JSONEncoder):
             "X-Nylas-Client-Id": self.client_id,
             "Nylas-API-Version": self.api_version,
             "User-Agent": version_header,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
         }
         self._access_token = None
         self.access_token = access_token
@@ -137,6 +139,8 @@ class APIClient(json.JSONEncoder):
                 "X-Nylas-Client-Id": self.client_id,
                 "Nylas-API-Version": self.api_version,
                 "User-Agent": version_header,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
             }
             self.admin_session.headers.update(self._add_auth_header(AuthMethod.BASIC))
         super(APIClient, self).__init__()
@@ -818,10 +822,11 @@ class APIClient(json.JSONEncoder):
             auth_method = cls.auth_method
 
         session = self._get_http_session(api_root)
-        headers = headers or {}
-        headers.update(session.headers)
-        headers.update(self._add_auth_header(auth_method))
-        return session.request(method.name, url, headers=headers, **kwargs)
+        outgoing_headers = {}
+        outgoing_headers.update(session.headers)
+        outgoing_headers.update(headers or {})
+        outgoing_headers.update(self._add_auth_header(auth_method))
+        return session.request(method.name, url, headers=outgoing_headers, **kwargs)
 
     def _add_auth_header(self, auth_method):
         authorization = None

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -585,8 +585,11 @@ class File(NylasAPIObject):
         if not self.id:
             message = "Can't download a file that hasn't been uploaded."
             raise FileUploadError(message)
+        headers = {"Accept": "*/*"}
 
-        return self.api._get_resource_data(File, self.id, extra="download")
+        return self.api._get_resource_data(
+            File, self.id, extra="download", headers=headers
+        )
 
     def __init__(self, api):
         NylasAPIObject.__init__(self, File, api)


### PR DESCRIPTION
# Description
This PR adds a default value of "application/json" for both the `Content-Type` and `Accept` headers for all outgoing connections to the Nylas API.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
