### PR TITLE
Add email field in CodeExchangeResponse model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Fix deserialization error when getting token info or verifying access token
-* Fix schema issue in the `Event` model
+* Fix schemas issue in the `Event` and `CodeExchangeResponse` models
 
 v6.0.0
 ----------------

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -110,6 +110,7 @@ class CodeExchangeResponse:
         grant_id: ID representing the new Grant.
         scope: List of scopes associated with the token.
         expires_in: The remaining lifetime of the access token, in seconds.
+        email: Email address of the grant that is created.
         refresh_token: Returned only if the code is requested using "access_type=offline".
         id_token: A JWT that contains identity information about the user. Digitally signed by Nylas.
         token_type: Always "Bearer".
@@ -119,6 +120,7 @@ class CodeExchangeResponse:
     grant_id: str
     scope: str
     expires_in: int
+    email: Optional[str] = None
     refresh_token: Optional[str] = None
     id_token: Optional[str] = None
     token_type: Optional[str] = None


### PR DESCRIPTION
# Description
This PR adds in missing `email` field in the `CodeExchangeResponse` model.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
