### PR TITLE
Remove use of TestCommand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ import shutil
 import sys
 import re
 import subprocess
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
+from setuptools import setup, find_packages, Command
 
 
 VERSION = ""
@@ -36,11 +35,10 @@ DOCS_DEPENDENCIES = [
 RELEASE_DEPENDENCIES = ["bumpversion>=0.6.0", "twine>=4.0.2"]
 
 
-class PyTest(TestCommand):
+class PyTest(Command):
     user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
 
     def initialize_options(self):
-        TestCommand.initialize_options(self)
         # pylint: disable=attribute-defined-outside-init
         self.pytest_args = [
             "--cov",
@@ -52,12 +50,11 @@ class PyTest(TestCommand):
         self.lint = False
 
     def finalize_options(self):
-        TestCommand.finalize_options(self)
         # pylint: disable=attribute-defined-outside-init
         self.test_args = []
         self.test_suite = True
 
-    def run_tests(self):
+    def run(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
 


### PR DESCRIPTION
# Description
This PR removes the use of `TestCommand` and uses `Command` instead. `setuptools` is set to remove `TestCommand` in November.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.