### PR TITLE
Move `Grants` to `NylasClient` and custom authentication to `Auth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ nylas-python Changelog
 
 v6.0.0b8
 ----------------
+* **BREAKING CHANGES**: Moved grants API out of `Auth` to `NylasClient`
+* **BREAKING CHANGES**: Moved `Grants.create()` to `Auth.customAuthentication()`
 * Added helper function for attaching files to messages
 * Fixed issues with sending messages and creating drafts
 

--- a/nylas/client.py
+++ b/nylas/client.py
@@ -1,3 +1,5 @@
+from nylas.resources.grants import Grants
+
 from nylas.config import DEFAULT_SERVER_URL
 from nylas.handler.http_client import HttpClient
 from nylas.resources.applications import Applications
@@ -106,6 +108,16 @@ class Client(object):
             The Folders API.
         """
         return Folders(self.http_client)
+
+    @property
+    def grants(self) -> Grants:
+        """
+        Access the Grants API.
+
+        Returns:
+            The Grants API.
+        """
+        return Grants(self.http_client)
 
     @property
     def messages(self) -> Messages:

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -3,6 +3,8 @@ import hashlib
 import urllib.parse
 import uuid
 
+from nylas.models.grant import CreateGrantRequest, Grant
+
 from nylas.models.auth import (
     CodeExchangeResponse,
     PkceAuthUrl,
@@ -98,6 +100,26 @@ class Auth(Resource):
         request_body["grant_type"] = "authorization_code"
 
         return self._get_token(request_body)
+
+    def custom_authentication(
+        self, request_body: CreateGrantRequest
+    ) -> Response[Grant]:
+        """
+        Create a Grant via Custom Authentication.
+
+        Args:
+            request_body: The values to create the Grant with.
+
+        Returns:
+            The created Grant.
+        """
+
+        json_response = self._http_client._execute(
+            method="POST",
+            path=f"/v3/connect/custom",
+            request_body=request_body,
+        )
+        return Response.from_dict(json_response, Grant)
 
     def refresh_access_token(
         self, request: TokenExchangeRequest

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -59,16 +59,6 @@ def _build_query_with_admin_consent(config: dict) -> dict:
 
 
 class Auth(Resource):
-    @property
-    def grants(self) -> Grants:
-        """
-        Access the Grants API.
-
-        Returns:
-            The Grants API.
-        """
-        return Grants(self._http_client)
-
     def url_for_oauth2(self, config: URLForAuthenticationConfig) -> str:
         """
         Build the URL for authenticating users to your application via Hosted Authentication.

--- a/nylas/resources/grants.py
+++ b/nylas/resources/grants.py
@@ -1,14 +1,12 @@
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
-    CreatableApiResource,
     UpdatableApiResource,
     DestroyableApiResource,
 )
 from nylas.models.grants import (
     Grant,
     ListGrantsQueryParams,
-    CreateGrantRequest,
     UpdateGrantRequest,
 )
 from nylas.models.response import Response, ListResponse, DeleteResponse
@@ -17,7 +15,6 @@ from nylas.models.response import Response, ListResponse, DeleteResponse
 class Grants(
     ListableApiResource,
     FindableApiResource,
-    CreatableApiResource,
     UpdatableApiResource,
     DestroyableApiResource,
 ):
@@ -49,21 +46,6 @@ class Grants(
 
         return super(Grants, self).find(
             path=f"/v3/grants/{grant_id}", response_type=Grant
-        )
-
-    def create(self, request_body: CreateGrantRequest) -> Response[Grant]:
-        """
-        Create a Grant via Custom Authentication.
-
-        Args:
-            request_body: The values to create the Grant with.
-
-        Returns:
-            The created Grant.
-        """
-
-        return super(Grants, self).create(
-            path=f"/v3/connect/custom", response_type=Grant, request_body=request_body
         )
 
     def update(


### PR DESCRIPTION
# Description
⚠️ This is a breaking change ⚠️ 

This PR moves the following:
* `Auth.grants()` to `NylasClient.grants()`
* `Grants.create()` to `Auth.customAuthentication()`

Functionality remains the same.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
