### PR TITLE
Add support for detect provider endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
         run: pip install black
 
       - name: Run black
-        run: black --check --extend-exclude="/examples" .
+        run: black --check --diff --extend-exclude="/examples" .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ on:
   # but only for the main branch
   push:
     branches:
-      - main
+      - v5
   pull_request:
     branches:
-      - main
+      - v5
 
 jobs:
   pytest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add support for `view` parameter in `Threads.search()`
+* Add support for detect_provider endpoint
 
 v5.14.1
 ----------------

--- a/examples/hosted-oauth/server.py
+++ b/examples/hosted-oauth/server.py
@@ -71,6 +71,7 @@ app.register_blueprint(nylas_bp, url_prefix="/login")
 # Teach Flask how to find out that it's behind an ngrok proxy
 app.wsgi_app = ProxyFix(app.wsgi_app)
 
+
 # Define what Flask should do when someone visits the root URL of this website.
 @app.route("/")
 def index():

--- a/examples/native-authentication-gmail/server.py
+++ b/examples/native-authentication-gmail/server.py
@@ -90,6 +90,7 @@ app.register_blueprint(google_bp, url_prefix="/login")
 # Teach Flask how to find out that it's behind an ngrok proxy
 app.wsgi_app = ProxyFix(app.wsgi_app)
 
+
 # Define what Flask should do when someone visits the root URL of this website.
 @app.route("/")
 def index():

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -664,9 +664,9 @@ class APIClient(json.JSONEncoder):
 
     def _create_resource(self, cls, data, **kwargs):
         name = "{prefix}{path}".format(
-            prefix="/{}/{}".format(cls.api_root, self.client_id)
-            if cls.api_root
-            else "",
+            prefix=(
+                "/{}/{}".format(cls.api_root, self.client_id) if cls.api_root else ""
+            ),
             path="/{}".format(cls.collection_name) if cls.collection_name else "",
         )
         url = (
@@ -696,9 +696,9 @@ class APIClient(json.JSONEncoder):
 
     def _create_resources(self, cls, data):
         name = "{prefix}{path}".format(
-            prefix="/{}/{}".format(cls.api_root, self.client_id)
-            if cls.api_root
-            else "",
+            prefix=(
+                "/{}/{}".format(cls.api_root, self.client_id) if cls.api_root else ""
+            ),
             path="/{}".format(cls.collection_name) if cls.collection_name else "",
         )
         url = URLObject(self.api_server).with_path("{name}".format(name=name))
@@ -719,9 +719,9 @@ class APIClient(json.JSONEncoder):
 
     def _delete_resource(self, cls, resource_id, data=None, **kwargs):
         name = "{prefix}{path}".format(
-            prefix="/{}/{}".format(cls.api_root, self.client_id)
-            if cls.api_root
-            else "",
+            prefix=(
+                "/{}/{}".format(cls.api_root, self.client_id) if cls.api_root else ""
+            ),
             path="/{}".format(cls.collection_name) if cls.collection_name else "",
         )
         url = (
@@ -740,9 +740,9 @@ class APIClient(json.JSONEncoder):
         if path is None:
             path = cls.collection_name
         name = "{prefix}{path}".format(
-            prefix="/{}/{}".format(cls.api_root, self.client_id)
-            if cls.api_root
-            else "",
+            prefix=(
+                "/{}/{}".format(cls.api_root, self.client_id) if cls.api_root else ""
+            ),
             path="/{}".format(path) if path else "",
         )
 

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -614,7 +614,7 @@ class APIClient(json.JSONEncoder):
         stream=False,
         path=None,
         stream_timeout=None,
-        **filters,
+        **filters
     ):
         """Get an individual REST resource"""
         if path is None:

--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -217,6 +217,27 @@ class APIClient(json.JSONEncoder):
         self.access_token = results["access_token"]
         return results
 
+    def detect_provider(self, email):
+        """
+        Detect the provider for a given email address.
+
+        Args:
+            email (str): The email address you want to check
+
+        Returns:
+            dict: The response from the API containing the provider, if found
+        """
+        url = "{api_server}/connect/detect-provider".format(api_server=self.api_server)
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "email_address": email,
+        }
+
+        resp = self._request(HttpMethod.POST, url, json=data)
+        _validate(resp)
+        return resp.json()
+
     def token_for_code(self, code):
         """
         Exchange an authorization code for an access token
@@ -593,7 +614,7 @@ class APIClient(json.JSONEncoder):
         stream=False,
         path=None,
         stream_timeout=None,
-        **filters
+        **filters,
     ):
         """Get an individual REST resource"""
         if path is None:


### PR DESCRIPTION
# Description
This PR adds support for the `/connect/detect_provider` endpint.

# Usage
To get the provider:

```python
from nylas import APIClient

# Pass the access token to the Nylas client
nylas = APIClient(
    NYLAS_CLIENT_ID,
    NYLAS_CLIENT_SECRET,
    ACCESS_TOKEN
)

# Pass the email to the detect provider function
provider = nylas.detect_provider("example@email.com")
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
