### PR TITLE
Release v6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 nylas-python Changelog
 ======================
 
-Unreleased
+v6.7.0
 ----------------
 * Added support for `select` query parameter in list calendars, list events, and list messages.
 


### PR DESCRIPTION
# Changelog
* Added support for `select` query parameter in list calendars, list events, and list messages. https://github.com/nylas/nylas-python/pull/407

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
