### PR TITLE
Added support for overriding various fields of outgoing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Added support for adding custom headers to outgoing requests
+* Added support for overriding various fields of outgoing requests
 * Added support for `provider` field in code exchange response
 * Added clean messages support
 * Added additional webhook triggers

--- a/nylas/config.py
+++ b/nylas/config.py
@@ -1,4 +1,7 @@
 from enum import Enum
+from typing import TypedDict
+
+from typing_extensions import NotRequired
 
 
 class Region(str, Enum):
@@ -8,6 +11,23 @@ class Region(str, Enum):
 
     US = "us"
     EU = "eu"
+
+
+class RequestOverrides(TypedDict):
+    """
+    Overrides to use for an outgoing request to the Nylas API
+
+    Attributes:
+        api_key: The API key to use for the request.
+        api_uri: The API URI to use for the request.
+        timeout: The timeout to use for the request.
+        headers: Additional headers to include in the request.
+    """
+
+    api_key: NotRequired[str]
+    api_uri: NotRequired[str]
+    timeout: NotRequired[int]
+    headers: NotRequired[dict]
 
 
 DEFAULT_REGION = Region.US

--- a/nylas/handler/api_resources.py
+++ b/nylas/handler/api_resources.py
@@ -8,10 +8,16 @@ from nylas.resources.resource import Resource
 
 class ListableApiResource(Resource):
     def list(
-        self, path, response_type, headers=None, query_params=None, request_body=None
+        self,
+        path,
+        response_type,
+        headers=None,
+        query_params=None,
+        request_body=None,
+        overrides=None,
     ) -> ListResponse:
         response_json = self._http_client._execute(
-            "GET", path, headers, query_params, request_body
+            "GET", path, headers, query_params, request_body, overrides=overrides
         )
 
         return ListResponse.from_dict(response_json, response_type)
@@ -19,10 +25,16 @@ class ListableApiResource(Resource):
 
 class FindableApiResource(Resource):
     def find(
-        self, path, response_type, headers=None, query_params=None, request_body=None
+        self,
+        path,
+        response_type,
+        headers=None,
+        query_params=None,
+        request_body=None,
+        overrides=None,
     ) -> Response:
         response_json = self._http_client._execute(
-            "GET", path, headers, query_params, request_body
+            "GET", path, headers, query_params, request_body, overrides=overrides
         )
 
         return Response.from_dict(response_json, response_type)
@@ -30,10 +42,16 @@ class FindableApiResource(Resource):
 
 class CreatableApiResource(Resource):
     def create(
-        self, path, response_type, headers=None, query_params=None, request_body=None
+        self,
+        path,
+        response_type,
+        headers=None,
+        query_params=None,
+        request_body=None,
+        overrides=None,
     ) -> Response:
         response_json = self._http_client._execute(
-            "POST", path, headers, query_params, request_body
+            "POST", path, headers, query_params, request_body, overrides=overrides
         )
 
         return Response.from_dict(response_json, response_type)
@@ -48,9 +66,10 @@ class UpdatableApiResource(Resource):
         query_params=None,
         request_body=None,
         method="PUT",
+        overrides=None,
     ):
         response_json = self._http_client._execute(
-            method, path, headers, query_params, request_body
+            method, path, headers, query_params, request_body, overrides=overrides
         )
 
         return Response.from_dict(response_json, response_type)
@@ -64,11 +83,12 @@ class DestroyableApiResource(Resource):
         headers=None,
         query_params=None,
         request_body=None,
+        overrides=None,
     ):
         if response_type is None:
             response_type = DeleteResponse
 
         response_json = self._http_client._execute(
-            "DELETE", path, headers, query_params, request_body
+            "DELETE", path, headers, query_params, request_body, overrides=overrides
         )
         return response_type.from_dict(response_json)

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -83,7 +83,7 @@ class HttpClient:
         overrides=None,
     ) -> dict:
         request = self._build_request(
-            method, path, headers, query_params, request_body, data
+            method, path, headers, query_params, request_body, data, overrides
         )
         try:
             response = self.session.request(
@@ -107,8 +107,9 @@ class HttpClient:
         headers=None,
         query_params=None,
         stream=False,
+        overrides=None,
     ) -> Union[bytes, Response]:
-        request = self._build_request("GET", path, headers, query_params)
+        request = self._build_request("GET", path, headers, query_params, overrides)
         try:
             response = self.session.request(
                 request["method"],

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -85,19 +85,21 @@ class HttpClient:
         request = self._build_request(
             method, path, headers, query_params, request_body, data, overrides
         )
+
+        timeout = self.timeout
+        if overrides and overrides.get("timeout"):
+            timeout = overrides["timeout"]
         try:
             response = self.session.request(
                 request["method"],
                 request["url"],
                 headers=request["headers"],
                 json=request_body,
-                timeout=self.timeout,
+                timeout=timeout,
                 data=data,
             )
         except requests.exceptions.Timeout as exc:
-            raise NylasSdkTimeoutError(
-                url=request["url"], timeout=self.timeout
-            ) from exc
+            raise NylasSdkTimeoutError(url=request["url"], timeout=timeout) from exc
 
         return _validate_response(response)
 
@@ -110,12 +112,16 @@ class HttpClient:
         overrides=None,
     ) -> Union[bytes, Response]:
         request = self._build_request("GET", path, headers, query_params, overrides)
+
+        timeout = self.timeout
+        if overrides and overrides.get("timeout"):
+            timeout = overrides["timeout"]
         try:
             response = self.session.request(
                 request["method"],
                 request["url"],
                 headers=request["headers"],
-                timeout=self.timeout,
+                timeout=timeout,
                 stream=stream,
             )
 
@@ -125,9 +131,7 @@ class HttpClient:
 
             return response.content if response.content else None
         except requests.exceptions.Timeout as exc:
