### PR TITLE
CUST 4499 python sdk list thread query params missing earliest message date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ nylas-python Changelog
 
 Unreleased
 ----------------
+* Added support for `earliest_message_date` query parameter for threads
 * Added support for new message fields query parameter values: `include_tracking_options` and `raw_mime`
 * Added `tracking_options` field to Message model for message tracking settings
 * Added `raw_mime` field to Message model for Base64url-encoded message data

--- a/nylas/models/threads.py
+++ b/nylas/models/threads.py
@@ -112,6 +112,7 @@ ListThreadsQueryParams = TypedDict(
         "unread": NotRequired[bool],
         "starred": NotRequired[bool],
         "thread_id": NotRequired[str],
+        "earliest_message_date": NotRequired[int],
         "latest_message_before": NotRequired[int],
         "latest_message_after": NotRequired[int],
         "has_attachment": NotRequired[bool],

--- a/nylas/models/threads.py
+++ b/nylas/models/threads.py
@@ -134,6 +134,7 @@ Attributes:
     unread: Filter threads by unread status.
     starred: Filter threads by starred status.
     thread_id: Filter threads by thread_id.
+    earliest_message_date: Unix timestamp of the earliest or first message in the thread.
     latest_message_before: Return threads whose most recent message was received before this Unix timestamp.
     latest_message_after: Return threads whose most recent message was received after this Unix timestamp.
     has_attachment: Filter threads by whether they have an attachment.

--- a/tests/resources/test_threads.py
+++ b/tests/resources/test_threads.py
@@ -188,6 +188,44 @@ class TestThread:
 
         # The actual response validation is handled by the mock in conftest.py
         assert result is not None
+        
+    def test_list_threads_with_earliest_message_date_param(self, http_client_list_response):
+        threads = Threads(http_client_list_response)
+        
+        timestamp = 1672531200
+        
+        http_client_list_response._execute.return_value = {
+            "request_id": "abc-123",
+            "data": [{
+                "id": "thread-123",
+                "has_attachments": False,
+                "earliest_message_date": 1672617600,
+                "participants": [
+                    {"email": "test@example.com", "name": "Test User"}
+                ],
+                "snippet": "Test snippet",
+                "unread": False,
+                "subject": "Test subject",
+                "message_ids": ["msg-123"],
+                "folders": ["folder-123"]
+            }]
+        }
+        
+        result = threads.list(
+            identifier="abc-123",
+            query_params={"earliest_message_date": timestamp}
+        )
+        
+        http_client_list_response._execute.assert_called_with(
+            "GET",
+            "/v3/grants/abc-123/threads",
+            None,
+            {"earliest_message_date": timestamp},
+            None,
+            overrides=None,
+        )
+        
+        assert result is not None
 
     def test_find_thread(self, http_client_response):
         threads = Threads(http_client_response)


### PR DESCRIPTION
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
