### PR TITLE
Fix KeyError when using tokeninfo functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Fix deserialization error when getting token info or verifying access token
+
 v6.0.0
 ----------------
 * **BREAKING CHANGE**: Python SDK v6 supports the Nylas API v3 exclusively, dropping support for any endpoints that are not available in v3

--- a/nylas/resources/auth.py
+++ b/nylas/resources/auth.py
@@ -138,7 +138,7 @@ class Auth(Resource):
 
         return self._get_token(request_body)
 
-    def id_token_info(self, id_token: str) -> TokenInfoResponse:
+    def id_token_info(self, id_token: str) -> Response[TokenInfoResponse]:
         """
         Get info about an ID token.
 
@@ -155,7 +155,7 @@ class Auth(Resource):
 
         return self._get_token_info(query_params)
 
-    def validate_access_token(self, access_token: str) -> TokenInfoResponse:
+    def validate_access_token(self, access_token: str) -> Response[TokenInfoResponse]:
         """
         Get info about an access token.
 
@@ -251,8 +251,8 @@ class Auth(Resource):
         )
         return CodeExchangeResponse.from_dict(json_response)
 
-    def _get_token_info(self, query_params: dict) -> TokenInfoResponse:
+    def _get_token_info(self, query_params: dict) -> Response[TokenInfoResponse]:
         json_response = self._http_client._execute(
             method="GET", path="/v3/connect/tokeninfo", query_params=query_params
         )
-        return TokenInfoResponse.from_dict(json_response)
+        return Response.from_dict(json_response, TokenInfoResponse)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,11 +121,14 @@ def http_client_token_exchange():
 def http_client_token_info():
     mock_http_client = Mock()
     mock_http_client._execute.return_value = {
-        "iss": "https://nylas.com",
-        "aud": "http://localhost:3030",
-        "sub": "Jaf84d88-£274-46cc-bbc9-aed7dac061c7",
-        "email": "user@example.com",
-        "iat": 1692094848,
-        "exp": 1692095173,
+        "request_id": "abc-123",
+        "data": {
+            "iss": "https://nylas.com",
+            "aud": "http://localhost:3030",
+            "sub": "Jaf84d88-£274-46cc-bbc9-aed7dac061c7",
+            "email": "user@example.com",
+            "iat": 1692094848,
+            "exp": 1692095173,
+        },
     }
     return mock_http_client

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -113,13 +113,13 @@ class TestAuth:
             path="/v3/connect/tokeninfo",
             query_params=req,
         )
-        assert type(res) is TokenInfoResponse
-        assert res.iss == "https://nylas.com"
-        assert res.aud == "http://localhost:3030"
-        assert res.sub == "Jaf84d88-£274-46cc-bbc9-aed7dac061c7"
-        assert res.email == "user@example.com"
-        assert res.iat == 1692094848
-        assert res.exp == 1692095173
+        assert type(res.data) is TokenInfoResponse
+        assert res.data.iss == "https://nylas.com"
+        assert res.data.aud == "http://localhost:3030"
+        assert res.data.sub == "Jaf84d88-£274-46cc-bbc9-aed7dac061c7"
+        assert res.data.email == "user@example.com"
+        assert res.data.iat == 1692094848
+        assert res.data.exp == 1692095173
 
     def test_url_for_oauth2(self, http_client):
         auth = Auth(http_client)


### PR DESCRIPTION
# Description
Calling `Auth.id_token_info()` and `Auth.validate_access_token()` returned a KeyError as the SDK was not handling the Response object properly.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
