### PR TITLE
Add support for from field for sending messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ nylas-python Changelog
 
 Unreleased
 ----------------
+* Add support for from field for sending messages
 * Fix IMAP identifiers not encoding correctly
 
 v6.3.1

--- a/nylas/models/drafts.py
+++ b/nylas/models/drafts.py
@@ -164,7 +164,9 @@ class SendMessageRequest(CreateDraftRequest):
         reply_to_message_id (NotRequired[str]): The ID of the message that you are replying to.
         tracking_options (NotRequired[TrackingOptions]): Options for tracking opens, links, and thread replies.
         custom_headers(NotRequired[List[CustomHeader]]): Custom headers to add to the message.
+        from_: The sender of the message.
         use_draft: Whether or not to use draft support. This is primarily used when dealing with large attachments.
     """
 
+    from_: NotRequired[List[EmailName]]
     use_draft: NotRequired[bool]

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -169,6 +169,10 @@ class Messages(
         form_data = None
         json_body = None
 
+        # From is a reserved keyword in Python, so we need to pull the data from 'from_' instead
+        if request_body["from_"]:
+            request_body["from"] = request_body.pop("from_")
+
         # Use form data only if the attachment size is greater than 3mb
         attachment_size = sum(
             attachment.get("size", 0)

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -170,8 +170,7 @@ class Messages(
         json_body = None
 
         # From is a reserved keyword in Python, so we need to pull the data from 'from_' instead
-        if request_body["from_"]:
-            request_body["from"] = request_body.pop("from_")
+        request_body["from"] = request_body.get("from_", None)
 
         # Use form data only if the attachment size is greater than 3mb
         attachment_size = sum(


### PR DESCRIPTION
# Description
Added support for a from field in `SendMessageRequest`.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
