### PR TITLE
v6.0.1 Changes to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------------
 * Added support for `round_to` field in availability response
 * Added support for `attributes` field in folder model
+* Added support for icloud as an auth provider
 
 v6.0.1
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 * Added support for `round_to` field in availability response
 * Added support for `attributes` field in folder model
 * Added support for icloud as an auth provider
+* Removed `client_id` from `detect_provider()`
 
 v6.0.1
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Added support for `round_to` field in availability response
+* Added support for `attributes` field in folder model
 
 v6.0.1
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Added support for `round_to` field in availability response
+
 v6.0.1
 ----------------
 * Fix deserialization error when getting token info or verifying access token

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -172,12 +172,10 @@ class ProviderDetectParams(TypedDict):
 
     Attributes:
         email: Email address to detect the provider for.
-        client_id: Client ID of the Nylas application.
         all_provider_types: Search by all providers regardless of created integrations. If unset, defaults to false.
     """
 
     email: str
-    client_id: str
     all_provider_types: NotRequired[bool]
 
 

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -7,7 +7,7 @@ from typing_extensions import TypedDict, NotRequired
 AccessType = Literal["online", "offline"]
 """ Literal for the access type of the authentication URL. """
 
-Provider = Literal["google", "imap", "microsoft", "virtual-calendar"]
+Provider = Literal["google", "imap", "microsoft", "icloud", "virtual-calendar"]
 """ Literal for the different authentication providers. """
 
 Prompt = Literal[

--- a/nylas/models/availability.py
+++ b/nylas/models/availability.py
@@ -128,7 +128,12 @@ class GetAvailabilityRequest(TypedDict):
             If you have a meeting starting at 9:59, the API returns times starting at 10:00. 10:00-10:30, 10:15-10:45.
         round_to_30_minutes: When set to true, the availability time slots will start at 30 minutes past or on the hour.
             For example, a free slot starting at 16:10 is considered available only from 16:30.
+            Note: This field is deprecated, use round_to instead.
         availability_rules: The rules to apply when checking availability.
+        round_to: The number of minutes to round the time slots to.
+            This allows for rounding to any multiple of 5 minutes, up to a maximum of 60 minutes.
+            The default value is set to 15 minutes.
+            When this variable is assigned a value, it overrides the behavior of the roundTo30Minutes flag,if it was set
     """
 
     start_time: int
@@ -138,3 +143,4 @@ class GetAvailabilityRequest(TypedDict):
     interval_minutes: NotRequired[int]
     round_to_30_minutes: NotRequired[bool]
     availability_rules: NotRequired[AvailabilityRules]
+    round_to: NotRequired[int]

--- a/nylas/models/folders.py
+++ b/nylas/models/folders.py
@@ -23,6 +23,10 @@ class Folder:
         child_count: The number of immediate child folders in the current folder. (Microsoft only)
         unread_count: The number of unread items inside of a folder.
         total_count: The number of items inside of a folder.
+        attributes: Common attribute descriptors shared by system folders across providers.
+            For example, Sent email folders have the `["\\Sent"]` attribute.
+            For IMAP grants, IMAP providers provide the attributes.
+            For Google and Microsoft Graph, Nylas matches system folders to a set of common attributes.
     """
 
     id: str
@@ -36,6 +40,7 @@ class Folder:
     child_count: Optional[int] = None
     unread_count: Optional[int] = None
     total_count: Optional[int] = None
+    attributes: Optional[str] = None
 
 
 class CreateFolderRequest(TypedDict):

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -365,7 +365,6 @@ class TestAuth:
         auth = Auth(mock_http_client)
         req = {
             "email": "test@gmail.com",
-            "client_id": "client-123",
             "all_provider_types": True,
         }
 

--- a/tests/resources/test_folders.py
+++ b/tests/resources/test_folders.py
@@ -17,6 +17,7 @@ class TestFolder:
             "background_color": "#039BE5",
             "text_color": "#039BE5",
             "total_count": 0,
+            "attributes": ["\\Sent"],
         }
 
         folder = Folder.from_dict(folder_json)
@@ -32,6 +33,7 @@ class TestFolder:
         assert folder.background_color == "#039BE5"
         assert folder.text_color == "#039BE5"
         assert folder.total_count == 0
+        assert folder.attributes == "['\\\\Sent']"
 
     def test_list_folders(self, http_client_list_response):
         folders = Folders(http_client_list_response)


### PR DESCRIPTION
# Description
* Added support for `roundTo` field in availability response model
* Added support for `attributes` field in folder model
* Added support for icloud as an auth provider
* Removed `clientId` from `detectProvider`

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
