### PR TITLE
Fix NylasOAuthError not setting the status code properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 * Add support for from field for sending messages
 * Fix IMAP identifiers not encoding correctly
 * Add missing schedule-specific fields to Message model
+* Fix NylasOAuthError not setting the status code properly
 
 v6.3.1
 ----------------

--- a/nylas/models/errors.py
+++ b/nylas/models/errors.py
@@ -134,7 +134,7 @@ class NylasOAuthError(AbstractNylasApiError):
             oauth_error: The error details from the API.
             status_code: The HTTP status code of the error response.
         """
-        super().__init__(oauth_error.error_description, status_code)
+        super().__init__(oauth_error.error_description, None, status_code)
         self.error: str = oauth_error.error
         self.error_code: int = oauth_error.error_code
         self.error_description: str = oauth_error.error_description


### PR DESCRIPTION
# Description
We were setting the wrong positional arguments when initing a NylasOAuthError. Closes #379.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
