### PR TITLE
Fix bug when deserializing delete response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 v6.0.0b3
 ----------------
 * Fix bug when deserializing Union types
+* Fix bug when deserializing delete response
 
 v6.0.0b2
 ----------------

--- a/nylas/handler/api_resources.py
+++ b/nylas/handler/api_resources.py
@@ -69,4 +69,4 @@ class DestroyableApiResource(Resource):
         response_json = self._http_client._execute(
             "DELETE", path, headers, query_params, request_body
         )
-        return Response.from_dict(response_json, response_type)
+        return response_type.from_dict(response_json)

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -316,7 +316,7 @@ class Event:
     participants: List[Participant]
     when: When = field(metadata=config(decoder=_decode_when))
     conferencing: Optional[Conferencing] = field(
-        metadata=config(decoder=_decode_conferencing)
+        default=None, metadata=config(decoder=_decode_conferencing)
     )
     object: str = "event"
     description: Optional[str] = None


### PR DESCRIPTION
# Description
For `.destroy()` method we are not using the correct model to deserialize the response to. We just discard it and use `Response` which results in a KeyError.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
