### PR TITLE
CUST-4960 Fixed Participant.email not being optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ nylas-python Changelog
 Unreleased
 ----------
 * Added `message.deleted` to the Webhook enum, appended tests
+* Fixed Participant.email not being optional, Microsoft events can now be represented 
 
 v6.13.1
 ----------

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -29,14 +29,14 @@ class Participant:
     Interface representing an Event participant.
 
     Attributes:
-        email: Participant's email address.
+        email: Participant's email address. Required for all providers except Microsoft.
         name: Participant's name.
         status: Participant's status.
         comment: Comment by the participant.
         phone_number: Participant's phone number.
     """
 
-    email: str
+    email: Optional[str] = None
     status: Optional[ParticipantStatus] = None
     name: Optional[str] = None
     comment: Optional[str] = None
@@ -409,7 +409,7 @@ class CreateParticipant(TypedDict):
         phone_number: Participant's phone number.
     """
 
-    email: str
+    email: NotRequired[str]
     name: NotRequired[str]
     comment: NotRequired[str]
     phone_number: NotRequired[str]


### PR DESCRIPTION
For reference: https://developer.nylas.com/docs/api/v3/ecc/?redirect=api#tag/events/post/v3/grants/{grant_id}/events.body.participants

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes event participant email optional (to support Microsoft events) by updating models/types and changelog.
> 
> - **Events Models**:
>   - Update `Participant` dataclass: `email` from `str` to `Optional[str] = None` and clarify docstring.
>   - Update `CreateParticipant` `TypedDict`: `email` from `str` to `NotRequired[str]`.
> - **Changelog**:
>   - Note change that `Participant.email` is now optional to represent Microsoft events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b12b02729b2d47bc68647ccc96a053b15ca37c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->