### PR TITLE
Use a fresh connection on every request

### DIFF
--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -70,7 +70,6 @@ class HttpClient:
         self.api_server = api_server
         self.api_key = api_key
         self.timeout = timeout
-        self.session = requests.Session()
 
     def _execute(
         self,
@@ -90,7 +89,7 @@ class HttpClient:
         if overrides and overrides.get("timeout"):
             timeout = overrides["timeout"]
         try:
-            response = self.session.request(
+            response = requests.request(
                 request["method"],
                 request["url"],
                 headers=request["headers"],
@@ -117,7 +116,7 @@ class HttpClient:
         if overrides and overrides.get("timeout"):
             timeout = overrides["timeout"]
         try:
-            response = self.session.request(
+            response = requests.request(
                 request["method"],
                 request["url"],
                 headers=request["headers"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,19 +34,19 @@ def patched_version_and_sys():
 
 
 @pytest.fixture
-def patched_session_request():
+def patched_request():
     mock_response = Mock()
     mock_response.content = b"mock data"
     mock_response.json.return_value = {"foo": "bar"}
     mock_response.status_code = 200
 
-    with patch("requests.Session.request", return_value=mock_response) as mock_request:
+    with patch("requests.request", return_value=mock_response) as mock_request:
         yield mock_request
 
 
 @pytest.fixture
 def mock_session_timeout():
-    with patch("requests.Session.request", side_effect=requests.exceptions.Timeout):
+    with patch("requests.request", side_effect=requests.exceptions.Timeout):
         yield
 
 

--- a/tests/handler/test_http_client.py
+++ b/tests/handler/test_http_client.py
@@ -162,14 +162,14 @@ class TestHttpClient:
             == "https://test.nylas.com/foo?foo=bar&list=a&list=b&list=c&map=key1:value1&map=key2:value2"
         )
 
-    def test_execute_download_request(self, http_client, patched_session_request):
+    def test_execute_download_request(self, http_client, patched_request):
         response = http_client._execute_download_request(
             path="/foo",
         )
         assert response == b"mock data"
 
     def test_execute_download_request_with_stream(
-        self, http_client, patched_session_request
+        self, http_client, patched_request
     ):
         response = http_client._execute_download_request(
             path="/foo",
@@ -189,13 +189,13 @@ class TestHttpClient:
         )
 
     def test_execute_download_request_override_timeout(
-        self, http_client, patched_version_and_sys, patched_session_request
+        self, http_client, patched_version_and_sys, patched_request
     ):
         response = http_client._execute_download_request(
             path="/foo",
             overrides={"timeout": 60},
         )
-        patched_session_request.assert_called_once_with(
+        patched_request.assert_called_once_with(
             "GET",
             "https://test.nylas.com/foo",
             headers={
@@ -276,7 +276,7 @@ class TestHttpClient:
         assert e.value.status_code == 400
 
     def test_execute(
-        self, http_client, patched_version_and_sys, patched_session_request
+        self, http_client, patched_version_and_sys, patched_request
     ):
         response = http_client._execute(
             method="GET",
@@ -287,7 +287,7 @@ class TestHttpClient:
         )
 
         assert response == {"foo": "bar"}
-        patched_session_request.assert_called_once_with(
+        patched_request.assert_called_once_with(
             "GET",
             "https://test.nylas.com/foo?query=param",
             headers={
@@ -303,7 +303,7 @@ class TestHttpClient:
         )
 
     def test_execute_override_timeout(
-        self, http_client, patched_version_and_sys, patched_session_request
+        self, http_client, patched_version_and_sys, patched_request
     ):
         response = http_client._execute(
             method="GET",
@@ -315,7 +315,7 @@ class TestHttpClient:
         )
 
         assert response == {"foo": "bar"}
-        patched_session_request.assert_called_once_with(
+        patched_request.assert_called_once_with(
             "GET",
             "https://test.nylas.com/foo?query=param",
             headers={


### PR DESCRIPTION
We shouldn't be using a shared `requests.Session()` object across all requests that a client makes. If the client (and therefore the session) is shared across multiple threads or greenlets we can encounter a race condition that causes the following error:
```
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```
This happens because the session maintains a connection pool for each host (keep-alive). If a connection is closed by the server around the same time a thread tries to make a new request using that connection, then the new request will be made on the already closed connection.

This PR simply removes the `session` member and lets the requests package make a new connection on every request.