-            raise NylasSdkTimeoutError(
-                url=request["url"], timeout=self.timeout
-            ) from exc
+            raise NylasSdkTimeoutError(url=request["url"], timeout=timeout) from exc
 
     def _build_request(
         self,

--- a/nylas/resources/applications.py
+++ b/nylas/resources/applications.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.models.application_details import ApplicationDetails
 from nylas.models.response import Response
 from nylas.resources.redirect_uris import RedirectUris
@@ -22,15 +23,18 @@ class Applications(Resource):
         """
         return RedirectUris(self._http_client)
 
-    def info(self) -> Response[ApplicationDetails]:
+    def info(self, overrides: RequestOverrides = None) -> Response[ApplicationDetails]:
         """
         Get the application information.
+
+        Args:
+            overrides: The query parameters to include in the request.
 
         Returns:
             Response: The application information.
         """
 
         json_response = self._http_client._execute(
-            method="GET", path="/v3/applications"
+            method="GET", path="/v3/applications", overrides=overrides
         )
         return Response.from_dict(json_response, ApplicationDetails)

--- a/nylas/resources/attachments.py
+++ b/nylas/resources/attachments.py
@@ -1,5 +1,6 @@
 from requests import Response
 
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     FindableApiResource,
 )
@@ -21,6 +22,7 @@ class Attachments(
         identifier: str,
         attachment_id: str,
         query_params: FindAttachmentQueryParams,
+        overrides: RequestOverrides = None,
     ) -> NylasResponse[Attachment]:
         """
         Return metadata of an attachment.
@@ -29,6 +31,7 @@ class Attachments(
             identifier: The identifier of the Grant to act upon.
             attachment_id: The id of the attachment to retrieve.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The attachment metadata.
@@ -37,6 +40,7 @@ class Attachments(
             path=f"/v3/grants/{identifier}/attachments/{attachment_id}",
             response_type=Attachment,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def download(
@@ -44,6 +48,7 @@ class Attachments(
         identifier: str,
         attachment_id: str,
         query_params: FindAttachmentQueryParams,
+        overrides: RequestOverrides = None,
     ) -> Response:
         """
         Download the attachment data.
@@ -56,6 +61,7 @@ class Attachments(
             identifier: The identifier of the Grant to act upon.
             attachment_id: The id of the attachment to download.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The Response object containing the file data.
@@ -78,6 +84,7 @@ class Attachments(
             path=f"/v3/grants/{identifier}/attachments/{attachment_id}/download",
             query_params=query_params,
             stream=True,
+            overrides=overrides,
         )
 
     def download_bytes(
@@ -85,6 +92,7 @@ class Attachments(
         identifier: str,
         attachment_id: str,
         query_params: FindAttachmentQueryParams,
+        overrides: RequestOverrides = None,
     ) -> bytes:
         """
         Download the attachment as a byte array.
@@ -93,6 +101,7 @@ class Attachments(
             identifier: The identifier of the Grant to act upon.
             attachment_id: The id of the attachment to download.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The raw file data.
@@ -101,4 +110,5 @@ class Attachments(
             path=f"/v3/grants/{identifier}/attachments/{attachment_id}/download",
             query_params=query_params,
             stream=False,
+            overrides=overrides,
         )

--- a/nylas/resources/calendars.py
+++ b/nylas/resources/calendars.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -40,7 +41,10 @@ class Calendars(
     """
 
     def list(
-        self, identifier: str, query_params: ListCalendarsQueryParams = None
+        self,
+        identifier: str,
+        query_params: ListCalendarsQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Calendar]:
         """
         Return all Calendars.
@@ -48,6 +52,7 @@ class Calendars(
         Args:
             identifier: The identifier of the Grant to act upon.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The list of Calendars.
@@ -57,9 +62,12 @@ class Calendars(
             path=f"/v3/grants/{identifier}/calendars",
             query_params=query_params,
             response_type=Calendar,
+            overrides=overrides,
         )
 
-    def find(self, identifier: str, calendar_id: str) -> Response[Calendar]:
+    def find(
+        self, identifier: str, calendar_id: str, overrides: RequestOverrides = None
+    ) -> Response[Calendar]:
         """
         Return a Calendar.
 
@@ -67,6 +75,7 @@ class Calendars(
             identifier: The identifier of the Grant to act upon.
             calendar_id: The ID of the Calendar to retrieve.
                 Use "primary" to refer to the primary Calendar associated with the Grant.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The Calendar.
@@ -74,10 +83,14 @@ class Calendars(
         return super().find(
             path=f"/v3/grants/{identifier}/calendars/{calendar_id}",
             response_type=Calendar,
+            overrides=overrides,
         )
 
     def create(
-        self, identifier: str, request_body: CreateCalendarRequest
+        self,
+        identifier: str,
+        request_body: CreateCalendarRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Calendar]:
         """
         Create a Calendar.
@@ -85,6 +98,7 @@ class Calendars(
         Args:
             identifier: The identifier of the Grant to act upon.
             request_body: The values to create the Calendar with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The created Calendar.
@@ -93,10 +107,15 @@ class Calendars(
             path=f"/v3/grants/{identifier}/calendars",
             response_type=Calendar,
             request_body=request_body,
+            overrides=overrides,
         )
 
     def update(
-        self, identifier: str, calendar_id: str, request_body: UpdateCalendarRequest
+        self,
+        identifier: str,
+        calendar_id: str,
+        request_body: UpdateCalendarRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Calendar]:
         """
         Update a Calendar.
@@ -106,6 +125,7 @@ class Calendars(
             calendar_id: The ID of the Calendar to update.
                 Use "primary" to refer to the primary Calendar associated with the Grant.
             request_body: The values to update the Calendar with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The updated Calendar.
@@ -114,9 +134,12 @@ class Calendars(
             path=f"/v3/grants/{identifier}/calendars/{calendar_id}",
             response_type=Calendar,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, calendar_id: str) -> DeleteResponse:
+    def destroy(
+        self, identifier: str, calendar_id: str, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a Calendar.
 
@@ -124,20 +147,24 @@ class Calendars(
             identifier: The identifier of the Grant to act upon.
             calendar_id: The ID of the Calendar to delete.
                 Use "primary" to refer to the primary Calendar associated with the Grant.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The deletion response.
         """
-        return super().destroy(path=f"/v3/grants/{identifier}/calendars/{calendar_id}")
+        return super().destroy(
+            path=f"/v3/grants/{identifier}/calendars/{calendar_id}", overrides=overrides
+        )
 
     def get_availability(
-        self, request_body: GetAvailabilityRequest
+        self, request_body: GetAvailabilityRequest, overrides: RequestOverrides = None
     ) -> Response[GetAvailabilityResponse]:
         """
         Get availability for a Calendar.
 
         Args:
             request_body: The request body to send to the API.
+            overrides: The request overrides to use for the request.
 
         Returns:
             Response: The availability response from the API.
@@ -146,12 +173,16 @@ class Calendars(
             method="POST",
             path="/v3/calendars/availability",
             request_body=request_body,
+            overrides=overrides,
         )
 
         return Response.from_dict(json_response, GetAvailabilityResponse)
 
     def get_free_busy(
-        self, identifier: str, request_body: GetFreeBusyRequest
+        self,
+        identifier: str,
+        request_body: GetFreeBusyRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[List[GetFreeBusyResponse]]:
         """
         Get free/busy info for a Calendar.
@@ -159,6 +190,7 @@ class Calendars(
         Args:
             identifier: The grant ID or email account to get free/busy for.
             request_body: The request body to send to the API.
+            overrides: The request overrides to use for the request.
 
         Returns:
             Response: The free/busy response from the API.
@@ -167,6 +199,7 @@ class Calendars(
             method="POST",
             path=f"/v3/grants/{identifier}/calendars/free-busy",
             request_body=request_body,
+            overrides=overrides,
         )
 
         data = []

--- a/nylas/resources/connectors.py
+++ b/nylas/resources/connectors.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.resources.credentials import Credentials
 
 from nylas.handler.api_resources import (
@@ -43,28 +44,37 @@ class Connectors(
         return Credentials(self._http_client)
 
     def list(
-        self, query_params: ListConnectorQueryParams = None
+        self,
+        query_params: ListConnectorQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Connector]:
         """
         Return all Connectors.
 
         Args:
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use.
 
         Returns:
             The list of Connectors.
         """
 
         return super().list(
-            path="/v3/connectors", response_type=Connector, query_params=query_params
+            path="/v3/connectors",
+            response_type=Connector,
+            query_params=query_params,
+            overrides=overrides,
         )
 
-    def find(self, provider: Provider) -> Response[Connector]:
+    def find(
+        self, provider: Provider, overrides: RequestOverrides = None
+    ) -> Response[Connector]:
         """
         Return a connector associated with the provider.
 
         Args:
             provider: The provider associated to the connector to retrieve.
+            overrides: The request overrides to use.
 
         Returns:
             The Connector.
@@ -72,14 +82,18 @@ class Connectors(
         return super().find(
             path=f"/v3/connectors/{provider}",
             response_type=Connector,
+            overrides=overrides,
         )
 
-    def create(self, request_body: CreateConnectorRequest) -> Response[Connector]:
+    def create(
+        self, request_body: CreateConnectorRequest, overrides: RequestOverrides = None
+    ) -> Response[Connector]:
         """
         Create a connector.
 
         Args:
             request_body: The values to create the connector with.
+            overrides: The request overrides to use.
 
         Returns:
             The created connector.
@@ -88,10 +102,14 @@ class Connectors(
             path="/v3/connectors",
             request_body=request_body,
             response_type=Connector,
+            overrides=overrides,
         )
 
     def update(
-        self, provider: Provider, request_body: UpdateConnectorRequest
+        self,
+        provider: Provider,
+        request_body: UpdateConnectorRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Connector]:
         """
         Create a connector.
@@ -99,6 +117,7 @@ class Connectors(
         Args:
             provider: The provider associated to the connector to update.
             request_body: The values to update the connector with.
+            overrides: The request overrides to use.
 
         Returns:
             The created connector.
@@ -108,16 +127,20 @@ class Connectors(
             request_body=request_body,
             response_type=Connector,
             method="PATCH",
+            overrides=overrides,
         )
 
-    def destroy(self, provider: Provider) -> DeleteResponse:
+    def destroy(
+        self, provider: Provider, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a connector.
 
         Args:
             provider: The provider associated to the connector to delete.
+            overrides: The request overrides to use.
 
         Returns:
             The deleted connector.
         """
-        return super().destroy(path=f"/v3/connectors/{provider}")
+        return super().destroy(path=f"/v3/connectors/{provider}", overrides=overrides)

--- a/nylas/resources/contacts.py
+++ b/nylas/resources/contacts.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -31,7 +32,10 @@ class Contacts(
     """
 
     def list(
-        self, identifier: str, query_params: ListContactsQueryParams = None
+        self,
+        identifier: str,
+        query_params: ListContactsQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Contact]:
         """
         Return all Contacts.
@@ -39,6 +43,7 @@ class Contacts(
         Attributes:
             identifier: The identifier of the Grant to act upon.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The list of contacts.
@@ -48,6 +53,7 @@ class Contacts(
             path=f"/v3/grants/{identifier}/contacts",
             query_params=query_params,
             response_type=Contact,
+            overrides=overrides,
         )
 
     def find(
@@ -55,6 +61,7 @@ class Contacts(
         identifier: str,
         contact_id: str,
         query_params: FindContactQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> Response[Contact]:
         """
         Return a Contact.
@@ -63,6 +70,7 @@ class Contacts(
             identifier: The identifier of the Grant to act upon.
             contact_id: The ID of the contact to retrieve.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The contact.
@@ -71,10 +79,14 @@ class Contacts(
             path=f"/v3/grants/{identifier}/contacts/{contact_id}",
             response_type=Contact,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def create(
-        self, identifier: str, request_body: CreateContactRequest
+        self,
+        identifier: str,
+        request_body: CreateContactRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Contact]:
         """
         Create a Contact.
@@ -82,6 +94,7 @@ class Contacts(
         Attributes:
             identifier: The identifier of the Grant to act upon.
             request_body: The values to create the Contact with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The created contact.
@@ -90,10 +103,15 @@ class Contacts(
             path=f"/v3/grants/{identifier}/contacts",
             response_type=Contact,
             request_body=request_body,
+            overrides=overrides,
         )
 
     def update(
-        self, identifier: str, contact_id: str, request_body: UpdateContactRequest
+        self,
+        identifier: str,
+        contact_id: str,
+        request_body: UpdateContactRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Contact]:
         """
         Update a Contact.
@@ -103,6 +121,7 @@ class Contacts(
             contact_id: The ID of the Contact to update.
                 Use "primary" to refer to the primary Contact associated with the Grant.
             request_body: The values to update the Contact with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The updated contact.
@@ -111,9 +130,15 @@ class Contacts(
             path=f"/v3/grants/{identifier}/contacts/{contact_id}",
             response_type=Contact,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, contact_id: str) -> DeleteResponse:
+    def destroy(
+        self,
+        identifier: str,
+        contact_id: str,
+        overrides: RequestOverrides = None,
+    ) -> DeleteResponse:
         """
         Delete a Contact.
 
@@ -121,14 +146,20 @@ class Contacts(
             identifier: The identifier of the Grant to act upon.
             contact_id: The ID of the Contact to delete.
                 Use "primary" to refer to the primary Contact associated with the Grant.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The deletion response.
         """
-        return super().destroy(path=f"/v3/grants/{identifier}/contacts/{contact_id}")
+        return super().destroy(
+            path=f"/v3/grants/{identifier}/contacts/{contact_id}", overrides=overrides
+        )
 
     def list_groups(
-        self, identifier: str, query_params: ListContactGroupsQueryParams = None
+        self,
+        identifier: str,
+        query_params: ListContactGroupsQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[ContactGroup]:
         """
         Return all contact groups.
@@ -136,6 +167,7 @@ class Contacts(
         Attributes:
             identifier: The identifier of the Grant to act upon.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The list of contact groups.
@@ -144,6 +176,7 @@ class Contacts(
             method="GET",
             path=f"/v3/grants/{identifier}/contacts/groups",
             query_params=query_params,
+            overrides=overrides,
         )
 
         return ListResponse.from_dict(json_response, ContactGroup)

--- a/nylas/resources/credentials.py
+++ b/nylas/resources/credentials.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -31,7 +32,10 @@ class Credentials(
     """
 
     def list(
-        self, provider: Provider, query_params: ListCredentialQueryParams = None
+        self,
+        provider: Provider,
+        query_params: ListCredentialQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Credential]:
         """
         Return all credentials for a particular provider.
@@ -39,6 +43,7 @@ class Credentials(
         Args:
             provider: The provider.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The list of credentials.
@@ -48,15 +53,22 @@ class Credentials(
             path=f"/v3/connectors/{provider}/creds",
             response_type=Credential,
             query_params=query_params,
+            overrides=overrides,
         )
 
-    def find(self, provider: Provider, credential_id: str) -> Response[Credential]:
+    def find(
+        self,
+        provider: Provider,
+        credential_id: str,
+        overrides: RequestOverrides = None,
+    ) -> Response[Credential]:
         """
         Return a credential.
 
         Args:
             provider: The provider of the credential.
             credential_id: The ID of the credential to retrieve.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The Credential.
@@ -65,10 +77,14 @@ class Credentials(
         return super().find(
             path=f"/v3/connectors/{provider}/creds/{credential_id}",
             response_type=Credential,
+            overrides=overrides,
         )
 
     def create(
-        self, provider: Provider, request_body: CredentialRequest
+        self,
+        provider: Provider,
+        request_body: CredentialRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Credential]:
         """
         Create a credential for a particular provider.
@@ -76,6 +92,7 @@ class Credentials(
         Args:
             provider: The provider.
             request_body: The values to create the Credential with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The created Credential.
@@ -85,6 +102,7 @@ class Credentials(
             path=f"/v3/connectors/{provider}/creds",
             response_type=Credential,
             request_body=request_body,
+            overrides=overrides,
         )
 
     def update(
@@ -92,6 +110,7 @@ class Credentials(
         provider: Provider,
         credential_id: str,
         request_body: UpdateCredentialRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Credential]:
         """
         Update a credential.
@@ -100,6 +119,7 @@ class Credentials(
             provider: The provider.
             credential_id: The ID of the credential to update.
             request_body: The values to update the credential with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The updated credential.
@@ -110,18 +130,27 @@ class Credentials(
             response_type=Credential,
             request_body=request_body,
             method="PATCH",
+            overrides=overrides,
         )
 
-    def destroy(self, provider: Provider, credential_id: str) -> DeleteResponse:
+    def destroy(
+        self,
+        provider: Provider,
+        credential_id: str,
+        overrides: RequestOverrides = None,
+    ) -> DeleteResponse:
         """
         Delete a credential.
 
         Args:
             provider: the provider for the grant
             credential_id: The ID of the credential to delete.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The deletion response.
         """
 
-        return super().destroy(path=f"/v3/connectors/{provider}/creds/{credential_id}")
+        return super().destroy(
+            path=f"/v3/connectors/{provider}/creds/{credential_id}", overrides=overrides
+        )

--- a/nylas/resources/drafts.py
+++ b/nylas/resources/drafts.py
@@ -1,6 +1,7 @@
 import io
 from typing import Optional
 
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -37,7 +38,10 @@ class Drafts(
     """
 
     def list(
-        self, identifier: str, query_params: Optional[ListDraftsQueryParams] = None
+        self,
+        identifier: str,
+        query_params: Optional[ListDraftsQueryParams] = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Draft]:
         """
         Return all Drafts.
@@ -45,6 +49,7 @@ class Drafts(
         Args:
             identifier: The identifier of the grant to get drafts for.
             query_params: The query parameters to filter drafts by.
+            overrides: The request overrides to use for the request.
 
         Returns:
             A list of Drafts.
@@ -53,12 +58,14 @@ class Drafts(
             path=f"/v3/grants/{identifier}/drafts",
             response_type=Draft,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def find(
         self,
         identifier: str,
         draft_id: str,
+        overrides: RequestOverrides = None,
     ) -> Response[Draft]:
         """
         Return a Draft.
@@ -66,6 +73,7 @@ class Drafts(
         Args:
             identifier: The identifier of the grant to get the draft for.
             draft_id: The identifier of the draft to get.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The requested Draft.
@@ -73,10 +81,14 @@ class Drafts(
         return super().find(
             path=f"/v3/grants/{identifier}/drafts/{draft_id}",
             response_type=Draft,
+            overrides=overrides,
         )
 
     def create(
-        self, identifier: str, request_body: CreateDraftRequest
+        self,
+        identifier: str,
+        request_body: CreateDraftRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Draft]:
         """
         Create a Draft.
@@ -84,6 +96,7 @@ class Drafts(
         Args:
             identifier: The identifier of the grant to send the message for.
             request_body: The request body to create a draft with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The newly created Draft.
@@ -100,6 +113,7 @@ class Drafts(
                 method="POST",
                 path=path,
                 data=_build_form_request(request_body),
+                overrides=overrides,
             )
 
             return Response.from_dict(json_response, Draft)
@@ -113,6 +127,7 @@ class Drafts(
             path=path,
             response_type=Draft,
             request_body=request_body,
+            overrides=overrides,
         )
 
     def update(
@@ -120,6 +135,7 @@ class Drafts(
         identifier: str,
         draft_id: str,
         request_body: UpdateDraftRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Draft]:
         """
         Update a Draft.
@@ -128,6 +144,7 @@ class Drafts(
             identifier: The identifier of the grant to update the draft for.
             draft_id: The identifier of the draft to update.
             request_body: The request body to update the draft with.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The updated Draft.
@@ -144,6 +161,7 @@ class Drafts(
                 method="PUT",
                 path=path,
                 data=_build_form_request(request_body),
+                overrides=overrides,
             )
 
             return Response.from_dict(json_response, Draft)
@@ -157,34 +175,49 @@ class Drafts(
             path=path,
             response_type=Draft,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, draft_id: str) -> DeleteResponse:
+    def destroy(
+        self,
+        identifier: str,
+        draft_id: str,
+        overrides: RequestOverrides = None,
+    ) -> DeleteResponse:
         """
         Delete a Draft.
 
         Args:
             identifier: The identifier of the grant to delete the draft for.
             draft_id: The identifier of the draft to delete.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The deletion response.
         """
         return super().destroy(
             path=f"/v3/grants/{identifier}/drafts/{draft_id}",
+            overrides=overrides,
         )
 
-    def send(self, identifier: str, draft_id: str) -> Response[Message]:
+    def send(
+        self,
+        identifier: str,
+        draft_id: str,
+        overrides: RequestOverrides = None,
+    ) -> Response[Message]:
         """
         Send a Draft.
 
         Args:
             identifier: The identifier of the grant to send the draft for.
             draft_id: The identifier of the draft to send.
+            overrides: The request overrides to use for the request.
         """
         json_response = self._http_client._execute(
             method="POST",
             path=f"/v3/grants/{identifier}/drafts/{draft_id}",
+            overrides=overrides,
         )
 
         return Response.from_dict(json_response, Message)

--- a/nylas/resources/events.py
+++ b/nylas/resources/events.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -39,7 +40,10 @@ class Events(
     """
 
     def list(
-        self, identifier: str, query_params: ListEventQueryParams
+        self,
+        identifier: str,
+        query_params: ListEventQueryParams,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Event]:
         """
         Return all Events.
@@ -47,6 +51,7 @@ class Events(
         Args:
             identifier: The identifier of the Grant to act upon.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The list of Events.
@@ -56,10 +61,15 @@ class Events(
             path=f"/v3/grants/{identifier}/events",
             response_type=Event,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def find(
-        self, identifier: str, event_id: str, query_params: FindEventQueryParams
+        self,
+        identifier: str,
+        event_id: str,
+        query_params: FindEventQueryParams,
+        overrides: RequestOverrides = None,
     ) -> Response[Event]:
         """
         Return an Event.
@@ -68,6 +78,7 @@ class Events(
             identifier: The identifier of the Grant to act upon.
             event_id: The ID of the Event to retrieve.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The Event.
@@ -77,6 +88,7 @@ class Events(
             path=f"/v3/grants/{identifier}/events/{event_id}",
             response_type=Event,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def create(
@@ -84,6 +96,7 @@ class Events(
         identifier: str,
         request_body: CreateEventRequest,
         query_params: CreateEventQueryParams,
+        overrides: RequestOverrides = None,
     ) -> Response[Event]:
         """
         Create an Event.
@@ -92,6 +105,7 @@ class Events(
             identifier: The identifier of the Grant to act upon.
             request_body: The values to create the Event with.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The created Event.
@@ -102,6 +116,7 @@ class Events(
             response_type=Event,
             request_body=request_body,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def update(
@@ -110,6 +125,7 @@ class Events(
         event_id: str,
         request_body: UpdateEventRequest,
         query_params: UpdateEventQueryParams,
+        overrides: RequestOverrides = None,
     ) -> Response[Event]:
         """
         Update an Event.
@@ -119,6 +135,7 @@ class Events(
             event_id: The ID of the Event to update.
             request_body: The values to update the Event with.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The updated Event.
@@ -129,10 +146,15 @@ class Events(
             response_type=Event,
             request_body=request_body,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def destroy(
-        self, identifier: str, event_id: str, query_params: DestroyEventQueryParams
+        self,
+        identifier: str,
+        event_id: str,
+        query_params: DestroyEventQueryParams,
+        overrides: RequestOverrides = None,
     ) -> DeleteResponse:
         """
         Delete an Event.
@@ -141,6 +163,7 @@ class Events(
             identifier: The identifier of the Grant to act upon.
             event_id: The ID of the Event to delete.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use for the request.
 
         Returns:
             The deletion response.
@@ -149,6 +172,7 @@ class Events(
         return super().destroy(
             path=f"/v3/grants/{identifier}/events/{event_id}",
             query_params=query_params,
+            overrides=overrides,
         )
 
     def send_rsvp(
@@ -157,6 +181,7 @@ class Events(
         event_id: str,
         request_body: SendRsvpRequest,
         query_params: SendRsvpQueryParams,
+        overrides: RequestOverrides = None,
     ) -> RequestIdOnlyResponse:
         """Send RSVP for an event.
 
@@ -165,6 +190,7 @@ class Events(
             event_id: The event ID to send RSVP for.
             query_params: The query parameters to send to the API.
             request_body: The request body to send to the API.
+            overrides: The request overrides to use for the request.
 
         Returns:
             Response: The RSVP response from the API.
@@ -174,6 +200,7 @@ class Events(
             path=f"/v3/grants/{identifier}/events/{event_id}/send-rsvp",
             query_params=query_params,
             request_body=request_body,
+            overrides=overrides,
         )
 
         return RequestIdOnlyResponse.from_dict(json_response)

--- a/nylas/resources/folders.py
+++ b/nylas/resources/folders.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -26,12 +27,17 @@ class Folders(
     The Nylas folders API allows you to create new folders or manage existing ones.
     """
 
-    def list(self, identifier: str) -> ListResponse[Folder]:
+    def list(
+        self,
+        identifier: str,
+        overrides: RequestOverrides = None,
+    ) -> ListResponse[Folder]:
         """
         Return all Folders.
 
         Args:
             identifier: The identifier of the Grant to act upon.
+            overrides: The request overrides to use.
 
         Returns:
             The list of Folders.
@@ -40,15 +46,22 @@ class Folders(
         return super().list(
             path=f"/v3/grants/{identifier}/folders",
             response_type=Folder,
+            overrides=overrides,
         )
 
-    def find(self, identifier: str, folder_id: str) -> Response[Folder]:
+    def find(
+        self,
+        identifier: str,
+        folder_id: str,
+        overrides: RequestOverrides = None,
+    ) -> Response[Folder]:
         """
         Return a Folder.
 
         Args:
             identifier: The identifier of the Grant to act upon.
             folder_id: The ID of the Folder to retrieve.
+            overrides: The request overrides to use.
 
         Returns:
             The Folder.
@@ -56,10 +69,14 @@ class Folders(
         return super().find(
             path=f"/v3/grants/{identifier}/folders/{folder_id}",
             response_type=Folder,
+            overrides=overrides,
         )
 
     def create(
-        self, identifier: str, request_body: CreateFolderRequest
+        self,
+        identifier: str,
+        request_body: CreateFolderRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Folder]:
         """
         Create a Folder.
@@ -67,6 +84,7 @@ class Folders(
         Args:
             identifier: The identifier of the Grant to act upon.
             request_body: The values to create the Folder with.
+            overrides: The request overrides to use.
 
         Returns:
             The created Folder.
@@ -75,10 +93,15 @@ class Folders(
             path=f"/v3/grants/{identifier}/folders",
             response_type=Folder,
             request_body=request_body,
+            overrides=overrides,
         )
 
     def update(
-        self, identifier: str, folder_id: str, request_body: UpdateFolderRequest
+        self,
+        identifier: str,
+        folder_id: str,
+        request_body: UpdateFolderRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Folder]:
         """
         Update a Folder.
@@ -87,6 +110,7 @@ class Folders(
             identifier: The identifier of the Grant to act upon.
             folder_id: The ID of the Folder to update.
             request_body: The values to update the Folder with.
+            overrides: The request overrides to use.
 
         Returns:
             The updated Folder.
@@ -95,17 +119,26 @@ class Folders(
             path=f"/v3/grants/{identifier}/folders/{folder_id}",
             response_type=Folder,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, folder_id: str) -> DeleteResponse:
+    def destroy(
+        self,
+        identifier: str,
+        folder_id: str,
+        overrides: RequestOverrides = None,
+    ) -> DeleteResponse:
         """
         Delete a Folder.
 
         Args:
             identifier: The identifier of the Grant to act upon.
             folder_id: The ID of the Folder to delete.
+            overrides: The request overrides to use.
 
         Returns:
             The deletion response.
         """
-        return super().destroy(path=f"/v3/grants/{identifier}/folders/{folder_id}")
+        return super().destroy(
+            path=f"/v3/grants/{identifier}/folders/{folder_id}", overrides=overrides
+        )

--- a/nylas/resources/grants.py
+++ b/nylas/resources/grants.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -27,36 +28,52 @@ class Grants(
     for a specific service provider
     """
 
-    def list(self, query_params: ListGrantsQueryParams = None) -> ListResponse[Grant]:
+    def list(
+        self,
+        query_params: ListGrantsQueryParams = None,
+        overrides: RequestOverrides = None,
+    ) -> ListResponse[Grant]:
         """
         Return all Grants.
 
         Args:
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to use.
 
         Returns:
             A list of Grants.
         """
 
         return super().list(
-            path="/v3/grants", response_type=Grant, query_params=query_params
+            path="/v3/grants",
+            response_type=Grant,
+            query_params=query_params,
+            overrides=overrides,
         )
 
-    def find(self, grant_id: str) -> Response[Grant]:
+    def find(
+        self, grant_id: str, overrides: RequestOverrides = None
+    ) -> Response[Grant]:
         """
         Return a Grant.
 
         Args:
             grant_id: The ID of the Grant to retrieve.
+            overrides: The request overrides to use.
 
         Returns:
             The Grant.
         """
 
-        return super().find(path=f"/v3/grants/{grant_id}", response_type=Grant)
+        return super().find(
+            path=f"/v3/grants/{grant_id}", response_type=Grant, overrides=overrides
+        )
 
     def update(
-        self, grant_id: str, request_body: UpdateGrantRequest
+        self,
+        grant_id: str,
+        request_body: UpdateGrantRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Grant]:
         """
         Update a Grant.
@@ -64,6 +81,7 @@ class Grants(
         Args:
             grant_id: The ID of the Grant to update.
             request_body: The values to update the Grant with.
+            overrides: The request overrides to use.
 
         Returns:
             The updated Grant.
@@ -73,17 +91,21 @@ class Grants(
             path=f"/v3/grants/{grant_id}",
             response_type=Grant,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, grant_id: str) -> DeleteResponse:
+    def destroy(
+        self, grant_id: str, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a Grant.
 
         Args:
             grant_id: The ID of the Grant to delete.
+            overrides: The request overrides to use.
 
         Returns:
             The deletion response.
         """
 
-        return super().destroy(path=f"/v3/grants/{grant_id}")
+        return super().destroy(path=f"/v3/grants/{grant_id}", overrides=overrides)

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -1,6 +1,7 @@
 import io
 from typing import Optional, List
 
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -52,7 +53,10 @@ class Messages(
         return SmartCompose(self._http_client)
 
     def list(
-        self, identifier: str, query_params: Optional[ListMessagesQueryParams] = None
+        self,
+        identifier: str,
+        query_params: Optional[ListMessagesQueryParams] = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Message]:
         """
         Return all Messages.
@@ -60,6 +64,7 @@ class Messages(
         Args:
             identifier: The identifier of the grant to get messages for.
             query_params: The query parameters to filter messages by.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             A list of Messages.
@@ -68,6 +73,7 @@ class Messages(
             path=f"/v3/grants/{identifier}/messages",
             response_type=Message,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def find(
@@ -75,6 +81,7 @@ class Messages(
         identifier: str,
         message_id: str,
         query_params: Optional[FindMessageQueryParams] = None,
+        overrides: RequestOverrides = None,
     ) -> Response[Message]:
         """
         Return a Message.
@@ -83,6 +90,7 @@ class Messages(
             identifier: The identifier of the grant to get the message for.
             message_id: The identifier of the message to get.
             query_params: The query parameters to include in the request.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The requested Message.
@@ -91,6 +99,7 @@ class Messages(
             path=f"/v3/grants/{identifier}/messages/{message_id}",
             response_type=Message,
             query_params=query_params,
+            overrides=overrides,
         )
 
     def update(
@@ -98,6 +107,7 @@ class Messages(
         identifier: str,
         message_id: str,
         request_body: UpdateMessageRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Message]:
         """
         Update a Message.
@@ -106,6 +116,7 @@ class Messages(
             identifier: The identifier of the grant to update the message for.
             message_id: The identifier of the message to update.
             request_body: The request body to update the message with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The updated Message.
@@ -114,25 +125,32 @@ class Messages(
             path=f"/v3/grants/{identifier}/messages/{message_id}",
             response_type=Message,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, message_id: str) -> DeleteResponse:
+    def destroy(
+        self, identifier: str, message_id: str, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a Message.
 
         Args:
             identifier: The identifier of the grant to delete the message for.
             message_id: The identifier of the message to delete.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The deletion response.
         """
         return super().destroy(
-            path=f"/v3/grants/{identifier}/messages/{message_id}",
+            path=f"/v3/grants/{identifier}/messages/{message_id}", overrides=overrides
         )
 
     def send(
-        self, identifier: str, request_body: SendMessageRequest
+        self,
+        identifier: str,
+        request_body: SendMessageRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Message]:
         """
         Send a Message.
@@ -140,6 +158,7 @@ class Messages(
         Args:
             identifier: The identifier of the grant to send the message for.
             request_body: The request body to send the message with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The sent message.
@@ -170,18 +189,20 @@ class Messages(
             path=path,
             request_body=json_body,
             data=form_data,
+            overrides=overrides,
         )
 
         return Response.from_dict(json_response, Message)
 
     def list_scheduled_messages(
-        self, identifier: str
+        self, identifier: str, overrides: RequestOverrides = None
     ) -> Response[List[ScheduledMessage]]:
         """
         Retrieve your scheduled messages.
 
         Args:
             identifier: The identifier of the grant to delete the message for.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             Response: The list of scheduled messages.
@@ -189,6 +210,7 @@ class Messages(
         json_response = self._http_client._execute(
             method="GET",
             path=f"/v3/grants/{identifier}/messages/schedules",
+            overrides=overrides,
         )
 
         data = []
@@ -199,7 +221,7 @@ class Messages(
         return Response(data, request_id)
 
     def find_scheduled_message(
-        self, identifier: str, schedule_id: str
+        self, identifier: str, schedule_id: str, overrides: RequestOverrides = None
     ) -> Response[ScheduledMessage]:
         """
         Retrieve your scheduled messages.
@@ -207,6 +229,7 @@ class Messages(
         Args:
             identifier: The identifier of the grant to delete the message for.
             schedule_id: The id of the scheduled message to retrieve.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             Response: The scheduled message.
@@ -214,12 +237,13 @@ class Messages(
         json_response = self._http_client._execute(
             method="GET",
             path=f"/v3/grants/{identifier}/messages/schedules/{schedule_id}",
+            overrides=overrides,
         )
 
         return Response.from_dict(json_response, ScheduledMessage)
 
     def stop_scheduled_message(
-        self, identifier: str, schedule_id: str
+        self, identifier: str, schedule_id: str, overrides: RequestOverrides = None
     ) -> Response[StopScheduledMessageResponse]:
         """
         Stop a scheduled message.
@@ -227,6 +251,7 @@ class Messages(
         Args:
             identifier: The identifier of the grant to delete the message for.
             schedule_id: The id of the scheduled message to stop.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             Response: The confirmation of the stopped scheduled message.
@@ -234,12 +259,16 @@ class Messages(
         json_response = self._http_client._execute(
             method="DELETE",
             path=f"/v3/grants/{identifier}/messages/schedules/{schedule_id}",
+            overrides=overrides,
         )
 
         return Response.from_dict(json_response, StopScheduledMessageResponse)
 
     def clean_messages(
-        self, identifier: str, request_body: CleanMessagesRequest
+        self,
+        identifier: str,
+        request_body: CleanMessagesRequest,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[CleanMessagesResponse]:
         """
         Remove extra information from a list of messages.
@@ -247,6 +276,7 @@ class Messages(
         Args:
             identifier: The identifier of the grant to clean the message for.
             request_body: The values to clean the message with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The list of cleaned messages.
@@ -255,6 +285,7 @@ class Messages(
             method="PUT",
             path=f"/v3/grants/{identifier}/messages/clean",
             request_body=request_body,
+            overrides=overrides,
         )
 
         return ListResponse.from_dict(json_resposne, CleanMessagesResponse)

--- a/nylas/resources/redirect_uris.py
+++ b/nylas/resources/redirect_uris.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -26,24 +27,32 @@ class RedirectUris(
     These endpoints allow you to create, update, and delete Redirect URIs for your Nylas Application.
     """
 
-    def list(self) -> ListResponse[RedirectUri]:
+    def list(self, overrides: RequestOverrides = None) -> ListResponse[RedirectUri]:
         """
         Return all Redirect URIs.
+
+        Args:
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The list of Redirect URIs.
         """
 
         return super().list(
-            path="/v3/applications/redirect-uris", response_type=RedirectUri
+            path="/v3/applications/redirect-uris",
+            response_type=RedirectUri,
+            overrides=overrides,
         )
 
-    def find(self, redirect_uri_id: str) -> Response[RedirectUri]:
+    def find(
+        self, redirect_uri_id: str, overrides: RequestOverrides = None
+    ) -> Response[RedirectUri]:
         """
         Return a Redirect URI.
 
         Args:
             redirect_uri_id: The ID of the Redirect URI to retrieve.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The Redirect URI.
@@ -52,14 +61,18 @@ class RedirectUris(
         return super().find(
             path=f"/v3/applications/redirect-uris/{redirect_uri_id}",
             response_type=RedirectUri,
+            overrides=overrides,
         )
 
-    def create(self, request_body: CreateRedirectUriRequest) -> Response[RedirectUri]:
+    def create(
+        self, request_body: CreateRedirectUriRequest, overrides: RequestOverrides = None
+    ) -> Response[RedirectUri]:
         """
         Create a Redirect URI.
 
         Args:
             request_body: The values to create the Redirect URI with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The created Redirect URI.
@@ -69,10 +82,14 @@ class RedirectUris(
             path="/v3/applications/redirect-uris",
             request_body=request_body,
             response_type=RedirectUri,
+            overrides=overrides,
         )
 
     def update(
-        self, redirect_uri_id: str, request_body: UpdateRedirectUriRequest
+        self,
+        redirect_uri_id: str,
+        request_body: UpdateRedirectUriRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[RedirectUri]:
         """
         Update a Redirect URI.
@@ -80,6 +97,7 @@ class RedirectUris(
         Args:
             redirect_uri_id: The ID of the Redirect URI to update.
             request_body: The values to update the Redirect URI with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The updated Redirect URI.
@@ -89,17 +107,24 @@ class RedirectUris(
             path=f"/v3/applications/redirect-uris/{redirect_uri_id}",
             request_body=request_body,
             response_type=RedirectUri,
+            overrides=overrides,
         )
 
-    def destroy(self, redirect_uri_id: str) -> DeleteResponse:
+    def destroy(
+        self, redirect_uri_id: str, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a Redirect URI.
 
         Args:
             redirect_uri_id: The ID of the Redirect URI to delete.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The deletion response.
         """
 
-        return super().destroy(path=f"/v3/applications/redirect-uris/{redirect_uri_id}")
+        return super().destroy(
+            path=f"/v3/applications/redirect-uris/{redirect_uri_id}",
+            overrides=overrides,
+        )

--- a/nylas/resources/smart_compose.py
+++ b/nylas/resources/smart_compose.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.models.response import Response
 
 from nylas.models.smart_compose import ComposeMessageRequest, ComposeMessageResponse
@@ -12,7 +13,10 @@ class SmartCompose(Resource):
     """
 
     def compose_message(
-        self, identifier: str, request_body: ComposeMessageRequest
+        self,
+        identifier: str,
+        request_body: ComposeMessageRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[ComposeMessageResponse]:
         """
         Compose a message.
@@ -20,6 +24,7 @@ class SmartCompose(Resource):
         Args:
             identifier: The identifier of the grant to generate a message suggestion for.
             request_body: The prompt that smart compose will use to generate a message suggestion.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The generated message.
@@ -28,12 +33,17 @@ class SmartCompose(Resource):
             method="POST",
             path=f"/v3/grants/{identifier}/messages/smart-compose",
             request_body=request_body,
+            overrides=overrides,
         )
 
         return Response.from_dict(res, ComposeMessageResponse)
 
     def compose_message_reply(
-        self, identifier: str, message_id: str, request_body: ComposeMessageRequest
+        self,
+        identifier: str,
+        message_id: str,
+        request_body: ComposeMessageRequest,
+        overrides: RequestOverrides = None,
     ) -> ComposeMessageResponse:
         """
         Compose a message reply.
@@ -42,6 +52,7 @@ class SmartCompose(Resource):
             identifier: The identifier of the grant to generate a message suggestion for.
             message_id: The id of the message to reply to.
             request_body: The prompt that smart compose will use to generate a message reply suggestion.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The generated message reply.
@@ -50,6 +61,7 @@ class SmartCompose(Resource):
             method="POST",
             path=f"/v3/grants/{identifier}/messages/{message_id}/smart-compose",
             request_body=request_body,
+            overrides=overrides,
         )
 
         return Response.from_dict(res, ComposeMessageResponse)

--- a/nylas/resources/threads.py
+++ b/nylas/resources/threads.py
@@ -1,3 +1,4 @@
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -21,7 +22,10 @@ class Threads(
     """
 
     def list(
-        self, identifier: str, query_params: ListThreadsQueryParams = None
+        self,
+        identifier: str,
+        query_params: ListThreadsQueryParams = None,
+        overrides: RequestOverrides = None,
     ) -> ListResponse[Thread]:
         """
         Return all Threads.
@@ -29,6 +33,7 @@ class Threads(
         Args:
             identifier: The identifier of the grant to get threads for.
             query_params: The query parameters to filter threads by.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             A list of Threads.
@@ -37,15 +42,19 @@ class Threads(
             path=f"/v3/grants/{identifier}/threads",
             response_type=Thread,
             query_params=query_params,
+            overrides=overrides,
         )
 
-    def find(self, identifier: str, thread_id: str) -> Response[Thread]:
+    def find(
+        self, identifier: str, thread_id: str, overrides: RequestOverrides = None
+    ) -> Response[Thread]:
         """
         Return a Thread.
 
         Args:
             identifier: The identifier of the grant to get the thread for.
             thread_id: The identifier of the thread to get.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The requested Thread.
@@ -53,6 +62,7 @@ class Threads(
         return super().find(
             path=f"/v3/grants/{identifier}/threads/{thread_id}",
             response_type=Thread,
+            overrides=overrides,
         )
 
     def update(
@@ -60,6 +70,7 @@ class Threads(
         identifier: str,
         thread_id: str,
         request_body: UpdateThreadRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Thread]:
         """
         Update a Thread.
@@ -68,6 +79,7 @@ class Threads(
             identifier: The identifier of the grant to update the thread for.
             thread_id: The identifier of the thread to update.
             request_body: The request body to update the thread with.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The updated Thread.
@@ -76,19 +88,23 @@ class Threads(
             path=f"/v3/grants/{identifier}/threads/{thread_id}",
             response_type=Thread,
             request_body=request_body,
+            overrides=overrides,
         )
 
-    def destroy(self, identifier: str, thread_id: str) -> DeleteResponse:
+    def destroy(
+        self, identifier: str, thread_id: str, overrides: RequestOverrides = None
+    ) -> DeleteResponse:
         """
         Delete a Thread.
 
         Args:
             identifier: The identifier of the grant to delete the thread for.
             thread_id: The identifier of the thread to delete.
+            overrides: The request overrides to apply to the request.
 
         Returns:
             The deletion response.
         """
         return super().destroy(
-            path=f"/v3/grants/{identifier}/threads/{thread_id}",
+            path=f"/v3/grants/{identifier}/threads/{thread_id}", overrides=overrides
         )

--- a/nylas/resources/webhooks.py
+++ b/nylas/resources/webhooks.py
@@ -1,5 +1,6 @@
 import urllib.parse
 
+from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
     FindableApiResource,
@@ -31,33 +32,46 @@ class Webhooks(
     The Nylas webhooks API allows you to manage webhook destinations for your Nylas application.
     """
 
-    def list(self) -> ListResponse[Webhook]:
+    def list(self, overrides: RequestOverrides = None) -> ListResponse[Webhook]:
         """
         List all webhook destinations
+
+        Args:
+            overrides: The request overrides to apply to the request
 
         Returns:
             The list of webhook destinations
         """
         return super().list(path="/v3/webhooks", response_type=Webhook)
 
-    def find(self, webhook_id: str) -> Response[Webhook]:
+    def find(
+        self, webhook_id: str, overrides: RequestOverrides = None
+    ) -> Response[Webhook]:
         """
         Get a webhook destination
 
         Parameters:
             webhook_id: The ID of the webhook destination to get
+            overrides: The request overrides to apply to the request
 
         Returns:
             The webhook destination
         """
-        return super().find(path=f"/v3/webhooks/{webhook_id}", response_type=Webhook)
+        return super().find(
+            path=f"/v3/webhooks/{webhook_id}",
+            response_type=Webhook,
+            overrides=overrides,
+        )
 
-    def create(self, request_body: CreateWebhookRequest) -> Response[WebhookWithSecret]:
+    def create(
+        self, request_body: CreateWebhookRequest, overrides: RequestOverrides = None
+    ) -> Response[WebhookWithSecret]:
         """
         Create a webhook destination
 
         Parameters:
             request_body: The request body to create the webhook destination
+            overrides: The request overrides to apply to the request
 
         Returns:
             The created webhook destination
@@ -66,10 +80,14 @@ class Webhooks(
             path="/v3/webhooks",
             request_body=request_body,
             response_type=WebhookWithSecret,
+            overrides=overrides,
         )
 
     def update(
-        self, webhook_id: str, request_body: UpdateWebhookRequest
+        self,
+        webhook_id: str,
+        request_body: UpdateWebhookRequest,
+        overrides: RequestOverrides = None,
     ) -> Response[Webhook]:
         """
         Update a webhook destination
@@ -77,6 +95,7 @@ class Webhooks(
         Parameters:
             webhook_id: The ID of the webhook destination to update
             request_body: The request body to update the webhook destination
+            overrides: The request overrides to apply to the request
 
         Returns:
             The updated webhook destination
@@ -85,28 +104,37 @@ class Webhooks(
             path=f"/v3/webhooks/{webhook_id}",
             request_body=request_body,
             response_type=Webhook,
+            overrides=overrides,
         )
 
-    def destroy(self, webhook_id: str) -> WebhookDeleteResponse:
+    def destroy(
+        self, webhook_id: str, overrides: RequestOverrides = None
+    ) -> WebhookDeleteResponse:
         """
         Delete a webhook destination
 
         Parameters:
             webhook_id: The ID of the webhook destination to delete
+            overrides: The request overrides to apply to the request
 
         Returns:
             The response from deleting the webhook destination
         """
         return super().destroy(
-            path=f"/v3/webhooks/{webhook_id}", response_type=WebhookDeleteResponse
+            path=f"/v3/webhooks/{webhook_id}",
+            response_type=WebhookDeleteResponse,
+            overrides=overrides,
         )
 
-    def rotate_secret(self, webhook_id: str) -> Response[WebhookWithSecret]:
+    def rotate_secret(
+        self, webhook_id: str, overrides: RequestOverrides = None
+    ) -> Response[WebhookWithSecret]:
         """
         Update the webhook secret value for a destination
 
         Parameters:
             webhook_id: The ID of the webhook destination to update
+            overrides: The request overrides to apply to the request
 
         Returns:
             The updated webhook destination
@@ -115,17 +143,25 @@ class Webhooks(
             method="PUT",
             path=f"/v3/webhooks/{webhook_id}/rotate-secret",
             request_body={},
+            overrides=overrides,
         )
         return Response.from_dict(res, WebhookWithSecret)
 
-    def ip_addresses(self) -> Response[WebhookIpAddressesResponse]:
+    def ip_addresses(
+        self, overrides: RequestOverrides = None
+    ) -> Response[WebhookIpAddressesResponse]:
         """
         Get the current list of IP addresses that Nylas sends webhooks from
+
+        Args:
+            overrides: The request overrides to apply to the request
 
         Returns:
             The list of IP addresses that Nylas sends webhooks from
         """
-        res = self._http_client._execute(method="GET", path="/v3/webhooks/ip-addresses")
+        res = self._http_client._execute(
+            method="GET", path="/v3/webhooks/ip-addresses", overrides=overrides
+        )
         return Response.from_dict(res, WebhookIpAddressesResponse)
 
 

--- a/tests/handler/test_api_resources.py
+++ b/tests/handler/test_api_resources.py
@@ -50,7 +50,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
     def test_find_resource(self, http_client_response):
@@ -71,7 +71,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
     def test_create_resource(self, http_client_response):
@@ -83,7 +83,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
         assert type(response) is Response
@@ -93,7 +93,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
     def test_update_resource(self, http_client_response):
@@ -105,7 +105,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
         assert type(response) is Response
@@ -115,7 +115,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_resource(self, http_client_delete_response):
@@ -127,7 +127,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
         assert type(response) is RequestIdOnlyResponse
@@ -137,7 +137,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_resource_default_type(self, http_client_delete_response):
@@ -148,7 +148,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
-            overrides=None
+            overrides=None,
         )
 
         assert type(response) is DeleteResponse
@@ -158,5 +158,5 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
-            overrides=None
+            overrides=None,
         )

--- a/tests/handler/test_api_resources.py
+++ b/tests/handler/test_api_resources.py
@@ -93,6 +93,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )
 
     def test_update_resource(self, http_client_response):
@@ -114,6 +115,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )
 
     def test_destroy_resource(self, http_client_delete_response):
@@ -135,6 +137,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )
 
     def test_destroy_resource_default_type(self, http_client_delete_response):
@@ -155,4 +158,5 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )

--- a/tests/handler/test_api_resources.py
+++ b/tests/handler/test_api_resources.py
@@ -50,6 +50,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )
 
     def test_find_resource(self, http_client_response):
@@ -70,6 +71,7 @@ class TestApiResource:
             {"test": "header"},
             {"query": "param"},
             {"foo": "bar"},
+            overrides=None
         )
 
     def test_create_resource(self, http_client_response):
@@ -81,6 +83,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
+            overrides=None
         )
 
         assert type(response) is Response
@@ -101,6 +104,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
+            overrides=None
         )
 
         assert type(response) is Response
@@ -121,6 +125,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
+            overrides=None
         )
 
         assert type(response) is RequestIdOnlyResponse
@@ -140,6 +145,7 @@ class TestApiResource:
             headers={"test": "header"},
             query_params={"query": "param"},
             request_body={"foo": "bar"},
+            overrides=None
         )
 
         assert type(response) is DeleteResponse

--- a/tests/resources/test_applications.py
+++ b/tests/resources/test_applications.py
@@ -57,7 +57,7 @@ class TestApplications:
         res = app.info()
 
         mock_http_client._execute.assert_called_once_with(
-            method="GET", path="/v3/applications"
+            method="GET", path="/v3/applications", overrides=None
         )
         assert type(res.data) == ApplicationDetails
         assert res.data.application_id == "ad410018-d306-43f9-8361-fa5d7b2172e0"

--- a/tests/resources/test_attachments.py
+++ b/tests/resources/test_attachments.py
@@ -62,6 +62,7 @@ class TestAttachments:
             path="/v3/grants/abc-123/attachments/attachment-123/download",
             query_params=query_params,
             stream=True,
+            overrides=None
         )
 
     def test_download_bytes(self):
@@ -81,4 +82,5 @@ class TestAttachments:
             path="/v3/grants/abc-123/attachments/attachment-123/download",
             query_params=query_params,
             stream=False,
+            overrides=None
         )

--- a/tests/resources/test_attachments.py
+++ b/tests/resources/test_attachments.py
@@ -42,7 +42,7 @@ class TestAttachments:
             None,
             query_params,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_download_attachment(self):
@@ -55,14 +55,14 @@ class TestAttachments:
             identifier="abc-123",
             attachment_id="attachment-123",
             query_params=query_params,
-            overrides=None
+            overrides=None,
         )
 
         mock_http_client._execute_download_request.assert_called_once_with(
             path="/v3/grants/abc-123/attachments/attachment-123/download",
             query_params=query_params,
             stream=True,
-            overrides=None
+            overrides=None,
         )
 
     def test_download_bytes(self):
@@ -75,12 +75,12 @@ class TestAttachments:
             identifier="abc-123",
             attachment_id="attachment-123",
             query_params=query_params,
-            overrides=None
+            overrides=None,
         )
 
         mock_http_client._execute_download_request.assert_called_once_with(
             path="/v3/grants/abc-123/attachments/attachment-123/download",
             query_params=query_params,
             stream=False,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_attachments.py
+++ b/tests/resources/test_attachments.py
@@ -42,6 +42,7 @@ class TestAttachments:
             None,
             query_params,
             None,
+            overrides=None
         )
 
     def test_download_attachment(self):
@@ -54,6 +55,7 @@ class TestAttachments:
             identifier="abc-123",
             attachment_id="attachment-123",
             query_params=query_params,
+            overrides=None
         )
 
         mock_http_client._execute_download_request.assert_called_once_with(
@@ -72,6 +74,7 @@ class TestAttachments:
             identifier="abc-123",
             attachment_id="attachment-123",
             query_params=query_params,
+            overrides=None
         )
 
         mock_http_client._execute_download_request.assert_called_once_with(

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -87,10 +87,7 @@ class TestAuth:
         res = auth._get_token(req, overrides=None)
 
         http_client_token_exchange._execute.assert_called_once_with(
-            method="POST",
-            path="/v3/connect/token",
-            request_body=req,
-            overrides=None
+            method="POST", path="/v3/connect/token", request_body=req, overrides=None
         )
         assert type(res) is CodeExchangeResponse
         assert res.access_token == "nylas_access_token"
@@ -111,10 +108,7 @@ class TestAuth:
         res = auth._get_token_info(req, overrides=None)
 
         http_client_token_info._execute.assert_called_once_with(
-            method="GET",
-            path="/v3/connect/tokeninfo",
-            query_params=req,
-            overrides=None
+            method="GET", path="/v3/connect/tokeninfo", query_params=req, overrides=None
         )
         assert type(res.data) is TokenInfoResponse
         assert res.data.iss == "https://nylas.com"
@@ -163,7 +157,8 @@ class TestAuth:
                 "code": "code",
                 "redirect_uri": "https://example.com/oauth/callback",
                 "grant_type": "authorization_code",
-            },overrides=None
+            },
+            overrides=None,
         )
 
     def test_exchange_code_for_token_no_secret(self, http_client_token_exchange):
@@ -186,7 +181,8 @@ class TestAuth:
                 "redirect_uri": "https://example.com/oauth/callback",
                 "client_secret": "nylas-api-key",
                 "grant_type": "authorization_code",
-            },overrides=None
+            },
+            overrides=None,
         )
 
     def test_custom_authentication(self):
@@ -216,7 +212,7 @@ class TestAuth:
             method="POST",
             path="/v3/connect/custom",
             request_body={"provider": "google", "settings": {"foo": "bar"}},
-            overrides=None
+            overrides=None,
         )
         assert type(res.data) is Grant
         assert res.data.id == "e19f8e1a-eb1c-41c0-b6a6-d2e59daf7f47"
@@ -250,7 +246,8 @@ class TestAuth:
                 "client_id": "abc-123",
                 "client_secret": "secret",
                 "grant_type": "refresh_token",
-            },overrides=None
+            },
+            overrides=None,
         )
 
     def test_refresh_access_token_no_secret(self, http_client_token_exchange):
@@ -273,7 +270,8 @@ class TestAuth:
                 "client_id": "abc-123",
                 "client_secret": "nylas-api-key",
                 "grant_type": "refresh_token",
-            },overrides=None
+            },
+            overrides=None,
         )
 
     def test_id_token_info(self, http_client_token_info):
@@ -285,7 +283,7 @@ class TestAuth:
             method="GET",
             path="/v3/connect/tokeninfo",
             query_params={"id_token": "id-123"},
-            overrides=None
+            overrides=None,
         )
 
     def test_validate_access_token(self, http_client_token_info):
@@ -297,7 +295,7 @@ class TestAuth:
             method="GET",
             path="/v3/connect/tokeninfo",
             query_params={"access_token": "id-123"},
-            overrides=None
+            overrides=None,
         )
 
     @mock.patch("uuid.uuid4")
@@ -354,7 +352,7 @@ class TestAuth:
             method="POST",
             path="/v3/connect/revoke",
             query_params={"token": "access_token"},
-            overrides=None
+            overrides=None,
         )
         assert res is True
 
@@ -370,10 +368,7 @@ class TestAuth:
             },
         }
         auth = Auth(mock_http_client)
-        req = {
-            "email": "test@gmail.com",
-            "all_provider_types": True
-        }
+        req = {"email": "test@gmail.com", "all_provider_types": True}
 
         res = auth.detect_provider(req)
 

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -90,6 +90,7 @@ class TestAuth:
             method="POST",
             path="/v3/connect/token",
             request_body=req,
+            overrides=None
         )
         assert type(res) is CodeExchangeResponse
         assert res.access_token == "nylas_access_token"
@@ -113,6 +114,7 @@ class TestAuth:
             method="GET",
             path="/v3/connect/tokeninfo",
             query_params=req,
+            overrides=None
         )
         assert type(res.data) is TokenInfoResponse
         assert res.data.iss == "https://nylas.com"
@@ -376,6 +378,6 @@ class TestAuth:
         res = auth.detect_provider(req)
 
         mock_http_client._execute.assert_called_once_with(
-            method="POST", path="/v3/providers/detect", query_params=req
+            method="POST", path="/v3/providers/detect", query_params=req, overrides=None
         )
         assert type(res.data) == ProviderDetectResponse

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -370,8 +370,7 @@ class TestAuth:
         auth = Auth(mock_http_client)
         req = {
             "email": "test@gmail.com",
-            "all_provider_types": True,
-            overrides=None
+            "all_provider_types": True
         }
 
         res = auth.detect_provider(req)

--- a/tests/resources/test_auth.py
+++ b/tests/resources/test_auth.py
@@ -84,7 +84,7 @@ class TestAuth:
             "client_secret": "client_secret",
         }
 
-        res = auth._get_token(req)
+        res = auth._get_token(req, overrides=None)
 
         http_client_token_exchange._execute.assert_called_once_with(
             method="POST",
@@ -107,7 +107,7 @@ class TestAuth:
             "foo": "bar",
         }
 
-        res = auth._get_token_info(req)
+        res = auth._get_token_info(req, overrides=None)
 
         http_client_token_info._execute.assert_called_once_with(
             method="GET",
@@ -161,7 +161,7 @@ class TestAuth:
                 "code": "code",
                 "redirect_uri": "https://example.com/oauth/callback",
                 "grant_type": "authorization_code",
-            },
+            },overrides=None
         )
 
     def test_exchange_code_for_token_no_secret(self, http_client_token_exchange):
@@ -184,7 +184,7 @@ class TestAuth:
                 "redirect_uri": "https://example.com/oauth/callback",
                 "client_secret": "nylas-api-key",
                 "grant_type": "authorization_code",
-            },
+            },overrides=None
         )
 
     def test_custom_authentication(self):
@@ -214,6 +214,7 @@ class TestAuth:
             method="POST",
             path="/v3/connect/custom",
             request_body={"provider": "google", "settings": {"foo": "bar"}},
+            overrides=None
         )
         assert type(res.data) is Grant
         assert res.data.id == "e19f8e1a-eb1c-41c0-b6a6-d2e59daf7f47"
@@ -247,7 +248,7 @@ class TestAuth:
                 "client_id": "abc-123",
                 "client_secret": "secret",
                 "grant_type": "refresh_token",
-            },
+            },overrides=None
         )
 
     def test_refresh_access_token_no_secret(self, http_client_token_exchange):
@@ -270,7 +271,7 @@ class TestAuth:
                 "client_id": "abc-123",
                 "client_secret": "nylas-api-key",
                 "grant_type": "refresh_token",
-            },
+            },overrides=None
         )
 
     def test_id_token_info(self, http_client_token_info):
@@ -282,6 +283,7 @@ class TestAuth:
             method="GET",
             path="/v3/connect/tokeninfo",
             query_params={"id_token": "id-123"},
+            overrides=None
         )
 
     def test_validate_access_token(self, http_client_token_info):
@@ -293,6 +295,7 @@ class TestAuth:
             method="GET",
             path="/v3/connect/tokeninfo",
             query_params={"access_token": "id-123"},
+            overrides=None
         )
 
     @mock.patch("uuid.uuid4")
@@ -349,6 +352,7 @@ class TestAuth:
             method="POST",
             path="/v3/connect/revoke",
             query_params={"token": "access_token"},
+            overrides=None
         )
         assert res is True
 
@@ -367,6 +371,7 @@ class TestAuth:
         req = {
             "email": "test@gmail.com",
             "all_provider_types": True,
+            overrides=None
         }
 
         res = auth.detect_provider(req)

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -43,7 +43,7 @@ class TestCalendar:
         calendars.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars", None, None, None,overrides=None
+            "GET", "/v3/grants/abc-123/calendars", None, None, None, overrides=None
         )
 
     def test_list_calendars_with_query_params(self, http_client_list_response):
@@ -52,7 +52,12 @@ class TestCalendar:
         calendars.list(identifier="abc-123", query_params={"limit": 20})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars", None, {"limit": 20}, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/calendars",
+            None,
+            {"limit": 20},
+            None,
+            overrides=None,
         )
 
     def test_find_calendar(self, http_client_response):
@@ -61,7 +66,12 @@ class TestCalendar:
         calendars.find(identifier="abc-123", calendar_id="calendar-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars/calendar-123", None, None, None,overrides=None
+            "GET",
+            "/v3/grants/abc-123/calendars/calendar-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_create_calendar(self, http_client_response):
@@ -82,7 +92,7 @@ class TestCalendar:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_calendar(self, http_client_response):
@@ -105,7 +115,7 @@ class TestCalendar:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_calendar(self, http_client_delete_response):
@@ -119,7 +129,7 @@ class TestCalendar:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_get_availability(self, http_client_response):
@@ -158,7 +168,7 @@ class TestCalendar:
                     }
                 ],
                 "round_robin_event_id": "event-123",
-            }
+            },
         }
 
         calendars.get_availability(request_body)
