### PR TITLE
Adding optional parameter for token-info endpoint

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -289,10 +289,10 @@ class APIClient(json.JSONEncoder):
         _validate(resp).json()
         return resp.json()
 
-    def token_info(self,account_id=None):
-        token_info_url=""
+    def token_info(self, account_id=None):
+        token_info_url = ""
         if account_id is not None:
-             token_info_url = self.token_info_url.format(
+            token_info_url = self.token_info_url.format(
                 client_id=self.client_id, account_id=account_id
             )
         else:

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -289,10 +289,16 @@ class APIClient(json.JSONEncoder):
         _validate(resp).json()
         return resp.json()
 
-    def token_info(self):
-        token_info_url = self.token_info_url.format(
-            client_id=self.client_id, account_id=self.account.id
-        )
+    def token_info(self,account_id=None):
+        token_info_url=""
+        if account_id is not None:
+             token_info_url = self.token_info_url.format(
+                client_id=self.client_id, account_id=account_id
+            )
+        else:
+            token_info_url = self.token_info_url.format(
+                client_id=self.client_id, account_id=self.account.id
+            )
         headers = {"Content-Type": "application/json"}
         headers.update(self.admin_session.headers)
         resp = self.admin_session.post(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1955,9 +1955,7 @@ def mock_ip_addresses(mocked_responses, api_url, client_id):
 
 @pytest.fixture
 def mock_token_info(mocked_responses, api_url, account_id, client_id):
-    token_info_url = "{base}/a/{client_id}/accounts/{id}/token-info".format(
-        base=api_url, id=account_id, client_id=client_id
-    )
+    token_info_url = re.compile(api_url + "/a/.*/accounts/.*/token-info")
     mocked_responses.add(
         responses.POST,
         token_info_url,

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -37,6 +37,13 @@ def test_token_info(api_client_with_client_id):
     assert "updated_at" in result
     assert "scopes" in result
 
+@pytest.mark.usefixtures("mock_token_info", "mock_account")
+def test_token_info(api_client_with_client_id):
+    result = api_client_with_client_id.token_info(account_id="anvkhwelkfdoehdflhdjkfhe1")
+    assert isinstance(result, dict)
+    assert "updated_at" in result
+    assert "scopes" in result
+
 
 @pytest.mark.usefixtures("mock_account")
 def test_account_datetime(api_client):

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -37,9 +37,12 @@ def test_token_info(api_client_with_client_id):
     assert "updated_at" in result
     assert "scopes" in result
 
+
 @pytest.mark.usefixtures("mock_token_info", "mock_account")
 def test_token_info(api_client_with_client_id):
-    result = api_client_with_client_id.token_info(account_id="anvkhwelkfdoehdflhdjkfhe1")
+    result = api_client_with_client_id.token_info(
+        account_id="anvkhwelkfdoehdflhdjkfhe1"
+    )
     assert isinstance(result, dict)
     assert "updated_at" in result
     assert "scopes" in result

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -39,7 +39,7 @@ def test_token_info(api_client_with_client_id):
 
 
 @pytest.mark.usefixtures("mock_token_info", "mock_account")
-def test_token_info(api_client_with_client_id):
+def test_token_info_with_account_id(api_client_with_client_id):
     result = api_client_with_client_id.token_info(
         account_id="anvkhwelkfdoehdflhdjkfhe1"
     )


### PR DESCRIPTION
# Description

Allow token_info parameter to pass in an account_id so the call to GET /accounts doesn't throw 401. This is how the actual endpoint behaves.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
