### PR TITLE
Making status a NotRequired field for UpdateParticipantEvent

### DIFF
--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -364,7 +364,8 @@ class UpdateParticipant(TypedDict):
         phoneNumber: Participant's phone number.
     """
 
-    email: NotRequired[str]
+    email: str
+    status: NotRequired[ParticipantStatus]
     name: NotRequired[str]
     comment: NotRequired[str]
     phoneNumber: NotRequired[str]


### PR DESCRIPTION
# Description

This PR is to also include the status value in the `UpdateParticipant` object of the Event model. We seem to include this value in CreateRequest so we should include them in the update request as well
