### PR TITLE
Fix deserialization error with event participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 * Added additional webhook triggers
 * Made event visibility optional to support iCloud events
 * Fixed issue where attachments < 3mb were not being encoded correctly
+* Fixed issue deserializing event and code exchange responses.
 
 v6.1.1
 ----------------

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -37,7 +37,7 @@ class Participant:
     """
 
     email: str
-    status: ParticipantStatus
+    status: Optional[ParticipantStatus] = None
     name: Optional[str] = None
     comment: Optional[str] = None
     phone_number: Optional[str] = None


### PR DESCRIPTION
# Description
Event participant status is optional, as the field doesn't get populated for iCloud events.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