@@ -167,7 +177,7 @@ class TestCalendar:
             method="POST",
             path="/v3/calendars/availability",
             request_body=request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_get_free_busy(self, http_client_free_busy):
@@ -186,7 +196,7 @@ class TestCalendar:
             method="POST",
             path="/v3/grants/abc-123/calendars/free-busy",
             request_body=request_body,
-            overrides=None
+            overrides=None,
         )
         assert len(response.data) == 2
         assert response.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -43,7 +43,7 @@ class TestCalendar:
         calendars.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars", None, None, None
+            "GET", "/v3/grants/abc-123/calendars", None, None, None,overrides=None
         )
 
     def test_list_calendars_with_query_params(self, http_client_list_response):
@@ -52,7 +52,7 @@ class TestCalendar:
         calendars.list(identifier="abc-123", query_params={"limit": 20})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars", None, {"limit": 20}, None
+            "GET", "/v3/grants/abc-123/calendars", None, {"limit": 20}, None, overrides=None
         )
 
     def test_find_calendar(self, http_client_response):
@@ -61,7 +61,7 @@ class TestCalendar:
         calendars.find(identifier="abc-123", calendar_id="calendar-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/calendars/calendar-123", None, None, None
+            "GET", "/v3/grants/abc-123/calendars/calendar-123", None, None, None,overrides=None
         )
 
     def test_create_calendar(self, http_client_response):
