### PR TITLE
Fix responses not deserializing correctly

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -29,3 +29,6 @@ generated-members=
     CodeExchangeResponse.from_dict,
     NylasApiErrorResponse.from_dict,
     NylasOAuthErrorResponse.from_dict,
+    FreeBusyError.from_dict,
+    FreeBusy.from_dict,
+    ScheduledMessage.from_dict,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 * Added support for `round_to` field in availability response
 * Added support for `attributes` field in folder model
 * Added support for icloud as an auth provider
+* Fixed issue with free busy and scheduled message responses not being deserialized correctly
 * Removed `client_id` from `detect_provider()`
 
 v6.0.1

--- a/nylas/models/messages.py
+++ b/nylas/models/messages.py
@@ -182,22 +182,9 @@ class ScheduledMessage:
         close_time: The time the message was sent or failed to send, in epoch time.
     """
 
-    schedule_id: int
+    schedule_id: str
     status: ScheduledMessageStatus
     close_time: Optional[int] = None
-
-
-@dataclass_json
-@dataclass
-class ScheduledMessagesList:
-    """
-    A list of scheduled messages.
-
-    Attributes:
-        schedules: The list of scheduled messages.
-    """
-
-    schedules: List[ScheduledMessage]
 
 
 @dataclass_json

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from nylas.handler.api_resources import (
     ListableApiResource,
@@ -12,7 +12,6 @@ from nylas.models.messages import (
     ListMessagesQueryParams,
     FindMessageQueryParams,
     UpdateMessageRequest,
-    ScheduledMessagesList,
     ScheduledMessage,
     StopScheduledMessageResponse,
 )
@@ -148,7 +147,7 @@ class Messages(
 
     def list_scheduled_messages(
         self, identifier: str
-    ) -> Response[ScheduledMessagesList]:
+    ) -> Response[List[ScheduledMessage]]:
         """
         Retrieve your scheduled messages.
 
@@ -163,7 +162,12 @@ class Messages(
             path=f"/v3/grants/{identifier}/messages/schedules",
         )
 
-        return Response.from_dict(json_response, ScheduledMessagesList)
+        data = []
+        request_id = json_response["request_id"]
+        for item in json_response["data"]:
+            data.append(ScheduledMessage.from_dict(item))
+
+        return Response(data, request_id)
 
     def find_scheduled_message(
         self, identifier: str, schedule_id: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,3 +166,26 @@ def http_client_free_busy():
         ],
     }
     return mock_http_client
+
+
+@pytest.fixture
+def http_client_list_scheduled_messages():
+    mock_http_client = Mock()
+    mock_http_client._execute.return_value = {
+        "request_id": "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5",
+        "data": [
+            {
+                "schedule_id": "8cd56334-6d95-432c-86d1-c5dab0ce98be",
+                "status": {
+                    "code": "pending",
+                    "description": "schedule send awaiting send at time",
+                },
+            },
+            {
+                "schedule_id": "rb856334-6d95-432c-86d1-c5dab0ce98be",
+                "status": {"code": "sucess", "description": "schedule send succeeded"},
+                "close_time": 1690579819,
+            },
+        ],
+    }
+    return mock_http_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,37 @@ def http_client_token_info():
         },
     }
     return mock_http_client
+
+
+@pytest.fixture
+def http_client_free_busy():
+    mock_http_client = Mock()
+    mock_http_client._execute.return_value = {
+        "request_id": "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5",
+        "data": [
+            {
+                "email": "user1@example.com",
+                "time_slots": [
+                    {
+                        "start_time": 1690898400,
+                        "end_time": 1690902000,
+                        "status": "busy",
+                        "object": "time_slot",
+                    },
+                    {
+                        "start_time": 1691064000,
+                        "end_time": 1691067600,
+                        "status": "busy",
+                        "object": "time_slot",
+                    },
+                ],
+                "object": "free_busy",
+            },
+            {
+                "email": "user2@example.com",
+                "error": "Unable to resolve e-mail address user2@example.com to an Active Directory object.",
+                "object": "error",
+            },
+        ],
+    }
+    return mock_http_client

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -166,18 +166,35 @@ class TestCalendar:
             request_body=request_body,
         )
 
-    def test_get_free_busy(self, http_client_response):
-        calendars = Calendars(http_client_response)
+    def test_get_free_busy(self, http_client_free_busy):
+        calendars = Calendars(http_client_free_busy)
         request_body = {
             "start_time": 1614556800,
             "end_time": 1614643200,
             "emails": ["test@gmail.com"],
         }
 
-        calendars.get_free_busy(identifier="abc-123", request_body=request_body)
+        response = calendars.get_free_busy(
+            identifier="abc-123", request_body=request_body
+        )
 
-        http_client_response._execute.assert_called_once_with(
+        http_client_free_busy._execute.assert_called_once_with(
             method="POST",
             path="/v3/grants/abc-123/calendars/free-busy",
             request_body=request_body,
+        )
+        assert len(response.data) == 2
+        assert response.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"
+        assert response.data[0].email == "user1@example.com"
+        assert len(response.data[0].time_slots) == 2
+        assert response.data[0].time_slots[0].start_time == 1690898400
+        assert response.data[0].time_slots[0].end_time == 1690902000
+        assert response.data[0].time_slots[0].status == "busy"
+        assert response.data[0].time_slots[1].start_time == 1691064000
+        assert response.data[0].time_slots[1].end_time == 1691067600
+        assert response.data[0].time_slots[1].status == "busy"
+        assert response.data[1].email == "user2@example.com"
+        assert (
+            response.data[1].error
+            == "Unable to resolve e-mail address user2@example.com to an Active Directory object."
         )

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -177,15 +177,24 @@ class TestMessage:
                 data=mock_encoder,
             )
 
-    def test_list_scheduled_messages(self, http_client_response):
-        messages = Messages(http_client_response)
+    def test_list_scheduled_messages(self, http_client_list_scheduled_messages):
+        messages = Messages(http_client_list_scheduled_messages)
 
-        messages.list_scheduled_messages(identifier="abc-123")
+        res = messages.list_scheduled_messages(identifier="abc-123")
 
-        http_client_response._execute.assert_called_once_with(
+        http_client_list_scheduled_messages._execute.assert_called_once_with(
             method="GET",
             path="/v3/grants/abc-123/messages/schedules",
         )
+        assert res.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"
+        assert len(res.data) == 2
+        assert res.data[0].schedule_id == "8cd56334-6d95-432c-86d1-c5dab0ce98be"
+        assert res.data[0].status.code == "pending"
+        assert res.data[0].status.description == "schedule send awaiting send at time"
+        assert res.data[1].schedule_id == "rb856334-6d95-432c-86d1-c5dab0ce98be"
+        assert res.data[1].status.code == "sucess"
+        assert res.data[1].status.description == "schedule send succeeded"
+        assert res.data[1].close_time == 1690579819
 
     def test_find_scheduled_message(self, http_client_response):
         messages = Messages(http_client_response)


### PR DESCRIPTION
# Description
This PR fixes the errors encountered when using the free busy and scheduled messages endpoints. Closes #347.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
