### PR TITLE
Fix IMAP identifiers not encoding correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------------
+* Fix IMAP identifiers not encoding correctly
+
 v6.3.1
 ----------------
 * Fix typo on Clean Messages

--- a/nylas/resources/drafts.py
+++ b/nylas/resources/drafts.py
@@ -1,4 +1,5 @@
 import io
+import urllib.parse
 from typing import Optional
 
 from nylas.config import RequestOverrides
@@ -79,7 +80,7 @@ class Drafts(
             The requested Draft.
         """
         return super().find(
-            path=f"/v3/grants/{identifier}/drafts/{draft_id}",
+            path=f"/v3/grants/{identifier}/drafts/{urllib.parse.quote(draft_id, safe='')}",
             response_type=Draft,
             overrides=overrides,
         )
@@ -149,7 +150,7 @@ class Drafts(
         Returns:
             The updated Draft.
         """
-        path = f"/v3/grants/{identifier}/drafts/{draft_id}"
+        path = f"/v3/grants/{identifier}/drafts/{urllib.parse.quote(draft_id, safe='')}"
 
         # Use form data only if the attachment size is greater than 3mb
         attachment_size = sum(
@@ -196,7 +197,7 @@ class Drafts(
             The deletion response.
         """
         return super().destroy(
-            path=f"/v3/grants/{identifier}/drafts/{draft_id}",
+            path=f"/v3/grants/{identifier}/drafts/{urllib.parse.quote(draft_id, safe='')}",
             overrides=overrides,
         )
 
@@ -216,7 +217,7 @@ class Drafts(
         """
         json_response = self._http_client._execute(
             method="POST",
-            path=f"/v3/grants/{identifier}/drafts/{draft_id}",
+            path=f"/v3/grants/{identifier}/drafts/{urllib.parse.quote(draft_id, safe='')}",
             overrides=overrides,
         )
 

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -1,4 +1,5 @@
 import io
+import urllib.parse
 from typing import Optional, List
 
 from nylas.config import RequestOverrides
@@ -96,7 +97,7 @@ class Messages(
             The requested Message.
         """
         return super().find(
-            path=f"/v3/grants/{identifier}/messages/{message_id}",
+            path=f"/v3/grants/{identifier}/messages/{urllib.parse.quote(message_id, safe='')}",
             response_type=Message,
             query_params=query_params,
             overrides=overrides,
@@ -122,7 +123,7 @@ class Messages(
             The updated Message.
         """
         return super().update(
-            path=f"/v3/grants/{identifier}/messages/{message_id}",
+            path=f"/v3/grants/{identifier}/messages/{urllib.parse.quote(message_id, safe='')}",
             response_type=Message,
             request_body=request_body,
             overrides=overrides,
@@ -143,7 +144,8 @@ class Messages(
             The deletion response.
         """
         return super().destroy(
-            path=f"/v3/grants/{identifier}/messages/{message_id}", overrides=overrides
+            path=f"/v3/grants/{identifier}/messages/{urllib.parse.quote(message_id, safe='')}",
+            overrides=overrides,
         )
 
     def send(

--- a/nylas/resources/threads.py
+++ b/nylas/resources/threads.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     ListableApiResource,
@@ -60,7 +61,7 @@ class Threads(
             The requested Thread.
         """
         return super().find(
-            path=f"/v3/grants/{identifier}/threads/{thread_id}",
+            path=f"/v3/grants/{identifier}/threads/{urllib.parse.quote(thread_id, safe='')}",
             response_type=Thread,
             overrides=overrides,
         )
@@ -85,7 +86,7 @@ class Threads(
             The updated Thread.
         """
         return super().update(
-            path=f"/v3/grants/{identifier}/threads/{thread_id}",
+            path=f"/v3/grants/{identifier}/threads/{urllib.parse.quote(thread_id, safe='')}",
             response_type=Thread,
             request_body=request_body,
             overrides=overrides,
@@ -106,5 +107,6 @@ class Threads(
             The deletion response.
         """
         return super().destroy(
-            path=f"/v3/grants/{identifier}/threads/{thread_id}", overrides=overrides
+            path=f"/v3/grants/{identifier}/threads/{urllib.parse.quote(thread_id, safe='')}",
+            overrides=overrides,
         )

--- a/tests/resources/test_drafts.py
+++ b/tests/resources/test_drafts.py
@@ -106,6 +106,23 @@ class TestDraft:
             overrides=None,
         )
 
+    def test_find_draft_encoded_id(self, http_client_response):
+        drafts = Drafts(http_client_response)
+
+        drafts.find(
+            identifier="abc-123",
+            draft_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "GET",
+            "/v3/grants/abc-123/drafts/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
     def test_create_draft(self, http_client_response):
         drafts = Drafts(http_client_response)
         request_body = {
@@ -206,6 +223,30 @@ class TestDraft:
             overrides=None,
         )
 
+    def test_update_draft_encoded_id(self, http_client_response):
+        drafts = Drafts(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "cc": [{"name": "Arya Stark", "email": "astark@gmail.com"}],
+            "body": "This is the body of my draft message.",
+        }
+
+        drafts.update(
+            identifier="abc-123",
+            draft_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+            request_body=request_body,
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "PUT",
+            "/v3/grants/abc-123/drafts/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            request_body,
+            overrides=None,
+        )
+
     def test_update_draft_small_attachment(self, http_client_response):
         drafts = Drafts(http_client_response)
         request_body = {
@@ -282,6 +323,23 @@ class TestDraft:
             overrides=None,
         )
 
+    def test_destroy_draft_encoded_id(self, http_client_delete_response):
+        drafts = Drafts(http_client_delete_response)
+
+        drafts.destroy(
+            identifier="abc-123",
+            draft_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_delete_response._execute.assert_called_once_with(
+            "DELETE",
+            "/v3/grants/abc-123/drafts/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
     def test_send_draft(self, http_client_response):
         drafts = Drafts(http_client_response)
 
@@ -289,4 +347,18 @@ class TestDraft:
 
         http_client_response._execute.assert_called_once_with(
             method="POST", path="/v3/grants/abc-123/drafts/draft-123", overrides=None
+        )
+
+    def test_send_draft_encoded_id(self, http_client_response):
+        drafts = Drafts(http_client_response)
+
+        drafts.send(
+            identifier="abc-123",
+            draft_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/drafts/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            overrides=None,
         )

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -109,6 +109,23 @@ class TestMessage:
             overrides=None,
         )
 
+    def test_find_message_encoded_id(self, http_client_response):
+        messages = Messages(http_client_response)
+
+        messages.find(
+            identifier="abc-123",
+            message_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "GET",
+            "/v3/grants/abc-123/messages/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
     def test_find_message_with_query_params(self, http_client_response):
         messages = Messages(http_client_response)
 
@@ -151,6 +168,30 @@ class TestMessage:
             overrides=None,
         )
 
+    def test_update_message_encoded_id(self, http_client_response):
+        messages = Messages(http_client_response)
+        request_body = {
+            "starred": True,
+            "unread": False,
+            "folders": ["folder-123"],
+            "metadata": {"foo": "bar"},
+        }
+
+        messages.update(
+            identifier="abc-123",
+            message_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+            request_body=request_body,
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "PUT",
+            "/v3/grants/abc-123/messages/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            request_body,
+            overrides=None,
+        )
+
     def test_destroy_message(self, http_client_delete_response):
         messages = Messages(http_client_delete_response)
 
@@ -159,6 +200,23 @@ class TestMessage:
         http_client_delete_response._execute.assert_called_once_with(
             "DELETE",
             "/v3/grants/abc-123/messages/message-123",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
+    def test_destroy_message_encoded_id(self, http_client_delete_response):
+        messages = Messages(http_client_delete_response)
+
+        messages.destroy(
+            identifier="abc-123",
+            message_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_delete_response._execute.assert_called_once_with(
+            "DELETE",
+            "/v3/grants/abc-123/messages/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
             None,
             None,
             None,

--- a/tests/resources/test_threads.py
+++ b/tests/resources/test_threads.py
@@ -161,6 +161,23 @@ class TestThread:
             overrides=None,
         )
 
+    def test_find_thread_encoded_id(self, http_client_response):
+        threads = Threads(http_client_response)
+
+        threads.find(
+            identifier="abc-123",
+            thread_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "GET",
+            "/v3/grants/abc-123/threads/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
     def test_update_thread(self, http_client_response):
         threads = Threads(http_client_response)
         request_body = {
@@ -182,6 +199,29 @@ class TestThread:
             overrides=None,
         )
 
+    def test_update_thread_encoded_id(self, http_client_response):
+        threads = Threads(http_client_response)
+        request_body = {
+            "starred": True,
+            "unread": False,
+            "folders": ["folder-123"],
+        }
+
+        threads.update(
+            identifier="abc-123",
+            thread_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+            request_body=request_body,
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "PUT",
+            "/v3/grants/abc-123/threads/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
+            None,
+            None,
+            request_body,
+            overrides=None,
+        )
+
     def test_destroy_thread(self, http_client_delete_response):
         threads = Threads(http_client_delete_response)
 
@@ -190,6 +230,23 @@ class TestThread:
         http_client_delete_response._execute.assert_called_once_with(
             "DELETE",
             "/v3/grants/abc-123/threads/thread-123",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+
+    def test_destroy_thread_encode_id(self, http_client_delete_response):
+        threads = Threads(http_client_delete_response)
+
+        threads.destroy(
+            identifier="abc-123",
+            thread_id="<!&!AAAAAAAAAAAuAAAAAAAAABQ/wHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ/T4N/0BgqPmf+AQAAAAA=@example.com>",
+        )
+
+        http_client_delete_response._execute.assert_called_once_with(
+            "DELETE",
+            "/v3/grants/abc-123/threads/%3C%21%26%21AAAAAAAAAAAuAAAAAAAAABQ%2FwHZyqaNCptfKg5rnNAoBAMO2jhD3dRHOtM0AqgC7tuYAAAAAAA4AABAAAACTn3BxdTQ%2FT4N%2F0BgqPmf%2BAQAAAAA%3D%40example.com%3E",
             None,
             None,
             None,


### PR DESCRIPTION
# Description
IMAP identifiers sometimes have characters that do not work well in the URL, including slashes, that would make the request fail. For these endpoints we ensure that we are encoding these IDs properly.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
