### PR TITLE
Adding scope as an optional parameter to the CodeExchangeResponse

### DIFF
--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -119,10 +119,10 @@ class CodeExchangeResponse:
 
     access_token: str
     grant_id: str
-    scope: str
     expires_in: int
     email: Optional[str] = None
     refresh_token: Optional[str] = None
+    scope: Optional[str] = None
     id_token: Optional[str] = None
     token_type: Optional[str] = None
     provider: Optional[Provider] = None


### PR DESCRIPTION
# Description

Adding `scope` as an optional string due to ICloud and IMAP grants not having a `scope` property associated with them.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
