### PR TITLE
Fix error when attempting to update labels or folders on a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Add support for `view` parameter in `Threads.search()`
+* Fix error when attempting to update labels or folders on a message
 
 v5.14.1
 ----------------

--- a/nylas/client/restful_models.py
+++ b/nylas/client/restful_models.py
@@ -239,7 +239,7 @@ class Message(NylasAPIObject):
         return []
 
     def update_folder(self, folder_id):
-        update = {"folder": folder_id}
+        update = {"folder_id": folder_id}
         new_obj = self.api._update_resource(self.cls, self.id, update)
         for attr in self.cls.attrs:
             if hasattr(new_obj, attr):
@@ -248,7 +248,7 @@ class Message(NylasAPIObject):
 
     def update_labels(self, label_ids=None):
         label_ids = label_ids or []
-        update = {"labels": label_ids}
+        update = {"label_ids": label_ids}
         new_obj = self.api._update_resource(self.cls, self.id, update)
         for attr in self.cls.attrs:
             if hasattr(new_obj, attr):


### PR DESCRIPTION
# Description
This PR fixes the `Invalid 'label_id'` and `Invalid 'folder_id'` errors encountered when trying to update a message.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
