### PR TITLE
Make Grants API available

### DIFF
--- a/nylas/client.py
+++ b/nylas/client.py
@@ -2,6 +2,7 @@ from nylas.config import DEFAULT_SERVER_URL
 from nylas.handler.http_client import HttpClient
 from nylas.resources.applications import Applications
 from nylas.resources.auth import Auth
+from nylas.resources.grants import Grants
 from nylas.resources.calendars import Calendars
 from nylas.resources.events import Events
 from nylas.resources.webhooks import Webhooks
@@ -41,6 +42,16 @@ class Client(object):
             The Auth API.
         """
         return Auth(self.http_client)
+
+    @property
+    def grants(self) -> Grants:
+        """
+        Access the Grants API.
+
+        Returns:
+            The Grants API.
+        """
+        return Grants(self.http_client)
 
     @property
     def applications(self) -> Applications:


### PR DESCRIPTION
This functionality was all implemented but not exposed on the Client object and therefore there was no way to make API calls

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