@@ -82,6 +82,7 @@ class TestCalendar:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_calendar(self, http_client_response):
@@ -104,6 +105,7 @@ class TestCalendar:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_calendar(self, http_client_delete_response):
@@ -117,6 +119,7 @@ class TestCalendar:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_get_availability(self, http_client_response):
@@ -155,7 +158,7 @@ class TestCalendar:
                     }
                 ],
                 "round_robin_event_id": "event-123",
-            },
+            },overrides=None
         }
 
         calendars.get_availability(request_body)
@@ -182,6 +185,7 @@ class TestCalendar:
             method="POST",
             path="/v3/grants/abc-123/calendars/free-busy",
             request_body=request_body,
+            overrides=None
         )
         assert len(response.data) == 2
         assert response.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -167,6 +167,7 @@ class TestCalendar:
             method="POST",
             path="/v3/calendars/availability",
             request_body=request_body,
+            overrides=None
         )
 
     def test_get_free_busy(self, http_client_free_busy):

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -158,7 +158,7 @@ class TestCalendar:
                     }
                 ],
                 "round_robin_event_id": "event-123",
-            },overrides=None
+            }
         }
 
         calendars.get_availability(request_body)

--- a/tests/resources/test_connectors.py
+++ b/tests/resources/test_connectors.py
@@ -33,7 +33,7 @@ class TestConnectors:
         connectors.list()
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/connectors", None, None, None
+            "GET", "/v3/connectors", None, None, None, overrides=None
         )
 
     def test_find_connector(self, http_client_response):
