### PR TITLE
Missing Webhook Secret on Webhooks.create response

### DIFF
--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -55,7 +55,8 @@ class Webhook:
     updated_at: int
     description: Optional[str] = None
 
-
+@dataclass_json
+@dataclass
 class WebhookWithSecret(Webhook):
     """
     Class representing a Nylas webhook with secret.
@@ -64,7 +65,7 @@ class WebhookWithSecret(Webhook):
         webhook_secret: A secret value used to encode the X-Nylas-Signature header on webhook requests.
     """
 
-    webhook_secret: str
+    webhook_secret: str = ""
 
 
 @dataclass_json

--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -47,7 +47,6 @@ class Webhook:
     id: str
     trigger_types: List[WebhookTriggers]
     webhook_url: str
-    webhook_secret: str
     status: WebhookStatus
     notification_email_addresses: List[str]
     status_updated_at: int

--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -47,6 +47,7 @@ class Webhook:
     id: str
     trigger_types: List[WebhookTriggers]
     webhook_url: str
+    webhook_secret: str
     status: WebhookStatus
     notification_email_addresses: List[str]
     status_updated_at: int

--- a/tests/resources/test_webhooks.py
+++ b/tests/resources/test_webhooks.py
@@ -11,6 +11,7 @@ class TestWebhooks:
             "description": "Production webhook destination",
             "trigger_types": ["calendar.created"],
             "webhook_url": "https://example.com/webhooks",
+            "webhook_secret": "sXYzyozuXhqGXeklWFCy",
             "status": "active",
             "notification_email_addresses": ["jane@example.com", "joe@example.com"],
             "status_updated_at": 1234567890,
@@ -24,6 +25,7 @@ class TestWebhooks:
         assert webhook.description == "Production webhook destination"
         assert webhook.trigger_types == ["calendar.created"]
         assert webhook.webhook_url == "https://example.com/webhooks"
+        assert webhook.webhook_secret == "sXYzyozuXhqGXeklWFCy"
         assert webhook.status == "active"
         assert webhook.notification_email_addresses == [
             "jane@example.com",

--- a/tests/resources/test_webhooks.py
+++ b/tests/resources/test_webhooks.py
@@ -11,7 +11,6 @@ class TestWebhooks:
             "description": "Production webhook destination",
             "trigger_types": ["calendar.created"],
             "webhook_url": "https://example.com/webhooks",
-            "webhook_secret": "sXYzyozuXhqGXeklWFCy",
             "status": "active",
             "notification_email_addresses": ["jane@example.com", "joe@example.com"],
             "status_updated_at": 1234567890,
@@ -25,7 +24,6 @@ class TestWebhooks:
         assert webhook.description == "Production webhook destination"
         assert webhook.trigger_types == ["calendar.created"]
         assert webhook.webhook_url == "https://example.com/webhooks"
-        assert webhook.webhook_secret == "sXYzyozuXhqGXeklWFCy"
         assert webhook.status == "active"
         assert webhook.notification_email_addresses == [
             "jane@example.com",


### PR DESCRIPTION
Added webhook_secret as part of the Webhook response

https://nylas.atlassian.net/browse/TW-2556

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
