### PR TITLE
Marking thread fields to Optional to address KeyErrors

### DIFF
--- a/nylas/models/threads.py
+++ b/nylas/models/threads.py
@@ -65,13 +65,14 @@ class Thread:
     has_drafts: bool
     starred: bool
     unread: bool
-    earliest_message_date: int
     message_ids: List[str]
     folders: List[str]
     latest_draft_or_message: Union[Message, Draft] = field(
+        default=None,
         metadata=config(decoder=_decode_draft_or_message)
     )
     object: str = "thread"
+    earliest_message_date: Optional[int] = None
     latest_message_received_date: Optional[int] = None
     draft_ids: Optional[List[str]] = None
     snippet: Optional[str] = None


### PR DESCRIPTION
# Description
Microsoft accounts doesn't return all the Thread values for some threads which leads to KeyErrors. This ticket marks the fields to Optional so that users can still enrich the data.

Ticket: https://nylas.atlassian.net/browse/CUST-3173

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
