### PR TITLE
Change auth build query to point to scope instead of scopes

### DIFF
--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -30,8 +30,8 @@ def _build_query(config: dict) -> dict:
     if not config["access_type"]:
         config["access_type"] = "online"
 
-    if config["scopes"]:
-        config["scopes"] = " ".join(config["scopes"])
+    if config["scope"]:
+        config["scope"] = " ".join(config["scope"])
 
     return config
 


### PR DESCRIPTION
# Description
This PR is to make sure we look for scope instead of scopes when we build the URL for v3 OAuth2.0