@@ -42,7 +42,7 @@ class TestConnectors:
         connectors.find("google")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/connectors/google", None, None, None
+            "GET", "/v3/connectors/google", None, None, None, overrides=None
         )
 
     def test_create_connector(self, http_client_response):
@@ -68,6 +68,7 @@ class TestConnectors:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_connector(self, http_client_response):
@@ -95,6 +96,7 @@ class TestConnectors:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_connector(self, http_client_delete_response):
@@ -108,4 +110,5 @@ class TestConnectors:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_connectors.py
+++ b/tests/resources/test_connectors.py
@@ -63,12 +63,7 @@ class TestConnectors:
         connectors.create(request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST",
-            "/v3/connectors",
-            None,
-            None,
-            request_body,
-            overrides=None
+            "POST", "/v3/connectors", None, None, request_body, overrides=None
         )
 
     def test_update_connector(self, http_client_response):
@@ -91,12 +86,7 @@ class TestConnectors:
         )
 
         http_client_response._execute.assert_called_once_with(
-            "PATCH",
-            "/v3/connectors/google",
-            None,
-            None,
-            request_body,
-            overrides=None
+            "PATCH", "/v3/connectors/google", None, None, request_body, overrides=None
         )
 
     def test_destroy_connector(self, http_client_delete_response):
