### PR TITLE
Fix schema issue in the `Event` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Fix deserialization error when getting token info or verifying access token
+* Fix schema issue in the `Event` model
 
 v6.0.0
 ----------------

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -315,8 +315,6 @@ class Event:
     grant_id: str
     calendar_id: str
     busy: bool
-    created_at: int
-    updated_at: int
     participants: List[Participant]
     visibility: Visibility
     when: When = field(metadata=config(decoder=_decode_when))
@@ -338,6 +336,8 @@ class Event:
     reminders: Optional[Reminders] = None
     status: Optional[Status] = None
     capacity: Optional[int] = None
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
 
 
 class CreateParticipant(TypedDict):


### PR DESCRIPTION
# Description
This PR makes `created_at` and `updated_at` optional in the SDK to reflect the API.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
