### PR TITLE
Changed client_secret to optional for token exchange methods; defaults to API Key now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+v6.0.0b9
+----------------
+* Changed `client_secret` to optional for token exchange methods; defaults to API Key now
+
 v6.0.0b8
 ----------------
 * **BREAKING CHANGES**: Moved grants API out of `Auth` to `NylasClient`

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -61,14 +61,14 @@ class CodeExchangeRequest(TypedDict):
         redirect_uri: Should match the same redirect URI that was used for getting the code during the initial authorization request.
         code: OAuth 2.0 code fetched from the previous step.
         client_id: Client ID of the application.
-        client_secret: Client secret of the application.
+        client_secret: Client secret of the application. If not provided, the API Key will be used instead.
         code_verifier: The original plain text code verifier (code_challenge) used in the initial authorization request (PKCE).
     """
 
     redirect_uri: str
     code: str
     client_id: str
-    client_secret: str
+    client_secret: NotRequired[str]
     code_verifier: NotRequired[str]
 
 
@@ -80,13 +80,13 @@ class TokenExchangeRequest(TypedDict):
         redirect_uri: Should match the same redirect URI that was used for getting the code during the initial authorization request.
         refresh_token: Token to refresh/request your short-lived access token
         client_id: Client ID of the application.
-        client_secret: Client secret of the application.
+        client_secret: Client secret of the application. If not provided, the API Key will be used instead.
     """
 
     redirect_uri: str
     refresh_token: str
     client_id: str
-    client_secret: str
+    client_secret: NotRequired[str]
 
 
 @dataclass_json

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -84,6 +84,8 @@ class Auth(Resource):
         Returns:
             Information about the Nylas application
         """
+        if "client_secret" not in request:
+            request["client_secret"] = self._http_client.api_key
 
         request_body = dict(request)
         request_body["grant_type"] = "authorization_code"
@@ -122,6 +124,8 @@ class Auth(Resource):
         Returns:
             The response containing the new access token.
         """
+        if "client_secret" not in request:
+            request["client_secret"] = self._http_client.api_key
 
         request_body = dict(request)
         request_body["grant_type"] = "refresh_token"


### PR DESCRIPTION
# Description
`client_secret` is not required if the API Key used for the SDK and the clientId belong to the same application.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
