### PR TITLE
CUST 4511 - earliest_message_date on models.Thread made optional, tests, added line to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------------
 * Added support for `earliest_message_date` query parameter for threads
+* Fixed `earliest_message_date` not being an optional response field
 * Added support for new message fields query parameter values: `include_tracking_options` and `raw_mime`
 * Added `tracking_options` field to Message model for message tracking settings
 * Added `raw_mime` field to Message model for Base64url-encoded message data

--- a/nylas/models/threads.py
+++ b/nylas/models/threads.py
@@ -65,13 +65,13 @@ class Thread:
     has_drafts: bool
     starred: bool
     unread: bool
-    earliest_message_date: int
     message_ids: List[str]
     folders: List[str]
     latest_draft_or_message: Union[Message, Draft] = field(
         metadata=config(decoder=_decode_draft_or_message)
     )
     object: str = "thread"
+    earliest_message_date: Optional[int] = None
     latest_message_received_date: Optional[int] = None
     draft_ids: Optional[List[str]] = None
     snippet: Optional[str] = None

--- a/tests/resources/test_threads.py
+++ b/tests/resources/test_threads.py
@@ -227,6 +227,53 @@ class TestThread:
         
         assert result is not None
 
+    def test_list_threads_without_earliest_message_date_in_response(self, http_client_list_response):
+        threads = Threads(http_client_list_response)
+        
+        http_client_list_response._execute.return_value = {
+            "request_id": "abc-123",
+            "data": [{
+                "id": "thread-123",
+                "grant_id": "test-grant-id",
+                "has_drafts": False,
+                "starred": False,
+                "unread": False,
+                "message_ids": ["msg-123"],
+                "folders": ["folder-123"],
+                "latest_draft_or_message": {
+                    "body": "Test message body",
+                    "date": 1672617600,
+                    "from": [{"name": "Test User", "email": "test@example.com"}],
+                    "grant_id": "test-grant-id",
+                    "id": "msg-123",
+                    "object": "message",
+                    "subject": "Test subject",
+                    "thread_id": "thread-123",
+                    "to": [{"name": "Recipient", "email": "recipient@example.com"}],
+                    "unread": False,
+                },
+                "has_attachments": False,
+                "participants": [
+                    {"email": "test@example.com", "name": "Test User"}
+                ],
+                "snippet": "Test snippet",
+                "subject": "Test subject"
+            }]
+        }
+        
+        result = threads.list(identifier="abc-123")
+        
+        http_client_list_response._execute.assert_called_with(
+            "GET",
+            "/v3/grants/abc-123/threads",
+            None,
+            None,
+            None,
+            overrides=None,
+        )
+        
+        assert result is not None
+
     def test_find_thread(self, http_client_response):
         threads = Threads(http_client_response)
 


### PR DESCRIPTION


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
