### PR TITLE
CUST-4901 added message.deleted to the webhook enum, appended webhook test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 nylas-python Changelog
 ======================
 
+Unreleased
+----------
+* Added `message.deleted` to the Webhook enum, appended tests
+
 v6.13.1
 ----------
 * Fixed UTF-8 character encoding for all API requests to preserve special characters (accented letters, emoji, etc.) instead of escaping them as unicode sequences

--- a/nylas/models/webhooks.py
+++ b/nylas/models/webhooks.py
@@ -33,6 +33,7 @@ class WebhookTriggers(str, Enum):
     MESSAGE_BOUNCE_DETECTED = "message.bounce_detected"
     MESSAGE_CREATED = "message.created"
     MESSAGE_UPDATED = "message.updated"
+    MESSAGE_DELETED= "message.deleted"
     MESSAGE_OPENED = "message.opened"
     MESSAGE_LINK_CLICKED = "message.link_clicked"
     MESSAGE_OPENED_LEGACY = "message.opened.legacy"

--- a/tests/resources/test_webhooks.py
+++ b/tests/resources/test_webhooks.py
@@ -57,6 +57,7 @@ class TestWebhooks:
             "message.bounce_detected",
             "message.created",
             "message.updated",
+            "message.deleted",
             "message.opened",
             "message.link_clicked",
             "message.opened.legacy",


### PR DESCRIPTION


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `message.deleted` to `WebhookTriggers` and updates tests and changelog.
> 
> - **Webhooks**:
>   - Add `WebhookTriggers.MESSAGE_DELETED` (`message.deleted`) in `nylas/models/webhooks.py`.
> - **Tests**:
>   - Update webhook deserialization trigger list to include `message.deleted` in `tests/resources/test_webhooks.py`.
> - **Docs**:
>   - Update `CHANGELOG.md` under Unreleased to note the new webhook trigger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c87e11d69b667e3c5bbcf506c0d70dfbbcccd190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->