### PR TITLE
Hanlde non JSON responses via a NylasAPI Error exception

### DIFF
--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -17,7 +17,19 @@ from nylas.models.errors import (
 
 
 def _validate_response(response: Response) -> dict:
-    json = response.json()
+    try:
+        json = response.json()
+    except Exception as exc:
+        raise NylasApiError(
+            NylasApiErrorResponse(
+                None,
+                NylasApiErrorResponseData(
+                    type="unknown",
+                    message=response.content,
+                ),
+            ),
+            status_code=response.status_code,
+        ) from exc
     if response.status_code >= 400:
         parsed_url = urlparse(response.url)
         try:


### PR DESCRIPTION
# Description
This is a PR attempt to handle non-json responses in our SDK. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
