### PR TITLE
Use PEP508 syntax for conditional dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,8 @@ RUN_DEPENDENCIES = [
     "requests[security]>=2.4.2",
     "six>=1.4.1",
     "urlobject",
+    "enum34>=1.1.10; python_version<='3.4'",
 ]
-
-if sys.version_info[:2] <= (3, 4):
-    RUN_DEPENDENCIES.append("enum34>=1.1.10")
 
 TEST_DEPENDENCIES = [
     "pytest",


### PR DESCRIPTION
Following up on #247, where I seem to have spaced-out and forgot the modern syntax.

Updates previous conditional dependency for `enum34` to use the modern PEP508 syntax.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