@@ -105,10 +95,5 @@ class TestConnectors:
         connectors.destroy("google")
 
         http_client_delete_response._execute.assert_called_once_with(
-            "DELETE",
-            "/v3/connectors/google",
-            None,
-            None,
-            None,
-            overrides=None
+            "DELETE", "/v3/connectors/google", None, None, None, overrides=None
         )

--- a/tests/resources/test_contacts.py
+++ b/tests/resources/test_contacts.py
@@ -104,7 +104,12 @@ class TestContact:
         contacts.list(identifier="abc-123", query_params={"limit": 20})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/contacts", None, {"limit": 20}, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/contacts",
+            None,
+            {"limit": 20},
+            None,
+            overrides=None,
         )
 
     def test_find_contact(self, http_client_response):
@@ -113,7 +118,12 @@ class TestContact:
         contacts.find(identifier="abc-123", contact_id="contact-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/contacts/contact-123", None, None, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/contacts/contact-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_find_contact_with_query_params(self, http_client_response):
@@ -131,7 +141,7 @@ class TestContact:
             None,
             {"profile_picture": True},
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_create_contact(self, http_client_response):
@@ -150,7 +160,7 @@ class TestContact:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_contact(self, http_client_response):
@@ -171,7 +181,7 @@ class TestContact:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_contact(self, http_client_delete_response):
@@ -185,7 +195,7 @@ class TestContact:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_list_groups(self, http_client_list_response):
@@ -197,5 +207,5 @@ class TestContact:
             method="GET",
             path="/v3/grants/abc-123/contacts/groups",
             query_params={"limit": 20},
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_contacts.py
+++ b/tests/resources/test_contacts.py
@@ -95,7 +95,7 @@ class TestContact:
         contacts.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/contacts", None, None, None
+            "GET", "/v3/grants/abc-123/contacts", None, None, None, overrides=None
         )
 
     def test_list_contacts_with_query_params(self, http_client_list_response):
@@ -104,7 +104,7 @@ class TestContact:
         contacts.list(identifier="abc-123", query_params={"limit": 20})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/contacts", None, {"limit": 20}, None
+            "GET", "/v3/grants/abc-123/contacts", None, {"limit": 20}, None, overrides=None
         )
 
     def test_find_contact(self, http_client_response):
@@ -113,7 +113,7 @@ class TestContact:
         contacts.find(identifier="abc-123", contact_id="contact-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/contacts/contact-123", None, None, None
+            "GET", "/v3/grants/abc-123/contacts/contact-123", None, None, None, overrides=None
         )
 
     def test_find_contact_with_query_params(self, http_client_response):
@@ -131,6 +131,7 @@ class TestContact:
             None,
             {"profile_picture": True},
             None,
+            overrides=None
         )
 
     def test_create_contact(self, http_client_response):
@@ -149,6 +150,7 @@ class TestContact:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_contact(self, http_client_response):
@@ -169,6 +171,7 @@ class TestContact:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_contact(self, http_client_delete_response):
@@ -182,6 +185,7 @@ class TestContact:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_list_groups(self, http_client_list_response):
@@ -193,4 +197,5 @@ class TestContact:
             method="GET",
             path="/v3/grants/abc-123/contacts/groups",
             query_params={"limit": 20},
+            overrides=None
         )

--- a/tests/resources/test_credentials.py
+++ b/tests/resources/test_credentials.py
@@ -24,7 +24,7 @@ class TestCredentials:
         credentials.list("google")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/connectors/google/creds", None, None, None
+            "GET", "/v3/connectors/google/creds", None, None, None, overrides=None
         )
 
     def test_find_credential(self, http_client_response):
@@ -33,7 +33,7 @@ class TestCredentials:
         credentials.find("google", "abc-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/connectors/google/creds/abc-123", None, None, None
+            "GET", "/v3/connectors/google/creds/abc-123", None, None, None, overrides=None
         )
 
     def test_create_credential(self, http_client_response):
@@ -56,6 +56,7 @@ class TestCredentials:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_credential(self, http_client_response):
@@ -81,6 +82,7 @@ class TestCredentials:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_credential(self, http_client_delete_response):
@@ -94,4 +96,5 @@ class TestCredentials:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_credentials.py
+++ b/tests/resources/test_credentials.py
@@ -33,7 +33,12 @@ class TestCredentials:
         credentials.find("google", "abc-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/connectors/google/creds/abc-123", None, None, None, overrides=None
+            "GET",
+            "/v3/connectors/google/creds/abc-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_create_credential(self, http_client_response):
@@ -56,7 +61,7 @@ class TestCredentials:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_credential(self, http_client_response):
@@ -82,7 +87,7 @@ class TestCredentials:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_credential(self, http_client_delete_response):
@@ -96,5 +101,5 @@ class TestCredentials:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_drafts.py
+++ b/tests/resources/test_drafts.py
@@ -68,7 +68,7 @@ class TestDraft:
         drafts.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/drafts", None, None, None
+            "GET", "/v3/grants/abc-123/drafts", None, None, None, overrides=None
         )
 
     def test_list_drafts_with_query_params(self, http_client_list_response):
