### PR TITLE
Added support for event_type filtering field for listing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 * Added support for adding custom headers to outgoing requests
 * Added support for overriding various fields of outgoing requests
 * Added support for `provider` field in code exchange response
+* Added support for `event_type` filtering field for listing events
 * Added clean messages support
 * Added additional webhook triggers
 * Made event visibility optional to support iCloud events

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -18,6 +18,9 @@ ParticipantStatus = Literal["noreply", "yes", "no", "maybe"]
 SendRsvpStatus = Literal["yes", "no", "maybe"]
 """ Literal representing the status of an RSVP. """
 
+EventType = Literal["default", "outOfOffice", "focusTime", "workingLocation"]
+""" Literal representing the event type to filter by. """
+
 
 @dataclass_json
 @dataclass
@@ -722,6 +725,8 @@ class ListEventQueryParams(ListQueryParams):
             This field defaults to 50. The maximum allowed value is 200.
         page_token (NotRequired[str]): An identifier that specifies which page of data to return.
             This value should be taken from a ListResponse object's next_cursor parameter.
+        event_type (NotRequired[List[EventType]]): (Google only) Filter events by event type.
+            You can pass the query parameter multiple times to select or exclude multiple event types.
     """
 
     calendar_id: str
@@ -735,6 +740,7 @@ class ListEventQueryParams(ListQueryParams):
     expand_recurring: NotRequired[bool]
     busy: NotRequired[bool]
     order_by: NotRequired[str]
+    event_type: NotRequired[List[EventType]]
 
 
 class CreateEventQueryParams(TypedDict):


### PR DESCRIPTION
# Description
This PR adds support for filtering events by event type. Note that this feature is only for Google events.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
