### PR TITLE
Add None init for Optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 v6.0.0b2
 ----------------
 * Fix inconsistency between Event model and API contract
+* Fix bug when deserializing Events with empty optional fields
 
 v6.0.0b1
 ----------------

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -33,9 +33,9 @@ class Participant:
 
     email: str
     status: ParticipantStatus
-    name: Optional[str]
-    comment: Optional[str]
-    phone_number: Optional[str]
+    name: Optional[str] = None
+    comment: Optional[str] = None
+    phone_number: Optional[str] = None
 
 
 @dataclass_json
@@ -50,7 +50,7 @@ class EmailName:
     """
 
     email: str
-    name: Optional[str]
+    name: Optional[str] = None
 
 
 @dataclass_json
@@ -86,8 +86,8 @@ class Timespan:
 
     start_time: int
     end_time: int
-    start_timezone: Optional[str]
-    end_timezone: Optional[str]
+    start_timezone: Optional[str] = None
+    end_timezone: Optional[str] = None
 
 
 @dataclass_json


### PR DESCRIPTION
# Description
This PR addresses a bug that causes Event deserialization to break. This is because we should init all Optional fields to None.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
