### PR TITLE
Python SDK - Add missing Webhook triggers

### DIFF
--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -30,8 +30,6 @@ class WebhookTriggers(str, Enum):
     MESSAGE_OPENED = "message.opened"
     MESSAGE_LINK_CLICKED = "message.link_clicked"
     THREAD_REPLIED = "thread.replied"
-    
-    
 
 
 @dataclass_json

--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -24,6 +24,14 @@ class WebhookTriggers(str, Enum):
     GRANT_EXPIRED = "grant.expired"
     MESSAGE_SEND_SUCCESS = "message.send_success"
     MESSAGE_SEND_FAILED = "message.send_failed"
+    MESSAGE_BOUNCE_DETECTED = "message.bounce_detected"
+    MESSAGE_CREATED = "message.created"
+    MESSAGE_UPDATED = "message.updated"
+    MESSAGE_OPENED = "message.opened"
+    MESSAGE_LINK_CLICKED = "message.link_clicked"
+    THREAD_REPLIED = "thread.replied"
+    
+    
 
 
 @dataclass_json


### PR DESCRIPTION
Added message_bouce_detected, message_created, message_updated, message_opened, message_link_clicked, thread.replied

https://nylas.atlassian.net/browse/TW-2782

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
