### PR TITLE
Add support for verifying webhook signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for verifying webhook signatures
+
 v5.13.1
 ----------------
 * Fix `send_authorization` not returning the correct dict

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -1,3 +1,5 @@
+import hashlib
+import hmac
 from datetime import datetime
 from collections import defaultdict
 from enum import Enum
@@ -979,6 +981,24 @@ class Webhook(NylasAPIObject):
         else:
             dct = NylasAPIObject.as_json(self, enforce_read_only)
         return dct
+
+    @staticmethod
+    def verify_webhook_signature(nylas_signature, raw_body, client_secret):
+        """
+        Verify incoming webhook signature came from Nylas
+
+        Args:
+            nylas_signature (str): The signature to verify
+            raw_body (bytes | bytearray): The raw body from the payload
+            client_secret (str): Client secret of the app receiving the webhook
+
+        Returns:
+            bool: True if the webhook signature was verified from Nylas
+        """
+        digest = hmac.new(
+            str.encode(client_secret), msg=raw_body, digestmod=hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(digest, nylas_signature)
 
     class Trigger(str, Enum):
         """

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -78,3 +78,21 @@ def test_create_webhook(mocked_responses, api_client_with_client_id):
     assert webhook.state == "active"
     assert webhook.triggers == ["message.created"]
     assert webhook.version == "1.0"
+
+
+def test_verify_webhook_signature():
+    is_verified = Webhook.verify_webhook_signature(
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        str.encode("test123"),
+        "myClientSecret",
+    )
+    assert is_verified is True
+
+
+def test_verify_webhook_signature_bad_signature():
+    is_verified = Webhook.verify_webhook_signature(
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        str.encode("test1234"),
+        "myClientSecret",
+    )
+    assert is_verified is False


### PR DESCRIPTION
# Description
This PR adds support for verifying the webhook signature of inbound webhook notifications.

# Usage
```py
from flask import Flask, request, jsonify
from nylas import APIClient, Webhook
import os
import json

app = Flask(__name__)
port = 9000
NYLAS_CLIENT_SECRET = os.environ.get("NYLAS_CLIENT_SECRET")

@app.route("/", methods=["POST"])
def webhook_callback():
    signature = request.headers.get("X-Nylas-Signature")
    request_data = json.dumps(request.get_json())
    
    if not WebhookNotification.verify_webhook_signature(signature, request_data, NYLAS_CLIENT_SECRET):
        return jsonify({"error": "Invalid signature"}), 403

    body = request.json
    print("Webhook event received: ", json.dumps(body))

    return jsonify({"success": True}), 200

if __name__ == "__main__":
    app.run(port=port)

```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
