### PR TITLE
Improved message sending and draft create/update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Improved message sending and draft create/update performance
+
 v6.1.0
 ----------------
 * Added support for `round_to` field in availability response

--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -54,6 +54,7 @@ class Webhook:
     updated_at: int
     description: Optional[str] = None
 
+
 @dataclass_json
 @dataclass
 class WebhookWithSecret(Webhook):

--- a/nylas/utils/file_utils.py
+++ b/nylas/utils/file_utils.py
@@ -8,6 +8,10 @@ from requests_toolbelt import MultipartEncoder
 from nylas.models.attachments import CreateAttachmentRequest
 
 
+MAXIMUM_JSON_ATTACHMENT_SIZE = 3 * 1024 * 1024
+"""The maximum size of an attachment that can be sent using json."""
+
+
 def attach_file_request_builder(file_path) -> CreateAttachmentRequest:
     """
     Build a request to attach a file.

--- a/tests/resources/test_drafts.py
+++ b/tests/resources/test_drafts.py
@@ -102,12 +102,58 @@ class TestDraft:
 
     def test_create_draft(self, http_client_response):
         drafts = Drafts(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+        }
+
+        drafts.create(identifier="abc-123", request_body=request_body)
+
+        http_client_response._execute.assert_called_once_with(
+            "POST", "/v3/grants/abc-123/drafts", None, None, request_body
+        )
+
+    def test_create_draft_small_attachment(self, http_client_response):
+        drafts = Drafts(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3,
+                },
+            ],
+        }
+
+        drafts.create(identifier="abc-123", request_body=request_body)
+
+        http_client_response._execute.assert_called_once_with(
+            "POST", "/v3/grants/abc-123/drafts", None, None, request_body
+        )
+
+    def test_create_draft_large_attachment(self, http_client_response):
+        drafts = Drafts(http_client_response)
         mock_encoder = Mock()
         request_body = {
             "subject": "Hello from Nylas!",
             "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
             "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
             "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3 * 1024 * 1024,
+                },
+            ],
         }
 
         with patch(
@@ -123,12 +169,70 @@ class TestDraft:
 
     def test_update_draft(self, http_client_response):
         drafts = Drafts(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+        }
+
+        drafts.update(
+            identifier="abc-123", draft_id="draft-123", request_body=request_body
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "PUT",
+            "/v3/grants/abc-123/drafts/draft-123",
+            None,
+            None,
+            request_body,
+        )
+
+    def test_update_draft_small_attachment(self, http_client_response):
+        drafts = Drafts(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3,
+                },
+            ],
+        }
+
+        drafts.update(
+            identifier="abc-123", draft_id="draft-123", request_body=request_body
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "PUT",
+            "/v3/grants/abc-123/drafts/draft-123",
+            None,
+            None,
+            request_body,
+        )
+
+    def test_update_draft_large_attachment(self, http_client_response):
+        drafts = Drafts(http_client_response)
         mock_encoder = Mock()
         request_body = {
             "subject": "Hello from Nylas!",
             "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
             "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
             "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3 * 1024 * 1024,
+                },
+            ],
         }
 
         with patch(

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -158,12 +158,64 @@ class TestMessage:
 
     def test_send_message(self, http_client_response):
         messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=request_body,
+            data=None,
+        )
+
+    def test_send_message_small_attachment(self, http_client_response):
+        messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3,
+                },
+            ],
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=request_body,
+            data=None,
+        )
+
+    def test_send_message_large_attachment(self, http_client_response):
+        messages = Messages(http_client_response)
         mock_encoder = Mock()
         request_body = {
             "subject": "Hello from Nylas!",
             "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
             "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
             "body": "This is the body of my draft message.",
+            "attachments": [
+                {
+                    "filename": "file1.txt",
+                    "content_type": "text/plain",
+                    "content": "this is a file",
+                    "size": 3 * 1024 * 1024,
+                },
+            ],
         }
 
         with patch(
@@ -174,6 +226,7 @@ class TestMessage:
             http_client_response._execute.assert_called_once_with(
                 method="POST",
                 path="/v3/grants/abc-123/messages/send",
+                request_body=None,
                 data=mock_encoder,
             )
 


### PR DESCRIPTION
# Description
This PR improves message send/draft create/update performance by always defaulting to application/json instead of multipart. Multipart will only be used for when a request contains a total attachments size of 3mb or higher.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
