### PR TITLE
CUST-3643 added yahoo, zoom, ews as providers on auth.py for API parity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------
+* Added Yahoo, Zoom, EWS as providers to models/auth.py
+
 v6.11.1
 ----------
 * Fixed KeyError when processing events with empty or incomplete conferencing objects

--- a/nylas/models/auth.py
+++ b/nylas/models/auth.py
@@ -7,7 +7,7 @@ from typing_extensions import TypedDict, NotRequired
 AccessType = Literal["online", "offline"]
 """ Literal for the access type of the authentication URL. """
 
-Provider = Literal["google", "imap", "microsoft", "icloud", "virtual-calendar"]
+Provider = Literal["google", "imap", "microsoft", "icloud", "virtual-calendar", "yahoo", "ews", "zoom"]
 """ Literal for the different authentication providers. """
 
 Prompt = Literal[


### PR DESCRIPTION
Ref: https://developer.nylas.com/docs/api/v3/admin/#tag/authentication-apis/get/v3/connect/auth
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
