### PR TITLE
Only install enum34 on python34 and below.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,11 @@ RUN_DEPENDENCIES = [
     "requests[security]>=2.4.2",
     "six>=1.4.1",
     "urlobject",
-    "enum34>=1.1.10",
 ]
+
+if sys.version_info[:2] <= (3, 4):
+    RUN_DEPENDENCIES.append("enum34>=1.1.10")
+
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
Hey folks,

Noticed earlier that nylas is our one dependency that's causing `enum34` to be added to our full dependencies, despite our codebase being well into the 3.x line. Small patch to limit `enum34` to installs on Python3.4 or less. Py34 is roughly chosen here due to the relative time of release (w.r.t. the last updates to `enum34`), and to avoid changing deps on any early-adopter py34 projects.

Ran through validation installs on 3.10.5 and 2.7.18 and checked the `pip freeze` output to verify py27 had `enum34` and py3 did not

# License

👍👍👍 

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
