### PR TITLE
v6 Alpha 1 fixes

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -241,7 +241,7 @@ class APIClient(json.JSONEncoder):
             code (str): One-time authorization code from Nylas
 
         Returns:
-            dict: The object containing the access token and other information
+            str: The access token
         """
         self.send_authorization(code)
         return self.access_token

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -231,7 +231,7 @@ class APIClient(json.JSONEncoder):
         results = _validate(resp).json()
 
         self.access_token = results["access_token"]
-        return resp
+        return results
 
     def token_for_code(self, code):
         """

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -346,6 +346,7 @@ class Thread(NylasAPIObject):
         "draft_ids",
         "id",
         "message_ids",
+        "_messages",
         "account_id",
         "object",
         "participants",
@@ -383,6 +384,8 @@ class Thread(NylasAPIObject):
 
     @property
     def messages(self):
+        if hasattr(self, "_messages"):
+            return [Message.create(self.api, **f) for f in self._messages]
         return self.child_collection(Message, thread_id=self.id)
 
     @property

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -130,6 +130,8 @@ class RestfulModel(dict):
             if hasattr(self, attr):
                 attr_value = getattr(self, attr)
                 if attr_value is not None:
+                    if attr.startswith("_"):
+                        attr = attr[1:]
                     dct[attr] = attr_value
         for date_attr, iso_attr in self.cls.date_attrs.items():
             if date_attr in self.read_only_attrs and enforce_read_only is True:

--- a/nylas/server_bindings/flask_binding.py
+++ b/nylas/server_bindings/flask_binding.py
@@ -57,13 +57,14 @@ class FlaskBinding(Blueprint):
         access_token = current_app.config.get("routes").exchange_code_for_token(
             request_body["token"]
         )
+        res = access_token
 
         if current_app.config.get("exchange_mailbox_token_callback") and callable(
             current_app.config.get("exchange_mailbox_token_callback")
         ):
-            current_app.config.get("exchange_mailbox_token_callback")(access_token)
+            res = current_app.config.get("exchange_mailbox_token_callback")(access_token)
 
-        return "success"
+        return res
 
     def build(self):
         """

--- a/nylas/server_bindings/flask_binding.py
+++ b/nylas/server_bindings/flask_binding.py
@@ -21,13 +21,13 @@ class FlaskBinding(Blueprint):
         2. '/nylas/exchange-mailbox-token': Exchange an authorization code for an access token
 
         Args:
-            name (str):
-            import_name (str):
-            api (APIClient):
-            default_scopes (list[str]):
-            exchange_mailbox_token_callback:
-            client_uri (str):
-            override_paths (dict):
+            name (str): The name of the blueprint. Will be prepended to each endpoint name.
+            import_name (str): The name of the blueprint package, usually ``__name__``.
+            api (APIClient): The configured Nylas API client
+            default_scopes (list[str]): The authentication scopes to request from the authenticating user
+            exchange_mailbox_token_callback: A callback function invoked after exchanging for the access token
+            client_uri (str): The route of the client
+            override_paths (dict): Override the paths of the routes served by this blueprint
         """
         super(FlaskBinding, self).__init__(name, import_name)
         current_app.config["routes"] = Routes(api)

--- a/nylas/services/routes.py
+++ b/nylas/services/routes.py
@@ -52,7 +52,7 @@ class Routes:
         Returns:
             dict: The object containing the access token and other information
         """
-        return self._api.token_for_code(code)
+        return self._api.send_authorization(code)
 
     def verify_webhook_signature(self, nylas_signature, raw_body):
         """

--- a/nylas/services/tunnel.py
+++ b/nylas/services/tunnel.py
@@ -1,6 +1,7 @@
 import uuid
 
 import websocket
+from threading import Thread
 
 from nylas.client import APIClient
 from nylas.client.restful_models import Webhook
@@ -24,6 +25,16 @@ def open_webhook_tunnel(api, config):
             and events to subscribe to
     """
 
+    ws = _build_webhook_tunnel(api, config)
+    ws_run = Thread(target=_run_webhook_tunnel, args=(ws,))
+    ws_run.start()
+
+
+def _run_webhook_tunnel(ws):
+    ws.run_forever()
+
+
+def _build_webhook_tunnel(api, config):
     ws_domain = "wss://tunnel.nylas.com"
     callback_domain = "cb.nylas.com"
     # This UUID will map our websocket to a webhook in the forwarding server
@@ -57,15 +68,12 @@ def open_webhook_tunnel(api, config):
         on_cont_message=on_cont_message,
         on_data=on_data,
     )
-    _build_webhook_tunnel(api, callback_domain, tunnel_id, triggers)
-    ws.run_forever()
 
-
-def _build_webhook_tunnel(api, callback_domain, tunnel_path, triggers):
+    # Register the webhook to the Nylas application
     webhook = api.webhooks.create()
-    webhook.callback_url = "https://{}/{}".format(callback_domain, tunnel_path)
+    webhook.callback_url = "https://{}/{}".format(callback_domain, tunnel_id)
     webhook.triggers = triggers
     webhook.state = Webhook.State.ACTIVE.value
     webhook.save()
-    return webhook
 
+    return ws

--- a/nylas/services/tunnel.py
+++ b/nylas/services/tunnel.py
@@ -2,8 +2,8 @@ import uuid
 
 import websocket
 
-from client import APIClient
-from client.restful_models import Webhook
+from nylas.client import APIClient
+from nylas.client.restful_models import Webhook
 from config import DEFAULT_REGION
 
 


### PR DESCRIPTION
# Description
This PR fixes a few flaws with the first alpha of the Python SDK v6 release:
* Allow the exchange token callback method to return a value
* Add missing Flask blueprint documentation
* Add support for getting messages when thread is expanded
* Fix returning the access token object when calling `token_for_code`
* Fix `send_authorization` returning `Response` instead of a `dict`
* Fix local import statements
* Fix serializing attributes with leading underscores
* Disable blocking when using the webhook tunnel

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
