### PR TITLE
Fix Invalid Escape Sequence for Image Extraction Regex

### DIFF
--- a/nylas/client/neural_api_models.py
+++ b/nylas/client/neural_api_models.py
@@ -165,7 +165,7 @@ class NeuralCleanConversation(Message):
         RestfulModel.__init__(self, NeuralCleanConversation, api)
 
     def extract_images(self):
-        pattern = "[\(']cid:(.*?)[\)']"
+        pattern = r"[\(']cid:(.*?)[\)']"
         file_ids = re.findall(pattern, self.conversation)
         files = []
         for match in file_ids:


### PR DESCRIPTION
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

When running Python 3.12, the invalid escape sequence here leads to a `SyntaxWarning`.