@@ -89,6 +89,7 @@ class TestDraft:
                 "subject": "Hello from Nylas!",
             },
             None,
+            overrides=None
         )
 
     def test_find_draft(self, http_client_response):
@@ -97,7 +98,7 @@ class TestDraft:
         drafts.find(identifier="abc-123", draft_id="draft-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/drafts/draft-123", None, None, None
+            "GET", "/v3/grants/abc-123/drafts/draft-123", None, None, None, overrides=None
         )
 
     def test_create_draft(self, http_client_response):
@@ -112,7 +113,7 @@ class TestDraft:
         drafts.create(identifier="abc-123", request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST", "/v3/grants/abc-123/drafts", None, None, request_body
+            "POST", "/v3/grants/abc-123/drafts", None, None, request_body, overrides=None
         )
 
     def test_create_draft_small_attachment(self, http_client_response):
@@ -135,7 +136,7 @@ class TestDraft:
         drafts.create(identifier="abc-123", request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST", "/v3/grants/abc-123/drafts", None, None, request_body
+            "POST", "/v3/grants/abc-123/drafts", None, None, request_body, overrides=None
         )
 
     def test_create_draft_large_attachment(self, http_client_response):
@@ -165,6 +166,7 @@ class TestDraft:
                 method="POST",
                 path="/v3/grants/abc-123/drafts",
                 data=mock_encoder,
+                overrides=None
             )
 
     def test_update_draft(self, http_client_response):
@@ -186,6 +188,7 @@ class TestDraft:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_draft_small_attachment(self, http_client_response):
@@ -215,6 +218,7 @@ class TestDraft:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_draft_large_attachment(self, http_client_response):
@@ -246,6 +250,7 @@ class TestDraft:
                 method="PUT",
                 path="/v3/grants/abc-123/drafts/draft-123",
                 data=mock_encoder,
+                overrides=None
             )
 
     def test_destroy_draft(self, http_client_delete_response):
@@ -259,6 +264,7 @@ class TestDraft:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_send_draft(self, http_client_response):
@@ -269,4 +275,5 @@ class TestDraft:
         http_client_response._execute.assert_called_once_with(
             method="POST",
             path="/v3/grants/abc-123/drafts/draft-123",
+            overrides=None
         )

--- a/tests/resources/test_drafts.py
+++ b/tests/resources/test_drafts.py
@@ -89,7 +89,7 @@ class TestDraft:
                 "subject": "Hello from Nylas!",
             },
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_find_draft(self, http_client_response):
@@ -98,7 +98,12 @@ class TestDraft:
         drafts.find(identifier="abc-123", draft_id="draft-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/drafts/draft-123", None, None, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/drafts/draft-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_create_draft(self, http_client_response):
@@ -113,7 +118,12 @@ class TestDraft:
         drafts.create(identifier="abc-123", request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST", "/v3/grants/abc-123/drafts", None, None, request_body, overrides=None
+            "POST",
+            "/v3/grants/abc-123/drafts",
+            None,
+            None,
+            request_body,
+            overrides=None,
         )
 
     def test_create_draft_small_attachment(self, http_client_response):
@@ -136,7 +146,12 @@ class TestDraft:
         drafts.create(identifier="abc-123", request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST", "/v3/grants/abc-123/drafts", None, None, request_body, overrides=None
+            "POST",
+            "/v3/grants/abc-123/drafts",
+            None,
+            None,
+            request_body,
+            overrides=None,
         )
 
     def test_create_draft_large_attachment(self, http_client_response):
@@ -166,7 +181,7 @@ class TestDraft:
                 method="POST",
                 path="/v3/grants/abc-123/drafts",
                 data=mock_encoder,
-                overrides=None
+                overrides=None,
             )
 
     def test_update_draft(self, http_client_response):
@@ -188,7 +203,7 @@ class TestDraft:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_draft_small_attachment(self, http_client_response):
@@ -218,7 +233,7 @@ class TestDraft:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_draft_large_attachment(self, http_client_response):
@@ -250,7 +265,7 @@ class TestDraft:
                 method="PUT",
                 path="/v3/grants/abc-123/drafts/draft-123",
                 data=mock_encoder,
-                overrides=None
+                overrides=None,
             )
 
     def test_destroy_draft(self, http_client_delete_response):
@@ -264,7 +279,7 @@ class TestDraft:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_send_draft(self, http_client_response):
@@ -273,7 +288,5 @@ class TestDraft:
         drafts.send(identifier="abc-123", draft_id="draft-123")
 
         http_client_response._execute.assert_called_once_with(
-            method="POST",
-            path="/v3/grants/abc-123/drafts/draft-123",
-            overrides=None
+            method="POST", path="/v3/grants/abc-123/drafts/draft-123", overrides=None
         )

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -118,7 +118,7 @@ class TestEvent:
                 "limit": 20,
             },
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_find_event(self, http_client_response):
@@ -136,7 +136,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_create_event(self, http_client_response):
@@ -156,7 +156,7 @@ class TestEvent:
         events.create(
             identifier="abc-123",
             request_body=request_body,
-            query_params={"calendar_id": "abc-123"}
+            query_params={"calendar_id": "abc-123"},
         )
 
         http_client_response._execute.assert_called_once_with(
@@ -165,7 +165,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_event(self, http_client_response):
@@ -195,7 +195,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_event(self, http_client_delete_response):
@@ -213,7 +213,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_send_rsvp(self, http_client_response):
@@ -232,5 +232,5 @@ class TestEvent:
             path="/v3/grants/abc-123/events/event-123/send-rsvp",
             request_body=request_body,
             query_params={"calendar_id": "abc-123"},
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -118,6 +118,7 @@ class TestEvent:
                 "limit": 20,
             },
             None,
+            overrides=None
         )
 
     def test_find_event(self, http_client_response):
@@ -135,6 +136,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             None,
+            overrides=None
         )
 
     def test_create_event(self, http_client_response):
@@ -154,7 +156,7 @@ class TestEvent:
         events.create(
             identifier="abc-123",
             request_body=request_body,
-            query_params={"calendar_id": "abc-123"},
+            query_params={"calendar_id": "abc-123"}
         )
 
         http_client_response._execute.assert_called_once_with(
@@ -163,6 +165,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             request_body,
+            overrides=None
         )
 
     def test_update_event(self, http_client_response):
@@ -192,6 +195,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             request_body,
+            overrides=None
         )
 
     def test_destroy_event(self, http_client_delete_response):
@@ -209,6 +213,7 @@ class TestEvent:
             None,
             {"calendar_id": "abc-123"},
             None,
+            overrides=None
         )
 
     def test_send_rsvp(self, http_client_response):
@@ -227,4 +232,5 @@ class TestEvent:
             path="/v3/grants/abc-123/events/event-123/send-rsvp",
             request_body=request_body,
             query_params={"calendar_id": "abc-123"},
+            overrides=None
         )

--- a/tests/resources/test_folders.py
+++ b/tests/resources/test_folders.py
@@ -46,6 +46,7 @@ class TestFolder:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_find_folder(self, http_client_response):
@@ -59,6 +60,7 @@ class TestFolder:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_create_folder(self, http_client_response):
@@ -78,6 +80,7 @@ class TestFolder:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_folder(self, http_client_response):
@@ -101,6 +104,7 @@ class TestFolder:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_folder(self, http_client_delete_response):
@@ -117,4 +121,5 @@ class TestFolder:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_folders.py
+++ b/tests/resources/test_folders.py
@@ -41,12 +41,7 @@ class TestFolder:
         folders.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET",
-            "/v3/grants/abc-123/folders",
-            None,
-            None,
-            None,
-            overrides=None
+            "GET", "/v3/grants/abc-123/folders", None, None, None, overrides=None
         )
 
     def test_find_folder(self, http_client_response):
@@ -60,7 +55,7 @@ class TestFolder:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_create_folder(self, http_client_response):
@@ -80,7 +75,7 @@ class TestFolder:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_folder(self, http_client_response):
@@ -104,7 +99,7 @@ class TestFolder:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_folder(self, http_client_delete_response):
@@ -121,5 +116,5 @@ class TestFolder:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_grants.py
+++ b/tests/resources/test_grants.py
@@ -36,7 +36,7 @@ class TestGrants:
         grants.list()
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants", None, None, None
+            "GET", "/v3/grants", None, None, None, overrides=None
         )
 
     def test_find_grant(self, http_client_response):
@@ -45,7 +45,7 @@ class TestGrants:
         grants.find("grant-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/grant-123", None, None, None
+            "GET", "/v3/grants/grant-123", None, None, None, overrides=None
         )
 
     def test_update_grant(self, http_client_response):
@@ -72,6 +72,7 @@ class TestGrants:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_grant(self, http_client_delete_response):
@@ -85,4 +86,5 @@ class TestGrants:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_grants.py
+++ b/tests/resources/test_grants.py
@@ -67,12 +67,7 @@ class TestGrants:
         )
 
         http_client_response._execute.assert_called_once_with(
-            "PUT",
-            "/v3/grants/grant-123",
-            None,
-            None,
-            request_body,
-            overrides=None
+            "PUT", "/v3/grants/grant-123", None, None, request_body, overrides=None
         )
 
     def test_destroy_grant(self, http_client_delete_response):
@@ -81,10 +76,5 @@ class TestGrants:
         grants.destroy("grant-123")
 
         http_client_delete_response._execute.assert_called_once_with(
-            "DELETE",
-            "/v3/grants/grant-123",
-            None,
-            None,
-            None,
-            overrides=None
+            "DELETE", "/v3/grants/grant-123", None, None, None, overrides=None
         )

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -92,7 +92,7 @@ class TestMessage:
                 "subject": "Hello from Nylas!",
             },
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_find_message(self, http_client_response):
@@ -101,7 +101,12 @@ class TestMessage:
         messages.find(identifier="abc-123", message_id="message-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/messages/message-123", None, None, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/messages/message-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_find_message_with_query_params(self, http_client_response):
@@ -119,7 +124,7 @@ class TestMessage:
             None,
             {"fields": "standard"},
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_message(self, http_client_response):
@@ -143,7 +148,7 @@ class TestMessage:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_message(self, http_client_delete_response):
@@ -157,7 +162,7 @@ class TestMessage:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )
 
     def test_send_message(self, http_client_response):
@@ -176,7 +181,7 @@ class TestMessage:
             path="/v3/grants/abc-123/messages/send",
             request_body=request_body,
             data=None,
-            overrides=None
+            overrides=None,
         )
 
     def test_send_message_small_attachment(self, http_client_response):
@@ -203,7 +208,7 @@ class TestMessage:
             path="/v3/grants/abc-123/messages/send",
             request_body=request_body,
             data=None,
-            overrides=None
+            overrides=None,
         )
 
     def test_send_message_large_attachment(self, http_client_response):
@@ -234,7 +239,7 @@ class TestMessage:
                 path="/v3/grants/abc-123/messages/send",
                 request_body=None,
                 data=mock_encoder,
-                overrides=None
+                overrides=None,
             )
 
     def test_list_scheduled_messages(self, http_client_list_scheduled_messages):
@@ -243,9 +248,7 @@ class TestMessage:
         res = messages.list_scheduled_messages(identifier="abc-123")
 
         http_client_list_scheduled_messages._execute.assert_called_once_with(
-            method="GET",
-            path="/v3/grants/abc-123/messages/schedules",
-            overrides=None
+            method="GET", path="/v3/grants/abc-123/messages/schedules", overrides=None
         )
         assert res.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"
         assert len(res.data) == 2
@@ -267,7 +270,7 @@ class TestMessage:
         http_client_response._execute.assert_called_once_with(
             method="GET",
             path="/v3/grants/abc-123/messages/schedules/schedule-123",
-            overrides=None
+            overrides=None,
         )
 
     def test_stop_scheduled_message(self, http_client_response):
@@ -280,7 +283,7 @@ class TestMessage:
         http_client_response._execute.assert_called_once_with(
             method="DELETE",
             path="/v3/grants/abc-123/messages/schedules/schedule-123",
-            overrides=None
+            overrides=None,
         )
 
     def test_clean_messages(self, http_client_clean_messages):
@@ -303,7 +306,7 @@ class TestMessage:
             method="PUT",
             path="/v3/grants/abc-123/messages/clean",
             request_body=request_body,
