### PR TITLE
Add support for view parameter in `threads.search()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Add support for `view` parameter in `Threads.search()`
+
 v5.14.1
 ----------------
 * Fix error when trying to iterate on list after calling count

--- a/nylas/client/restful_model_collection.py
+++ b/nylas/client/restful_model_collection.py
@@ -110,7 +110,9 @@ class RestfulModelCollection(object):
     def delete(self, id, data=None, **kwargs):
         return self.api._delete_resource(self.model_class, id, data=data, **kwargs)
 
-    def search(self, q, limit=None, offset=None):  # pylint: disable=invalid-name
+    def search(
+        self, q, limit=None, offset=None, view=None
+    ):  # pylint: disable=invalid-name
         from nylas.client.restful_models import (
             Message,
             Thread,
@@ -122,6 +124,8 @@ class RestfulModelCollection(object):
                 kwargs["limit"] = limit
             if offset is not None:
                 kwargs["offset"] = offset
+            if view is not None and self.model_class is Thread:
+                kwargs["view"] = view
             return self.api._get_resources(self.model_class, extra="search", **kwargs)
         else:
             raise Exception("Searching is only allowed on Thread and Message models")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1005,7 +1005,7 @@ def mock_thread_search_response(mocked_responses, api_url):
 
     mocked_responses.add(
         responses.GET,
-        api_url + "/threads/search?q=Helena",
+        re.compile(api_url + "/threads/search\?q=Helena.*"),
         body=response_body,
         status=200,
         content_type="application/json",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -24,6 +24,20 @@ def test_search_messages_with_limit_offset(mocked_responses, api_client):
 
 
 @pytest.mark.usefixtures("mock_message_search_response")
+def test_search_messages_with_view_should_not_appear(mocked_responses, api_client):
+    api_client.messages.search("Pinot", view="expanded")
+    request = mocked_responses.calls[0].request
+    assert request.path_url == "/messages/search?q=Pinot"
+
+
+@pytest.mark.usefixtures("mock_thread_search_response")
+def test_search_messages_with_view_should_appear(mocked_responses, api_client):
+    api_client.threads.search("Helena", view="expanded")
+    request = mocked_responses.calls[0].request
+    assert request.path_url == "/threads/search?q=Helena&view=expanded"
+
+
+@pytest.mark.usefixtures("mock_message_search_response")
 def test_search_drafts(api_client):
     with pytest.raises(Exception):
         api_client.drafts.search("Pinot")


### PR DESCRIPTION
# Description
This PR adds support for the view parameter in thread searching. Closes #287.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
