### PR TITLE
Fix message send/draft create/modify not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 nylas-python Changelog
 ======================
 
+v6.0.0b8
+----------------
+* Added helper function for attaching files to messages
+* Fixed issues with sending messages and creating drafts
+
 v6.0.0b7
 ----------------
 * Add Message Send, Drafts, Threads, and Smart Compose APIs support

--- a/nylas/models/attachments.py
+++ b/nylas/models/attachments.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union, BinaryIO
 
 from dataclasses_json import dataclass_json
 from typing_extensions import TypedDict, NotRequired
@@ -31,7 +31,7 @@ class CreateAttachmentRequest(TypedDict):
     Attributes:
         filename: Name of the attachment.
         content_type: MIME type of the attachment.
-        content: Base64 encoded content of the attachment.
+        content: Either a Base64 encoded content of the attachment or a pointer to a file.
         size: Size of the attachment in bytes.
         content_id: The content ID of the attachment.
         content_disposition: The content disposition of the attachment.
@@ -40,7 +40,7 @@ class CreateAttachmentRequest(TypedDict):
 
     filename: str
     content_type: str
-    content: str
+    content: Union[str, BinaryIO]
     size: int
     content_id: NotRequired[str]
     content_disposition: NotRequired[str]

--- a/nylas/models/attachments.py
+++ b/nylas/models/attachments.py
@@ -28,6 +28,8 @@ class CreateAttachmentRequest(TypedDict):
     """
     A request to create an attachment.
 
+    You can use `attach_file_request_builder()` to build this request.
+
     Attributes:
         filename: Name of the attachment.
         content_type: MIME type of the attachment.

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -40,9 +40,7 @@ class Participant:
     phone_number: Optional[str] = None
 
 
-@dataclass_json
-@dataclass
-class EmailName:
+class EmailName(TypedDict):
     """
     Interface representing an email address and optional name.
 
@@ -52,7 +50,7 @@ class EmailName:
     """
 
     email: str
-    name: Optional[str] = None
+    name: NotRequired[str]
 
 
 @dataclass_json

--- a/nylas/resources/drafts.py
+++ b/nylas/resources/drafts.py
@@ -14,7 +14,7 @@ from nylas.models.drafts import (
     CreateDraftRequest,
 )
 from nylas.models.response import ListResponse, Response, DeleteResponse
-from nylas.resources.messages import _build_form_request
+from nylas.utils.file_utils import _build_form_request
 
 
 class Drafts(

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -1,7 +1,4 @@
-import json
 from typing import Optional
-
-from requests_toolbelt import MultipartEncoder
 
 from nylas.handler.api_resources import (
     ListableApiResource,
@@ -21,26 +18,7 @@ from nylas.models.messages import (
 )
 from nylas.models.response import Response, ListResponse, DeleteResponse
 from nylas.resources.smart_compose import SmartCompose
-
-
-def _build_form_request(request_body: dict) -> MultipartEncoder:
-    attachments = request_body.get("attachments", [])
-    request_body.pop("attachments", None)
-    message_payload = json.dumps(request_body)
-
-    # Create the multipart/form-data encoder
-    return MultipartEncoder(
-        fields={
-            "message": message_payload,
-            **{
-                f"file{index}": {
-                    "filename": attachment.filename,
-                    "content_type": attachment.content_type,
-                }
-                for index, attachment in enumerate(attachments)
-            },
-        }
-    )
+from nylas.utils.file_utils import _build_form_request
 
 
 class Messages(

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -31,7 +31,7 @@ def _build_form_request(request_body: dict) -> MultipartEncoder:
     # Create the multipart/form-data encoder
     return MultipartEncoder(
         fields={
-            "message": ("message", message_payload, "application/json"),
+            "message": message_payload,
             **{
                 f"file{index}": {
                     "filename": attachment.filename,

--- a/nylas/utils/file_utils.py
+++ b/nylas/utils/file_utils.py
@@ -1,0 +1,35 @@
+import json
+import mimetypes
+import os
+
+from requests_toolbelt import MultipartEncoder
+
+
+def _build_form_request(request_body: dict) -> MultipartEncoder:
+    """
+    Build a form-data request.
+
+    Attributes:
+        request_body: The request body to send.
+
+    Returns:
+        The multipart/form-data request.
+    """
+    attachments = request_body.get("attachments", [])
+    request_body.pop("attachments", None)
+    message_payload = json.dumps(request_body)
+
+    # Create the multipart/form-data encoder
+    return MultipartEncoder(
+        fields={
+            "message": message_payload,
+            **{
+                f"file{index}": {
+                    "filename": attachment.filename,
+                    "content_type": attachment.content_type,
+                    "content": attachment.content,
+                }
+                for index, attachment in enumerate(attachments)
+            },
+        }
+    )

--- a/nylas/utils/file_utils.py
+++ b/nylas/utils/file_utils.py
@@ -1,8 +1,35 @@
 import json
 import mimetypes
 import os
+from pathlib import Path
 
 from requests_toolbelt import MultipartEncoder
+
+from nylas.models.attachments import CreateAttachmentRequest
+
+
+def attach_file_request_builder(file_path) -> CreateAttachmentRequest:
+    """
+    Build a request to attach a file.
+
+    Attributes:
+        file_path: The path to the file to attach.
+
+    Returns:
+        A properly-formatted request to attach the file.
+    """
+    path = Path(file_path)
+    filename = path.name
+    size = os.path.getsize(file_path)
+    content_type = mimetypes.guess_type(file_path)[0]
+    file_stream = open(file_path, "rb")
+
+    return {
+        "filename": filename,
+        "content_type": content_type if content_type else "application/octet-stream",
+        "content": file_stream,
+        "size": size,
+    }
 
 
 def _build_form_request(request_body: dict) -> MultipartEncoder:

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -12,6 +12,7 @@ excluded_files = [
     "handler/http_client",
     "models/__init__",
     "resources/__init__",
+    "utils/__init__",
 ]
 
 # Prepare Navigation


### PR DESCRIPTION
# Description
This PR fixes the serialization of outgoing message requests using the multipart formatter. We've also added in a helper function to help with formatting files to attach to a message.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
