### PR TITLE
Making timezone value and timestamps for Grant optional due to no sup…

### DIFF
--- a/nylas/models/calendars.py
+++ b/nylas/models/calendars.py
@@ -17,7 +17,8 @@ class Calendar:
         id: Globally unique object identifier.
         grant_id: Grant ID representing the user's account.
         name: Name of the Calendar.
-        timezone: IANA time zone database-formatted string (for example, "America/New_York").
+        timezone: IANA time zone database-formatted string (for example, "America/New_York"). This value is only supported
+            for Google and Virtual Calendars.
         read_only: If the event participants are able to edit the Event.
         is_owned_by_user: If the Calendar is owned by the user account.
         object: The type of object.
@@ -34,10 +35,10 @@ class Calendar:
     id: str
     grant_id: str
     name: str
-    timezone: str
     read_only: bool
     is_owned_by_user: bool
     object: str = "calendar"
+    timezone: Optional[str] = None
     description: Optional[str] = None
     location: Optional[str] = None
     hex_color: Optional[str] = None

--- a/nylas/models/grants.py
+++ b/nylas/models/grants.py
@@ -30,13 +30,13 @@ class Grant:
 
     id: str
     provider: str
-    created_at: int
     scope: List[str] = field(default_factory=list)
     grant_status: Optional[str] = None
     email: Optional[str] = None
     user_agent: Optional[str] = None
     ip: Optional[str] = None
     state: Optional[str] = None
+    created_at: Optional[int] = None
     updated_at: Optional[int] = None
     provider_user_id: Optional[str] = None
     settings: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
# Description

Timezone value is not supported for Microsoft calendars. This throws a key error while decoding.
Additionally, the created_at value is omitted during the re-authentication attempt.

https://nylas.atlassian.net/browse/CUST-2071

The grant issue should be fixed in our API and this should eliminate the issue in our Python SDK.
https://nylas.atlassian.net/browse/CUST-2072

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
