### PR TITLE
Make email to optional

### DIFF
--- a/nylas/models/messages.py
+++ b/nylas/models/messages.py
@@ -78,7 +78,6 @@ class Message:
     subject: str
 
     from_: List[EmailName] = field(metadata=config(field_name="from"))
-    to: List[EmailName]
 
     date: datetime
 
@@ -88,6 +87,7 @@ class Message:
     snippet: str
     body: str
 
+    to: Optional[List[EmailName]] = None
     bcc: Optional[List[EmailName]] = None
     cc: Optional[List[EmailName]] = None
     reply_to: Optional[List[EmailName]] = None


### PR DESCRIPTION
# License

When sending an email without a To (using bc or bcc), fetching breaks.

https://nylas.atlassian.net/jira/software/c/projects/AV/boards/125?selectedIssue=AV-2705

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
