### PR TITLE
Validate attachment response and throw error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+# Unreleased
+----------------
+* Fixed attachment download response handling
+
 v6.4.0
 ----------------
 * Add support for from field for sending messages

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -46,8 +46,8 @@ def _validate_response(response: Response) -> dict:
     return json
 
 def _validate_download_response(response:Response, stream = False) -> Union[bytes, Response, dict]:
-    if response.status_code < 400:
-        return response if stream == True else response.content
+    if response.ok:
+        return response.content
     return _validate_response(response)
 
 def _build_query_params(base_url: str, query_params: dict = None) -> str:

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -130,7 +130,7 @@ class HttpClient:
 
             # If we stream an iterator for streaming the content, otherwise return the entire byte array
             if stream:
-                return _validate_download_response(response,stream)
+                return response if response.ok else _validate_response(response)
 
             return _validate_download_response(response) if response.content else None
         except requests.exceptions.Timeout as exc:

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -45,6 +45,10 @@ def _validate_response(response: Response) -> dict:
 
     return json
 
+def _validate_download_response(response:Response, stream = False) -> Union[bytes, Response, dict]:
+    if response.status_code < 400:
+        return response if stream == True else response.content
+    return _validate_response(response)
 
 def _build_query_params(base_url: str, query_params: dict = None) -> str:
     query_param_parts = []
@@ -126,9 +130,9 @@ class HttpClient:
 
             # If we stream an iterator for streaming the content, otherwise return the entire byte array
             if stream:
-                return response
+                return _validate_download_response(response,stream)
 
-            return response.content if response.content else None
+            return _validate_download_response(response) if response.content else None
         except requests.exceptions.Timeout as exc:
             raise NylasSdkTimeoutError(url=request["url"], timeout=timeout) from exc
 

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -45,7 +45,7 @@ def _validate_response(response: Response) -> dict:
 
     return json
 
-def _validate_download_response(response:Response, stream = False) -> Union[bytes, Response, dict]:
+def _validate_download_response(response:Response) -> Union[bytes, Response, dict]:
     if response.ok:
         return response.content
     return _validate_response(response)


### PR DESCRIPTION
# Description
At the moment we are not returning a NylasAPIError exception if we are unable to download the attachment. Which results in customers writing the content to a file. This PR adds a validation for the download request and return an exception if the status code is >=400. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
