### PR TITLE
CUST-4797 from field handles "from" and "from_"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------
+* Fixed from field handling in messages.send() to properly map "from_" field to "from field
+* Added comprehensive tests for from field mapping functionality
+
 v6.12.0
 ----------
 * Added Yahoo, Zoom, EWS as providers to models/auth.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ nylas-python Changelog
 Unreleased
 ----------
 * Fixed from field handling in messages.send() to properly map "from_" field to "from field
-* Added comprehensive tests for from field mapping functionality
 
 v6.12.0
 ----------

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -170,7 +170,11 @@ class Messages(
         json_body = None
 
         # From is a reserved keyword in Python, so we need to pull the data from 'from_' instead
-        request_body["from"] = request_body.get("from_", None)
+        # Handle both dictionary-style "from" and typed "from_" field
+        if "from_" in request_body and "from" not in request_body:
+            request_body["from"] = request_body["from_"]
+            del request_body["from_"]
+        # If "from" already exists, leave it unchanged
 
         # Use form data only if the attachment size is greater than 3mb
         attachment_size = sum(

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -950,3 +950,123 @@ class TestMessage:
             data=None,
             overrides=None,
         ) 
+
+    def test_send_message_with_from_field_mapping(self, http_client_response):
+        """Test that from_ field is properly mapped to from field in request body."""
+        messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from_": [
+                {"name": "Daenerys Targaryen", "email": "daenerys.t@example.com"}
+            ],
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        # Verify that from_ was mapped to from and from_ was removed
+        expected_request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from": [{"name": "Daenerys Targaryen", "email": "daenerys.t@example.com"}],
+        }
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=expected_request_body,
+            data=None,
+            overrides=None,
+        )
+
+    def test_send_message_with_existing_from_field_unchanged(
+        self, http_client_response
+    ):
+        """Test that existing from field is left unchanged when both from and from_ are present."""
+        messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from": [{"name": "Existing Sender", "email": "existing@example.com"}],
+            "from_": [
+                {"name": "Daenerys Targaryen", "email": "daenerys.t@example.com"}
+            ],
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        # Verify that the original from field is preserved and from_ is not processed
+        expected_request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from": [{"name": "Existing Sender", "email": "existing@example.com"}],
+            "from_": [
+                {"name": "Daenerys Targaryen", "email": "daenerys.t@example.com"}
+            ],
+        }
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=expected_request_body,
+            data=None,
+            overrides=None,
+        )
+
+    def test_send_message_with_only_from_field_unchanged(self, http_client_response):
+        """Test that when only from field is present, it remains unchanged."""
+        messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from": [{"name": "Direct Sender", "email": "direct@example.com"}],
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        # Verify that the from field remains unchanged
+        expected_request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+            "from": [{"name": "Direct Sender", "email": "direct@example.com"}],
+        }
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=expected_request_body,
+            data=None,
+            overrides=None,
+        )
+
+    def test_send_message_without_from_fields_unchanged(self, http_client_response):
+        """Test that request body without from or from_ fields remains unchanged."""
+        messages = Messages(http_client_response)
+        request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+        }
+
+        messages.send(identifier="abc-123", request_body=request_body)
+
+        # Verify that the request body remains unchanged
+        expected_request_body = {
+            "subject": "Hello from Nylas!",
+            "to": [{"name": "Jon Snow", "email": "jsnow@gmail.com"}],
+            "body": "This is the body of my message.",
+        }
+
+        http_client_response._execute.assert_called_once_with(
+            method="POST",
+            path="/v3/grants/abc-123/messages/send",
+            request_body=expected_request_body,
+            data=None,
+            overrides=None,
+        )


### PR DESCRIPTION
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Refactor from field handling in messages send

     - Fix critical bug in Python SDK for Gmail message sending with aliases

     - Make from_ field mapping happen on request instead of response

     - Ensure consistent behavior between REST API and SDK usage

     - Allow for proper handling of from field while preserving from_ field
     
 
✅ Tests checks:

 test_send_message_with_from_field_mapping (25%)

 test_send_message_with_existing_from_field_unchanged (50%)

 test_send_message_with_only_from_field_unchanged (75%)

 test_send_message_without_from_fields_unchanged (100%)