### PR TITLE
Local webhook development support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
         run: pip install black
 
       - name: Run black
-        run: black --check .
+        run: black --check --extend-exclude="/examples" .

--- a/nylas/config.py
+++ b/nylas/config.py
@@ -6,11 +6,8 @@ class Region(str, Enum):
     Enum representing the regions supported by the Nylas API
     """
 
-    US = 'us',
-    CANADA = 'canada'
-    IRELAND = 'ireland'
-    AUSTRALIA = 'australia'
-    STAGING = 'staging'
+    US = "us"
+    IRELAND = "ireland"
 
 
 DEFAULT_REGION = Region.US

--- a/nylas/config.py
+++ b/nylas/config.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class Region(str, Enum):
+    """
+    Enum representing the regions supported by the Nylas API
+    """
+
+    US = 'us',
+    CANADA = 'canada'
+    IRELAND = 'ireland'
+    AUSTRALIA = 'australia'
+    STAGING = 'staging'
+
+
+DEFAULT_REGION = Region.US

--- a/nylas/services/tunnel.py
+++ b/nylas/services/tunnel.py
@@ -35,6 +35,14 @@ def _run_webhook_tunnel(ws):
     ws.run_forever()
 
 
+def _register_webhook(api, callback_domain, tunnel_id, triggers):
+    webhook = api.webhooks.create()
+    webhook.callback_url = "https://{}/{}".format(callback_domain, tunnel_id)
+    webhook.triggers = triggers
+    webhook.state = Webhook.State.ACTIVE.value
+    webhook.save()
+
+
 def _build_webhook_tunnel(api, config):
     ws_domain = "wss://tunnel.nylas.com"
     callback_domain = "cb.nylas.com"
@@ -83,10 +91,6 @@ def _build_webhook_tunnel(api, config):
     )
 
     # Register the webhook to the Nylas application
-    webhook = api.webhooks.create()
-    webhook.callback_url = "https://{}/{}".format(callback_domain, tunnel_id)
-    webhook.triggers = triggers
-    webhook.state = Webhook.State.ACTIVE.value
-    webhook.save()
+    _register_webhook(api, callback_domain, tunnel_id, triggers)
 
     return ws

--- a/nylas/services/tunnel.py
+++ b/nylas/services/tunnel.py
@@ -1,0 +1,71 @@
+import uuid
+
+import websocket
+
+from client import APIClient
+from client.restful_models import Webhook
+from config import DEFAULT_REGION
+
+
+def open_webhook_tunnel(api, config):
+    """
+    Open a webhook tunnel and register it with the Nylas API
+    1. Creates a UUID
+    2. Opens a websocket connection to Nylas' webhook forwarding service,
+       with the UUID as a header
+    3. Creates a new webhook pointed at the forwarding service with the UUID as the path
+
+    When an event is received by the forwarding service, it will push directly to this websocket
+    connection
+
+    Args:
+        api (APIClient): The configured Nylas API client
+        config (dict[str, any]): Configuration for the webhook tunnel, including callback functions, region,
+            and events to subscribe to
+    """
+
+    ws_domain = "wss://tunnel.nylas.com"
+    callback_domain = "cb.nylas.com"
+    # This UUID will map our websocket to a webhook in the forwarding server
+    tunnel_id = str(uuid.uuid4())
+
+    region = config.get('region', DEFAULT_REGION)
+    triggers = config.get('triggers', [e.value for e in Webhook.Trigger])
+    on_message = config.get('on_message', None)
+    on_open = config.get('on_open', None)
+    on_error = config.get('on_error', None)
+    on_close = config.get('on_close', None)
+    on_ping = config.get('on_ping', None)
+    on_pong = config.get('on_pong', None)
+    on_cont_message = config.get('on_cont_message', None)
+    on_data = config.get('on_data', None)
+
+    ws = websocket.WebSocketApp(
+        ws_domain,
+        header={
+            'Client-Id': api.client_id,
+            'Client-Secret': api.client_secret,
+            'Tunnel-Id': tunnel_id,
+            'Region': region.value,
+        },
+        on_open=on_open,
+        on_message=on_message,
+        on_error=on_error,
+        on_close=on_close,
+        on_ping=on_ping,
+        on_pong=on_pong,
+        on_cont_message=on_cont_message,
+        on_data=on_data,
+    )
+    _build_webhook_tunnel(api, callback_domain, tunnel_id, triggers)
+    ws.run_forever()
+
+
+def _build_webhook_tunnel(api, callback_domain, tunnel_path, triggers):
+    webhook = api.webhooks.create()
+    webhook.callback_url = "https://{}/{}".format(callback_domain, tunnel_path)
+    webhook.triggers = triggers
+    webhook.state = Webhook.State.ACTIVE.value
+    webhook.save()
+    return webhook
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ RUN_DEPENDENCIES = [
     "requests[security]>=2.4.2",
     "six>=1.4.1",
     "urlobject",
-    "websocket-client==0.59.0"
+    "websocket-client==0.59.0",
 ]
 
 if sys.version_info[:2] <= (3, 4):

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ TEST_DEPENDENCIES = [
     "pytest",
     "pytest-cov",
     "pytest-timeout",
+    "pytest-mock",
     "responses==0.10.5",
     "twine",
     "pytz",

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ TEST_DEPENDENCIES = [
     "twine",
     "pytz",
 ]
+
+if sys.version_info < (3, 3):
+    TEST_DEPENDENCIES.append("mock")
+
 RELEASE_DEPENDENCIES = ["bumpversion>=0.5.0", "twine>=3.4.2"]
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ RUN_DEPENDENCIES = [
     "requests[security]>=2.4.2",
     "six>=1.4.1",
     "urlobject",
+    "websocket-client==0.59.0"
 ]
 
 if sys.version_info[:2] <= (3, 4):

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -81,6 +81,11 @@ def test_register_webhook(mocked_responses, api_client_with_client_id):
     }
 
 
+# ============================================================================
+# Mock functions for websocket callback
+# ============================================================================
+
+
 # This function mocks websocket implementation and returns a list of params as a dict
 def mock_websocket(
     domain,
@@ -95,11 +100,6 @@ def mock_websocket(
     on_data,
 ):
     return locals()
-
-
-# ============================================================================
-# Mock functions for websocket callback
-# ============================================================================
 
 
 def on_open():

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -2,13 +2,14 @@ import json
 
 import pytest
 from urlobject import URLObject
-import services.tunnel
-from client.restful_models import Webhook
+
+from nylas.services import tunnel
+from nylas.client.restful_models import Webhook
 
 
 @pytest.mark.usefixtures("mock_create_webhook")
 def test_register_webhook(mocked_responses, api_client_with_client_id):
-    services.tunnel._register_webhook(
+    tunnel._register_webhook(
         api_client_with_client_id,
         "domain.com",
         "tunnel_id",

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -3,8 +3,64 @@ import json
 import pytest
 from urlobject import URLObject
 
+from nylas.config import Region
 from nylas.services import tunnel
 from nylas.client.restful_models import Webhook
+
+
+@pytest.mark.usefixtures("mock_create_webhook")
+def test_build_webhook_tunnel(mocker, api_client_with_client_id):
+    mocker.patch("websocket.WebSocketApp", mock_websocket)
+    mocker.patch("uuid.uuid4", return_value="uuid")
+    ws = tunnel._build_webhook_tunnel(
+        api_client_with_client_id,
+        {
+            "region": Region.IRELAND,
+            "triggers": [Webhook.Trigger.MESSAGE_CREATED],
+            "on_open": on_open,
+            "on_error": on_error,
+            "on_close": on_close,
+            "on_ping": on_ping,
+            "on_pong": on_pong,
+            "on_cont_message": on_cont_message,
+            "on_data": on_data,
+        },
+    )
+    assert ws["domain"] == "wss://tunnel.nylas.com"
+    assert ws["header"] == {
+        "Client-Id": "fake-client-id",
+        "Client-Secret": "nyl4n4ut",
+        "Tunnel-Id": "uuid",
+        "Region": "ireland",
+    }
+    assert ws["on_open"] == on_open
+    assert ws["on_error"] == on_error
+    assert ws["on_close"] == on_close
+    assert ws["on_ping"] == on_ping
+    assert ws["on_pong"] == on_pong
+    assert ws["on_cont_message"] == on_cont_message
+    assert ws["on_data"] == on_data
+
+
+@pytest.mark.usefixtures("mock_create_webhook")
+def test_build_webhook_tunnel_defaults(mocker, api_client_with_client_id):
+    mocker.patch("websocket.WebSocketApp", mock_websocket)
+    mocker.patch("uuid.uuid4", return_value="uuid")
+    ws = tunnel._build_webhook_tunnel(api_client_with_client_id, {})
+    assert ws["domain"] == "wss://tunnel.nylas.com"
+    assert ws["header"] == {
+        "Client-Id": "fake-client-id",
+        "Client-Secret": "nyl4n4ut",
+        "Tunnel-Id": "uuid",
+        "Region": "us",
+    }
+    assert ws["on_open"] is None
+    assert ws["on_error"] is None
+    assert ws["on_close"] is None
+    assert ws["on_ping"] is None
+    assert ws["on_pong"] is None
+    assert ws["on_cont_message"] is None
+    assert ws["on_data"] is None
 
 
 @pytest.mark.usefixtures("mock_create_webhook")
@@ -23,3 +79,52 @@ def test_register_webhook(mocked_responses, api_client_with_client_id):
         "triggers": ["message.created"],
         "state": "active",
     }
+
+
+# This function mocks websocket implementation and returns a list of params as a dict
+def mock_websocket(
+    domain,
+    header,
+    on_open,
+    on_message,
+    on_error,
+    on_close,
+    on_ping,
+    on_pong,
+    on_cont_message,
+    on_data,
+):
+    return locals()
+
+
+# ============================================================================
+# Mock functions for websocket callback
+# ============================================================================
+
+
+def on_open():
+    print("on_open")
+
+
+def on_error():
+    print("on_error")
+
+
+def on_close():
+    print("on_close")
+
+
+def on_ping():
+    print("on_ping")
+
+
+def on_pong():
+    print("on_pong")
+
+
+def on_cont_message():
+    print("on_cont_message")
+
+
+def on_data():
+    print("on_data")

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+from urlobject import URLObject
+import services.tunnel
+from client.restful_models import Webhook
+
+
+@pytest.mark.usefixtures("mock_create_webhook")
+def test_register_webhook(mocked_responses, api_client_with_client_id):
+    services.tunnel._register_webhook(
+        api_client_with_client_id,
+        "domain.com",
+        "tunnel_id",
+        [Webhook.Trigger.MESSAGE_CREATED],
+    )
+    request = mocked_responses.calls[0].request
+    assert URLObject(request.url).path == "/a/fake-client-id/webhooks"
+    assert request.method == "POST"
+    assert json.loads(request.body) == {
+        "callback_url": "https://domain.com/tunnel_id",
+        "triggers": ["message.created"],
+        "state": "active",
+    }

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -61,6 +61,7 @@ def test_build_webhook_tunnel_defaults(mocker, api_client_with_client_id):
         "Region": "us",
     }
     assert ws["on_open"] is None
+    assert ws["on_message"] is None
     assert ws["on_error"] is None
     assert ws["on_close"] is None
     assert ws["on_ping"] is None
@@ -135,6 +136,10 @@ def mock_websocket(
     on_data,
 ):
     return locals()
+
+
+def on_message():
+    print("on_message")
 
 
 def on_open():

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -117,6 +117,17 @@ def test_run_webhook_tunnel():
     assert mock_method_calls[0][0] == "run_forever"
 
 
+def test_parse_deltas():
+    message = '{"body": "{\\"deltas\\": [{\\"date\\": 1675098465, \\"object\\": \\"message\\", \\"type\\": \\"message.created\\", \\"object_data\\": {\\"namespace_id\\": \\"namespace_123\\", \\"account_id\\": \\"account_123\\", \\"object\\": \\"message\\", \\"attributes\\": {\\"thread_id\\": \\"thread_123\\", \\"received_date\\": 1675098459}, \\"id\\": \\"123\\", \\"metadata\\": null}}]}"}'
+    deltas = tunnel._parse_deltas(message)
+    assert len(deltas) == 1
+    delta = deltas[0]
+    assert delta["date"] == 1675098465
+    assert delta["object"] == "message"
+    assert delta["type"] == Webhook.Trigger.MESSAGE_CREATED
+    assert delta["object_data"] is not None
+
+
 # ============================================================================
 # Mock functions for websocket callback
 # ============================================================================

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock
 
 import pytest
 from urlobject import URLObject
@@ -79,6 +80,35 @@ def test_register_webhook(mocked_responses, api_client_with_client_id):
         "triggers": ["message.created"],
         "state": "active",
     }
+
+
+@pytest.mark.usefixtures("mock_create_webhook")
+def test_open_webhook_tunnel(mocker, api_client_with_client_id):
+    mock_build = Mock()
+    mock_run = Mock()
+    mocker.patch("nylas.services.tunnel._build_webhook_tunnel", mock_build)
+    mocker.patch("nylas.services.tunnel._run_webhook_tunnel", mock_run)
+
+    tunnel.open_webhook_tunnel(api_client_with_client_id, {"region": Region.IRELAND})
+
+    mock_build_calls = mock_build.call_args_list
+    assert len(mock_build_calls) == 1
+    assert len(mock_build_calls[0].args) == 2
+    assert mock_build_calls[0].args == (
+        api_client_with_client_id,
+        {"region": Region.IRELAND},
+    )
+
+    mock_run_calls = mock_run.call_args_list
+    assert len(mock_run_calls) == 1
+
+
+def test_run_webhook_tunnel():
+    mock = Mock()
+    tunnel._run_webhook_tunnel(mock)
+    mock_method_calls = mock.method_calls
+    assert len(mock_method_calls) == 1
+    assert mock_method_calls[0][0] == "run_forever"
 
 
 # ============================================================================

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,5 +1,10 @@
 import json
-from unittest.mock import Mock
+import sys
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock
+else:
+    from mock import Mock
 
 import pytest
 from urlobject import URLObject


### PR DESCRIPTION
# Description
This PR enables support for local webhook development. When implementing this feature in your app, the SDK will create a tunnel connection to a websocket server and registers it as a webhook callback to your Nylas account. 

# Usage
During the setup process you can pass in methods to override the websocket client's callback methods. The most important method is the `on_message` method which returns a parsed delta event from the webhook server.
```python
from client.restful_models import Webhook
from nylas import APIClient

from services.tunnel import open_webhook_tunnel

nylas = APIClient(
    "CLIENT_ID",
    "CLIENT_SECRET",
)


def run_webhook():
    def on_message(delta):
        if delta["type"] == Webhook.Trigger.MESSAGE_UPDATED:
            print(delta)

    def on_open(ws):
        print("opened")

    def on_error(ws, err):
        print("Error found")
        print(err)

    open_webhook_tunnel(
        nylas, {"on_message": on_message, "on_open": on_open, "on_error": on_error}
    )


if __name__ == "__main__":
    run_webhook()
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
