### PR TITLE
Add support for free-busy endpoint

### DIFF
--- a/nylas/models/free_busy.py
+++ b/nylas/models/free_busy.py
@@ -44,7 +44,7 @@ class GetFreeBusyResponse:
 
     """
 
-    data: List[Union[FreeBusy, Error]]
+    List[Union[FreeBusy, Error]]
 
 
 class GetFreeBusyRequest(TypedDict):

--- a/nylas/models/free_busy.py
+++ b/nylas/models/free_busy.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+from dataclasses_json import dataclass_json
+from typing_extensions import TypedDict
+
+
+@dataclass_json
+@dataclass
+class Error:
+    email: str
+    error: str
+
+
+@dataclass_json
+@dataclass
+class TimeSlot:
+    """
+    Interface for a Nylas free/busy time slot
+
+    Attributes:
+        emails: The emails of the participants who are available for the time slot.
+        start_time: Unix timestamp for the start of the slot.
+        end_time: Unix timestamp for the end of the slot.
+    """
+
+    start_time: int
+    end_time: int
+    status: str
+
+
+@dataclass_json
+@dataclass
+class FreeBusy:
+    email: str
+    time_slots: List[TimeSlot]
+
+
+@dataclass_json
+@dataclass
+class GetFreeBusyResponse:
+    """
+    Interface for a Nylas get free/busy response
+
+    """
+
+    data: List[Union[FreeBusy, Error]]
+
+
+class GetFreeBusyRequest(TypedDict):
+    """
+    Interface for a Nylas get free/busy request
+
+    Attributes:
+        start_time: Unix timestamp for the start time to check free/busy for.
+        end_time: Unix timestamp for the end time to check free/busy for.
+        emails: List of email addresses to check free/busy for.
+    """
+
+    start_time: int
+    end_time: int
+    emails: List[str]

--- a/nylas/models/free_busy.py
+++ b/nylas/models/free_busy.py
@@ -8,6 +8,14 @@ from typing_extensions import TypedDict
 @dataclass_json
 @dataclass
 class Error:
+    """
+    Interface for a Nylas free/busy call error
+
+    Attributes:
+        email: The email address of the participant who had an error.
+        error: The provider's error message.
+    """
+
     email: str
     error: str
 
@@ -19,9 +27,9 @@ class TimeSlot:
     Interface for a Nylas free/busy time slot
 
     Attributes:
-        emails: The emails of the participants who are available for the time slot.
         start_time: Unix timestamp for the start of the slot.
         end_time: Unix timestamp for the end of the slot.
+        status: The status of the slot. Can be "free", "busy", or "tentative".
     """
 
     start_time: int
@@ -32,6 +40,14 @@ class TimeSlot:
 @dataclass_json
 @dataclass
 class FreeBusy:
+    """
+    Interface for an individual Nylas free/busy response
+
+    Attributes:
+        email: The email address of the participant.
+        time_slots: List of time slots for the participant.
+    """
+
     email: str
     time_slots: List[TimeSlot]
 
@@ -41,6 +57,8 @@ class FreeBusy:
 class GetFreeBusyResponse:
     """
     Interface for a Nylas get free/busy response
+
+    A list of FreeBusy objects and Error objects.
 
     """
 

--- a/nylas/resources/calendars.py
+++ b/nylas/resources/calendars.py
@@ -153,8 +153,4 @@ class Calendars(
             request_body=request_body,
         )
 
-        import pdb
-
-        pdb.set_trace()
-
-        return Response.from_dict(json_response, GetFreeBusyResponse)
+        return Response(json_response, GetFreeBusyResponse)

--- a/nylas/resources/calendars.py
+++ b/nylas/resources/calendars.py
@@ -153,4 +153,8 @@ class Calendars(
             request_body=request_body,
         )
 
+        import pdb
+
+        pdb.set_trace()
+
         return Response.from_dict(json_response, GetFreeBusyResponse)

--- a/nylas/resources/calendars.py
+++ b/nylas/resources/calendars.py
@@ -6,6 +6,7 @@ from nylas.handler.api_resources import (
     DestroyableApiResource,
 )
 from nylas.models.availability import GetAvailabilityResponse, GetAvailabilityRequest
+from nylas.models.free_busy import GetFreeBusyResponse, GetFreeBusyRequest
 from nylas.models.calendars import (
     Calendar,
     CreateCalendarRequest,
@@ -132,3 +133,24 @@ class Calendars(
         )
 
         return Response.from_dict(json_response, GetAvailabilityResponse)
+
+    def get_free_busy(
+        self, identifier: str, request_body: GetFreeBusyRequest
+    ) -> Response[GetFreeBusyResponse]:
+        """
+        Get free/busy info for a Calendar.
+
+        Args:
+            identifier: The grant ID or email account to get free/busy for.
+            request_body: The request body to send to the API.
+
+        Returns:
+            Response: The free/busy response from the API.
+        """
+        json_response = self._http_client._execute(
+            method="POST",
+            path=f"/v3/grants/{identifier}/calendars/free-busy",
+            request_body=request_body,
+        )
+
+        return Response.from_dict(json_response, GetFreeBusyResponse)


### PR DESCRIPTION
Mostly cribbed off the availability support, though radically stripped
down as free-busy is a great deal simpler.

Didn't see any test support, so I didn't write any tests.

You can call it like this:

```
    nylas = nylasSDK.Client(api_key=NYLAS_API_KEY)

    response, request_id = nylas.calendars.get_free_busy(
        identifier=grant_id,
        request_body=dict(
            emails=["foobar@nylas.com"],
            start_time=start_unix_timestamp,
            end_time=end_unix_timestamp,
        ),
    )
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
