### PR TITLE
Add missing schedule-specific fields to Message model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Fix IMAP identifiers not encoding correctly
+* Add missing schedule-specific fields to Message model
 
 v6.3.1
 ----------------

--- a/nylas/models/messages.py
+++ b/nylas/models/messages.py
@@ -53,10 +53,14 @@ class Message:
         folders: The folders that the message is in.
         headers: The headers of the message.
         created_at: Unix timestamp of when the message was created.
+        schedule_id: The ID of the scheduled email message. Nylas returns the schedule_id if send_at is set.
+        send_at: Unix timestamp of when the message will be sent, if scheduled.
     """
 
     grant_id: str
-    from_: Optional[List[EmailName]] = field(default=None,metadata=config(field_name="from"))
+    from_: Optional[List[EmailName]] = field(
+        default=None, metadata=config(field_name="from")
+    )
     object: str = "message"
     id: Optional[str] = None
     body: Optional[str] = None
@@ -74,6 +78,8 @@ class Message:
     starred: Optional[bool] = None
     created_at: Optional[int] = None
     date: Optional[int] = None
+    schedule_id: Optional[str] = None
+    send_at: Optional[int] = None
 
 
 # Need to use Functional typed dicts because "from" and "in" are Python


### PR DESCRIPTION
# Description
This PR adds in two fields, `schedule_id` and `send_at`, to the `Message` model. These fields are returned by the API if the message being sent is scheduled.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
