### PR TITLE
Fix incorrect PKCE code challenge generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v6.0.0b8
 * Fix issues with sending messages and creating drafts
 * Fix issue where an error was raised when trying to attach a file to a message
 * Fix inaccuracies with Event models
+* Fix incorrect PKCE code challenge generation
 
 v6.0.0b7
 ----------------

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -17,7 +17,6 @@ from nylas.models.auth import (
     URLForAdminConsentConfig,
 )
 from nylas.models.response import Response
-from nylas.resources.grants import Grants
 from nylas.resources.resource import Resource
 
 

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -21,8 +21,8 @@ from nylas.resources.resource import Resource
 
 
 def _hash_pkce_secret(secret: str) -> str:
-    sha256_hash = hashlib.sha256(secret.encode()).digest()
-    return base64.b64encode(sha256_hash).decode()
+    sha256_hash = hashlib.sha256(secret.encode()).hexdigest()
+    return base64.b64encode(sha256_hash.encode()).decode().rstrip("=")
 
 
 def _build_query(config: dict) -> dict:


### PR DESCRIPTION
# Description
This PR fixes the PKCE code challenge generation; the correct method the API wants is for us to base64 encode the hex string as opposed to base64 encoding resulting hashed bytearray directly. Closes #329. Thanks to @wobeng for reporting and providing the correct code.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
