### PR TITLE
Bug, cannot do a record count before an iteration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: MatteoH2O1999/setup-python@v1.4.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -70,7 +70,8 @@ class RestfulModelCollection(object):
         Returns:
             int: The number of objects in the collection being queried
         """
-        self.filters["view"] = "count"
+        filters = self.filters.copy()
+        filters["view"] = "count"
         response = self.api._get_resource_raw(
             self.model_class, resource_id=None, **self.filters
         ).json()


### PR DESCRIPTION

Create a copy of the filer to prevent other functions for using the "count" view when making calls

# TL;DR
When getting a count before iterating it fails
Example:
```python
logger.info('Messages')
limit, offset, message_count = 25, 0, 1
while offset < message_count:
    messages = client.messages.where(limit=limit, offset=offset)
    # Crashes code, cannot do count and then iterate
    message_count = messages.count()
    for message in messages:
        logger.info(f'ID:      {message.id}')
    offset += limit
```

Error:
```python
Traceback (most recent call last):
  File "/Users/thedzy/Scripts/nylas/nylas/nylas_test.py", line 223, in <module>
    main()
  File "/Users/thedzy/Scripts/nylas/nylas/nylas_test.py", line 124, in main
    for message in messages:
  File "/Users/thedzy/python_venv/lib/python3.11/site-packages/nylas/client/restful_model_collection.py", line 46, in values
    models = self._get_model_collection(offset + fetched, req_limit)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thedzy/python_venv/lib/python3.11/site-packages/nylas/client/restful_model_collection.py", line 154, in _get_model_collection
    return self.api._get_resources(self.model_class, **filters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thedzy/python_venv/lib/python3.11/site-packages/nylas/client/client.py", line 585, in _get_resources
    return [cls.create(self, **x) for x in results if x is not None]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thedzy/python_venv/lib/python3.11/site-packages/nylas/client/client.py", line 585, in <listcomp>
    return [cls.create(self, **x) for x in results if x is not None]
            ^^^^^^^^^^^^^^^^^^^^^
TypeError: nylas.client.restful_models.RestfulModel.create() argument after ** must be a mapping, not str
```

Reason appear to be altering the class property `filters` with `['view'] = 'count'`.  When calling iteration, the `filer['view'] ` is still `'count'`.

Proposed change is to copy the filter instead of modifying original.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
