### PR TITLE
Change default timeout to match API (90 seconds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Change default timeout to match API (90 seconds)
+
 v6.1.0
 ----------------
 * Added support for `round_to` field in availability response

--- a/nylas/client.py
+++ b/nylas/client.py
@@ -26,7 +26,7 @@ class Client:
     """
 
     def __init__(
-        self, api_key: str, api_uri: str = DEFAULT_SERVER_URL, timeout: int = 30
+        self, api_key: str, api_uri: str = DEFAULT_SERVER_URL, timeout: int = 90
     ):
         """
         Initialize the Nylas API client.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ class TestClient:
 
         assert client.api_key == "test-key"
         assert client.api_uri == "https://api.us.nylas.com"
-        assert client.http_client.timeout == 30
+        assert client.http_client.timeout == 90
 
     def test_client_auth_property(self, client):
         assert client.auth is not None


### PR DESCRIPTION
# Description
The API's default timeout is 90 seconds, so it's best we match that. We have updated the default value to match this, user can still override the default.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
