### PR TITLE
Fix issue with multipart attachments throwing KeyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v6.0.0b8
 ----------------
 * Added helper function for attaching files to messages
 * Fixed issues with sending messages and creating drafts
+* Fixed issue where an error was raised when trying to attach a file to a message
 
 v6.0.0b7
 ----------------

--- a/nylas/utils/file_utils.py
+++ b/nylas/utils/file_utils.py
@@ -47,16 +47,12 @@ def _build_form_request(request_body: dict) -> MultipartEncoder:
     message_payload = json.dumps(request_body)
 
     # Create the multipart/form-data encoder
-    return MultipartEncoder(
-        fields={
-            "message": message_payload,
-            **{
-                f"file{index}": {
-                    "filename": attachment.filename,
-                    "content_type": attachment.content_type,
-                    "content": attachment.content,
-                }
-                for index, attachment in enumerate(attachments)
-            },
-        }
-    )
+    fields = {"message": ("", message_payload, "application/json")}
+    for index, attachment in enumerate(attachments):
+        fields[f"file{index}"] = (
+            attachment["filename"],
+            attachment["content"],
+            attachment["content_type"],
+        )
+
+    return MultipartEncoder(fields=fields)


### PR DESCRIPTION
# Description
We were attaching files via MultipartEncoder the wrong way. It's not expecting raw data, we needed to pass in the fields as a tuple instead of a dict.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
