### PR TITLE
adding this header reduces the networking by 10X

### DIFF
--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -179,6 +179,7 @@ class HttpClient:
             "X-Nylas-API-Wrapper": "python",
             "User-Agent": user_agent_header,
             "Authorization": f"Bearer {api_key}",
+            "Accept-Encoding": "gzip",
         }
         if data is not None and data.content_type is not None:
             headers["Content-type"] = data.content_type


### PR DESCRIPTION
# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adding this header allows for nginx to compress the payloads resulting in compressed json payloads by an order of magnitude