### PR TITLE
Add new fields; provider for code exchange and custom_headers for drafts/messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Added support for adding custom headers to outgoing requests
+* Added support for `provider` field in code exchange response
+
 v6.1.1
 ----------------
 * Improved message sending and draft create/update performance

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -114,6 +114,7 @@ class CodeExchangeResponse:
         refresh_token: Returned only if the code is requested using "access_type=offline".
         id_token: A JWT that contains identity information about the user. Digitally signed by Nylas.
         token_type: Always "Bearer".
+        provider: The provider that the code was exchanged with.
     """
 
     access_token: str
@@ -124,6 +125,7 @@ class CodeExchangeResponse:
     refresh_token: Optional[str] = None
     id_token: Optional[str] = None
     token_type: Optional[str] = None
+    provider: Optional[Provider] = None
 
 
 @dataclass_json

--- a/nylas/models/drafts.py
+++ b/nylas/models/drafts.py
@@ -57,6 +57,19 @@ class TrackingOptions(TypedDict):
     thread_replies: NotRequired[bool]
 
 
+class CustomHeader(TypedDict):
+    """
+    A key-value pair representing a header that can be added to drafts and outgoing messages.
+
+    Attributes:
+        name: The name of the custom header.
+        value: The value of the custom header.
+    """
+
+    name: str
+    value: str
+
+
 class CreateDraftRequest(TypedDict):
     """
     A request to create a draft.
@@ -73,6 +86,7 @@ class CreateDraftRequest(TypedDict):
         send_at: Unix timestamp to send the message at.
         reply_to_message_id: The ID of the message that you are replying to.
         tracking_options: Options for tracking opens, links, and thread replies.
+        custom_headers: Custom headers to add to the message.
     """
 
     body: NotRequired[str]
@@ -86,6 +100,7 @@ class CreateDraftRequest(TypedDict):
     send_at: NotRequired[int]
     reply_to_message_id: NotRequired[str]
     tracking_options: NotRequired[TrackingOptions]
+    custom_headers: NotRequired[List[CustomHeader]]
 
 
 UpdateDraftRequest = CreateDraftRequest
@@ -148,6 +163,7 @@ class SendMessageRequest(CreateDraftRequest):
         send_at (NotRequired[int]): Unix timestamp to send the message at.
         reply_to_message_id (NotRequired[str]): The ID of the message that you are replying to.
         tracking_options (NotRequired[TrackingOptions]): Options for tracking opens, links, and thread replies.
+        custom_headers(NotRequired[List[CustomHeader]]): Custom headers to add to the message.
         use_draft: Whether or not to use draft support. This is primarily used when dealing with large attachments.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,7 @@ def http_client_token_exchange():
         "scope": "https://www.googleapis.com/auth/gmail.readonly profile",
         "token_type": "Bearer",
         "grant_id": "grant_123",
+        "provider": "google",
     }
     return mock_http_client
 

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -99,6 +99,7 @@ class TestAuth:
         assert res.scope == "https://www.googleapis.com/auth/gmail.readonly profile"
         assert res.token_type == "Bearer"
         assert res.grant_id == "grant_123"
+        assert res.provider == "google"
 
     def test_get_token_info(self, http_client_token_info):
         auth = Auth(http_client_token_info)


### PR DESCRIPTION
# Description
This PR adds two new fields:
- `provider` to `CodeExchangeResponse`
- `custom_headers` to `CreateDraftRequest`, `UpdateDraftRequest`, and `SendMessageRequest`

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