-            overrides=None
+            overrides=None,
         )
 
         # Assert the conversation field, and the typical message fields serialize properly

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -71,7 +71,7 @@ class TestMessage:
         messages.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/messages", None, None, None
+            "GET", "/v3/grants/abc-123/messages", None, None, None, overrides=None
         )
 
     def test_list_messages_with_query_params(self, http_client_list_response):
@@ -92,6 +92,7 @@ class TestMessage:
                 "subject": "Hello from Nylas!",
             },
             None,
+            overrides=None
         )
 
     def test_find_message(self, http_client_response):
@@ -100,7 +101,7 @@ class TestMessage:
         messages.find(identifier="abc-123", message_id="message-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/messages/message-123", None, None, None
+            "GET", "/v3/grants/abc-123/messages/message-123", None, None, None, overrides=None
         )
 
     def test_find_message_with_query_params(self, http_client_response):
@@ -118,6 +119,7 @@ class TestMessage:
             None,
             {"fields": "standard"},
             None,
+            overrides=None
         )
 
     def test_update_message(self, http_client_response):
@@ -141,6 +143,7 @@ class TestMessage:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_message(self, http_client_delete_response):
@@ -154,6 +157,7 @@ class TestMessage:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_send_message(self, http_client_response):
@@ -172,6 +176,7 @@ class TestMessage:
             path="/v3/grants/abc-123/messages/send",
             request_body=request_body,
             data=None,
+            overrides=None
         )
 
     def test_send_message_small_attachment(self, http_client_response):
@@ -198,6 +203,7 @@ class TestMessage:
             path="/v3/grants/abc-123/messages/send",
             request_body=request_body,
             data=None,
+            overrides=None
         )
 
     def test_send_message_large_attachment(self, http_client_response):
@@ -228,6 +234,7 @@ class TestMessage:
                 path="/v3/grants/abc-123/messages/send",
                 request_body=None,
                 data=mock_encoder,
+                overrides=None
             )
 
     def test_list_scheduled_messages(self, http_client_list_scheduled_messages):
@@ -259,6 +266,7 @@ class TestMessage:
         http_client_response._execute.assert_called_once_with(
             method="GET",
             path="/v3/grants/abc-123/messages/schedules/schedule-123",
+            overrides=None
         )
 
     def test_stop_scheduled_message(self, http_client_response):
@@ -293,6 +301,7 @@ class TestMessage:
             method="PUT",
             path="/v3/grants/abc-123/messages/clean",
             request_body=request_body,
+            overrides=None
         )
 
         # Assert the conversation field, and the typical message fields serialize properly

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -245,6 +245,7 @@ class TestMessage:
         http_client_list_scheduled_messages._execute.assert_called_once_with(
             method="GET",
             path="/v3/grants/abc-123/messages/schedules",
+            overrides=None
         )
         assert res.request_id == "dd3ec9a2-8f15-403d-b269-32b1f1beb9f5"
         assert len(res.data) == 2
@@ -279,6 +280,7 @@ class TestMessage:
         http_client_response._execute.assert_called_once_with(
             method="DELETE",
             path="/v3/grants/abc-123/messages/schedules/schedule-123",
+            overrides=None
         )
 
     def test_clean_messages(self, http_client_clean_messages):

--- a/tests/resources/test_redirect_uris.py
+++ b/tests/resources/test_redirect_uris.py
@@ -46,7 +46,12 @@ class TestRedirectUri:
         redirect_uris.find(redirect_uri_id="redirect_uri-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/applications/redirect-uris/redirect_uri-123", None, None, None, overrides=None
+            "GET",
+            "/v3/applications/redirect-uris/redirect_uri-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_create_redirect_uri(self, http_client_response):
@@ -72,7 +77,7 @@ class TestRedirectUri:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_update_redirect_uri(self, http_client_response):
@@ -101,7 +106,7 @@ class TestRedirectUri:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_redirect_uri(self, http_client_delete_response):
@@ -115,5 +120,5 @@ class TestRedirectUri:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_redirect_uris.py
+++ b/tests/resources/test_redirect_uris.py
@@ -37,7 +37,7 @@ class TestRedirectUri:
         redirect_uris.list()
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/applications/redirect-uris", None, None, None
+            "GET", "/v3/applications/redirect-uris", None, None, None, overrides=None
         )
 
     def test_find_redirect_uri(self, http_client_response):
@@ -46,7 +46,7 @@ class TestRedirectUri:
         redirect_uris.find(redirect_uri_id="redirect_uri-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/applications/redirect-uris/redirect_uri-123", None, None, None
+            "GET", "/v3/applications/redirect-uris/redirect_uri-123", None, None, None, overrides=None
         )
 
     def test_create_redirect_uri(self, http_client_response):
@@ -72,6 +72,7 @@ class TestRedirectUri:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_redirect_uri(self, http_client_response):
@@ -100,6 +101,7 @@ class TestRedirectUri:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_redirect_uri(self, http_client_delete_response):
@@ -113,4 +115,5 @@ class TestRedirectUri:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_smart_compose.py
+++ b/tests/resources/test_smart_compose.py
@@ -20,6 +20,7 @@ class TestSmartCompose:
             method="POST",
             path="/v3/grants/grant-123/messages/smart-compose",
             request_body=request_body,
+            overrides=None
         )
 
     def test_compose_message_reply(self, http_client_response):
@@ -32,4 +33,5 @@ class TestSmartCompose:
             method="POST",
             path="/v3/grants/grant-123/messages/message-123/smart-compose",
             request_body=request_body,
+            overrides=None
         )

--- a/tests/resources/test_smart_compose.py
+++ b/tests/resources/test_smart_compose.py
@@ -20,7 +20,7 @@ class TestSmartCompose:
             method="POST",
             path="/v3/grants/grant-123/messages/smart-compose",
             request_body=request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_compose_message_reply(self, http_client_response):
@@ -33,5 +33,5 @@ class TestSmartCompose:
             method="POST",
             path="/v3/grants/grant-123/messages/message-123/smart-compose",
             request_body=request_body,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_threads.py
+++ b/tests/resources/test_threads.py
@@ -139,7 +139,12 @@ class TestThread:
         threads.list(identifier="abc-123", query_params={"to": "abc@gmail.com"})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/threads", None, {"to": "abc@gmail.com"}, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/threads",
+            None,
+            {"to": "abc@gmail.com"},
+            None,
+            overrides=None,
         )
 
     def test_find_thread(self, http_client_response):
@@ -148,7 +153,12 @@ class TestThread:
         threads.find(identifier="abc-123", thread_id="thread-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/threads/thread-123", None, None, None, overrides=None
+            "GET",
+            "/v3/grants/abc-123/threads/thread-123",
+            None,
+            None,
+            None,
+            overrides=None,
         )
 
     def test_update_thread(self, http_client_response):
@@ -169,7 +179,7 @@ class TestThread:
             None,
             None,
             request_body,
-            overrides=None
+            overrides=None,
         )
 
     def test_destroy_thread(self, http_client_delete_response):
@@ -183,5 +193,5 @@ class TestThread:
             None,
             None,
             None,
-            overrides=None
+            overrides=None,
         )

--- a/tests/resources/test_threads.py
+++ b/tests/resources/test_threads.py
@@ -130,7 +130,7 @@ class TestThread:
         threads.list(identifier="abc-123")
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/threads", None, None, None
+            "GET", "/v3/grants/abc-123/threads", None, None, None, overrides=None
         )
 
     def test_list_threads_with_query_params(self, http_client_list_response):
@@ -139,7 +139,7 @@ class TestThread:
         threads.list(identifier="abc-123", query_params={"to": "abc@gmail.com"})
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/threads", None, {"to": "abc@gmail.com"}, None
+            "GET", "/v3/grants/abc-123/threads", None, {"to": "abc@gmail.com"}, None, overrides=None
         )
 
     def test_find_thread(self, http_client_response):
@@ -148,7 +148,7 @@ class TestThread:
         threads.find(identifier="abc-123", thread_id="thread-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/grants/abc-123/threads/thread-123", None, None, None
+            "GET", "/v3/grants/abc-123/threads/thread-123", None, None, None, overrides=None
         )
 
     def test_update_thread(self, http_client_response):
@@ -169,6 +169,7 @@ class TestThread:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_thread(self, http_client_delete_response):
@@ -182,4 +183,5 @@ class TestThread:
             None,
             None,
             None,
+            overrides=None
         )

--- a/tests/resources/test_webhooks.py
+++ b/tests/resources/test_webhooks.py
@@ -39,7 +39,7 @@ class TestWebhooks:
         webhooks.list()
 
         http_client_list_response._execute.assert_called_once_with(
-            "GET", "/v3/webhooks", None, None, None
+            "GET", "/v3/webhooks", None, None, None, overrides=None
         )
 
     def test_find_webhook(self, http_client_response):
@@ -48,7 +48,7 @@ class TestWebhooks:
         webhooks.find("webhook-123")
 
         http_client_response._execute.assert_called_once_with(
-            "GET", "/v3/webhooks/webhook-123", None, None, None
+            "GET", "/v3/webhooks/webhook-123", None, None, None, overrides=None
         )
 
     def test_create_webhook(self, http_client_response):
@@ -68,6 +68,7 @@ class TestWebhooks:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_update_webhook(self, http_client_response):
@@ -90,6 +91,7 @@ class TestWebhooks:
             None,
             None,
             request_body,
+            overrides=None
         )
 
     def test_destroy_webhook(self, http_client_delete_response):
@@ -103,6 +105,7 @@ class TestWebhooks:
             None,
             None,
             None,
+            overrides=None
         )
 
     def test_rotate_secret(self, http_client_response):
@@ -114,6 +117,7 @@ class TestWebhooks:
             method="PUT",
             path="/v3/webhooks/webhook-123/rotate-secret",
             request_body={},
+            overrides=None
         )
 
     def test_ip_addresses(self, http_client_response):
@@ -124,6 +128,7 @@ class TestWebhooks:
         http_client_response._execute.assert_called_once_with(
             method="GET",
             path="/v3/webhooks/ip-addresses",
+            overrides=None
         )
 
     def test_extract_challenge_parameter(self, http_client):

--- a/tests/resources/test_webhooks.py
+++ b/tests/resources/test_webhooks.py
@@ -63,12 +63,7 @@ class TestWebhooks:
         webhooks.create(request_body=request_body)
 
         http_client_response._execute.assert_called_once_with(
-            "POST",
-            "/v3/webhooks",
-            None,
-            None,
-            request_body,
-            overrides=None
+            "POST", "/v3/webhooks", None, None, request_body, overrides=None
         )
 
     def test_update_webhook(self, http_client_response):
@@ -86,12 +81,7 @@ class TestWebhooks:
         )
 
         http_client_response._execute.assert_called_once_with(
-            "PUT",
-            "/v3/webhooks/webhook-123",
-            None,
-            None,
-            request_body,
-            overrides=None
+            "PUT", "/v3/webhooks/webhook-123", None, None, request_body, overrides=None
         )
 
     def test_destroy_webhook(self, http_client_delete_response):
@@ -100,12 +90,7 @@ class TestWebhooks:
         webhooks.destroy("webhook-123")
 
         http_client_delete_response._execute.assert_called_once_with(
-            "DELETE",
-            "/v3/webhooks/webhook-123",
-            None,
-            None,
-            None,
-            overrides=None
+            "DELETE", "/v3/webhooks/webhook-123", None, None, None, overrides=None
         )
 
     def test_rotate_secret(self, http_client_response):
@@ -117,7 +102,7 @@ class TestWebhooks:
             method="PUT",
             path="/v3/webhooks/webhook-123/rotate-secret",
             request_body={},
-            overrides=None
+            overrides=None,
         )
 
     def test_ip_addresses(self, http_client_response):
@@ -126,9 +111,7 @@ class TestWebhooks:
         webhooks.ip_addresses()
 
         http_client_response._execute.assert_called_once_with(
-            method="GET",
-            path="/v3/webhooks/ip-addresses",
-            overrides=None
+            method="GET", path="/v3/webhooks/ip-addresses", overrides=None
         )
 
     def test_extract_challenge_parameter(self, http_client):


### PR DESCRIPTION
# Description
This PR adds support for adding a new `RequestOverride` object which can be built with fields that can override:
* API URI
* API Key
* Timeout
* and, adding additional headers

for outgoing requests.

# Usage
For all methods that call the Nylas API, there is now an additional `overrides: RequestOverrides` field that takes in the built object and will override the specific outgoing call with whatever non-null values are present. This can also be used to add additional headers to outgoing calls. Here's an example:
```python
from nylas import Client

nylas = Client(
    api_key="API_KEY",
)

calendars, request_id, next_cursor = nylas.calendars.list("GRANT_ID", overrides={
 "api_key": "SECONDARY_API_KEY",
 "api_uri": "https://random.api.nylas.com",
 "timeout": 360,
 "headers": {
    "X-Header": "value"
  }
})
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
