### PR TITLE
Fixed issue where attachments < 3mb were not being encoded correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 * Added clean messages support
 * Added additional webhook triggers
 * Made event visibility optional to support iCloud events
+* Fixed issue where attachments < 3mb were not being encoded correctly
 
 v6.1.1
 ----------------

--- a/nylas/resources/drafts.py
+++ b/nylas/resources/drafts.py
@@ -1,3 +1,4 @@
+import io
 from typing import Optional
 
 from nylas.handler.api_resources import (
@@ -15,7 +16,11 @@ from nylas.models.drafts import (
 )
 from nylas.models.messages import Message
 from nylas.models.response import ListResponse, Response, DeleteResponse
-from nylas.utils.file_utils import _build_form_request, MAXIMUM_JSON_ATTACHMENT_SIZE
+from nylas.utils.file_utils import (
+    _build_form_request,
+    MAXIMUM_JSON_ATTACHMENT_SIZE,
+    encode_stream_to_base64,
+)
 
 
 class Drafts(
@@ -99,6 +104,11 @@ class Drafts(
 
             return Response.from_dict(json_response, Draft)
 
+        # Encode the content of the attachments to base64
+        for attachment in request_body.get("attachments", []):
+            if issubclass(type(attachment["content"]), io.IOBase):
+                attachment["content"] = encode_stream_to_base64(attachment["content"])
+
         return super().create(
             path=path,
             response_type=Draft,
@@ -137,6 +147,11 @@ class Drafts(
             )
 
             return Response.from_dict(json_response, Draft)
+
+        # Encode the content of the attachments to base64
+        for attachment in request_body.get("attachments", []):
+            if issubclass(type(attachment["content"]), io.IOBase):
+                attachment["content"] = encode_stream_to_base64(attachment["content"])
 
         return super().update(
             path=path,

--- a/nylas/utils/file_utils.py
+++ b/nylas/utils/file_utils.py
@@ -1,7 +1,9 @@
+import base64
 import json
 import mimetypes
 import os
 from pathlib import Path
+from typing import BinaryIO
 
 from requests_toolbelt import MultipartEncoder
 
@@ -34,6 +36,21 @@ def attach_file_request_builder(file_path) -> CreateAttachmentRequest:
         "content": file_stream,
         "size": size,
     }
+
+
+def encode_stream_to_base64(binary_stream: BinaryIO) -> str:
+    """
+    Encode the content of a binary stream to a base64 string.
+
+    Attributes:
+        binary_stream: The binary stream to encode.
+
+    Returns:
+        The base64 encoded content of the binary stream.
+    """
+    binary_stream.seek(0)
+    binary_content = binary_stream.read()
+    return base64.b64encode(binary_content).decode("utf-8")
 
 
 def _build_form_request(request_body: dict) -> MultipartEncoder:


### PR DESCRIPTION
# Description
This PR fixes the encoding for attachments (<3mb) being sent via application/json. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
