### PR TITLE
[Build] Added UV folders to .gitignore + created pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,81 @@
-# Byte-compiled / optimized / DLL files
+# UV virtual environment
+.venv/
+.venv
+
+# UV cache and lock files
+.uv/
+uv.lock
+
+# Python cache and compiled files
 __pycache__/
 *.py[cod]
-
-# C extensions
+*$py.class
 *.so
 
 # Distribution / packaging
 .Python
-env/
-bin/
 build/
 develop-eggs/
 dist/
+downloads/
 eggs/
+.eggs/
+lib/
+lib64/
 parts/
 sdist/
 var/
+wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+# PyInstaller
+*.manifest
+*.spec
 
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Environments
+.env
+.venv
+ENV/
+env/
+venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# macOS
+.DS_Store
+
+# Docs
+docs/_build/
+site/
+
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=69.0.3", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nylas"
+dynamic = ["version"]
+description = "Python bindings for the Nylas API platform."
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Nylas Team", email = "support@nylas.com"}
+]
+keywords = ["inbox", "app", "appserver", "email", "nylas", "contacts", "calendar"]
+requires-python = ">=3.8"
+dependencies = [
+    "requests[security]>=2.31.0",
+    "requests-toolbelt>=1.0.0",
+    "dataclasses-json>=0.5.9",
+    "typing_extensions>=4.7.1",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+    "setuptools>=69.0.3",
+]
+docs = [
+    "mkdocs>=1.5.2",
+    "mkdocstrings[python]>=0.22.0",
+    "mkdocs-material>=9.2.6",
+    "mkdocs-gen-files>=0.5.0",
+    "mkdocs-literate-nav>=0.6.0",
+]
+release = [
+    "bumpversion>=0.6.0",
+    "twine>=4.0.2",
+]
+
+[project.urls]
+Homepage = "https://github.com/nylas/nylas-python"
+Repository = "https://github.com/nylas/nylas-python"
+
+[tool.setuptools.dynamic]
+version = {attr = "nylas._client_sdk_version.__VERSION__"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["nylas*"]


### PR DESCRIPTION
Had a discussion with a customer over a call in the past week and they mentioned this, seems like a quick and simple update we can push to enable more current tooling.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
