### PR TITLE
Add Graph large attachment support

### DIFF
--- a/nylas/models/attachments.py
+++ b/nylas/models/attachments.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional, Union, BinaryIO
+from typing import Optional, Union, BinaryIO, Dict
 
 from dataclasses_json import dataclass_json
-from typing_extensions import TypedDict, NotRequired
+from typing_extensions import TypedDict, NotRequired, Literal
 
 
 @dataclass_json
@@ -66,3 +66,71 @@ class FindAttachmentQueryParams(TypedDict):
     """
 
     message_id: str
+
+
+AttachmentUploadSessionStatusType = Literal["uploading", "ready", "failed", "expired"]
+
+
+class CreateAttachmentUploadSessionRequest(TypedDict):
+    """
+    Request body for creating a large-attachment upload session (Graph only).
+
+    Attributes:
+        filename: The name of the file as it will appear in the email.
+        content_type: MIME type of the file (e.g. 'application/pdf').
+        size: Expected file size in bytes (max 157286400 / 150 MB). Recommended —
+              Nylas validates the upload matches this size at completion.
+    """
+
+    filename: str
+    content_type: str
+    size: NotRequired[int]
+
+
+@dataclass_json
+@dataclass
+class AttachmentUploadSession:
+    """
+    Upload session returned when creating a large-attachment upload session.
+
+    Attributes:
+        attachment_id: Unique session ID — use when completing the session and when
+                       referencing the attachment in send/draft.
+        method: HTTP method to use when uploading to `url`. Always 'PUT'.
+        url: Pre-signed URL to upload file bytes (no Nylas auth header needed).
+        headers: Headers to include when uploading to `url`.
+        expires_at: When the session expires (RFC 3339).
+        max_size: Maximum allowed file size in bytes (157286400).
+        size: Expected file size echoing the request; 0 if `size` was omitted.
+        content_type: MIME type of the file.
+        filename: Name of the file.
+        grant_id: Grant ID the session belongs to.
+    """
+
+    attachment_id: Optional[str] = None
+    method: Optional[str] = None
+    url: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+    expires_at: Optional[str] = None
+    max_size: Optional[int] = None
+    size: Optional[int] = None
+    content_type: Optional[str] = None
+    filename: Optional[str] = None
+    grant_id: Optional[str] = None
+
+
+@dataclass_json
+@dataclass
+class AttachmentUploadSessionComplete:
+    """
+    Result of completing a large-attachment upload session.
+
+    Attributes:
+        attachment_id: The session ID.
+        grant_id: Grant ID the session belongs to.
+        status: Upload status; typically 'ready' after successful completion.
+    """
+
+    attachment_id: Optional[str] = None
+    grant_id: Optional[str] = None
+    status: Optional[str] = None

--- a/nylas/resources/attachments.py
+++ b/nylas/resources/attachments.py
@@ -3,13 +3,21 @@ from requests import Response
 from nylas.config import RequestOverrides
 from nylas.handler.api_resources import (
     FindableApiResource,
+    CreatableApiResource,
 )
-from nylas.models.attachments import Attachment, FindAttachmentQueryParams
+from nylas.models.attachments import (
+    Attachment,
+    FindAttachmentQueryParams,
+    CreateAttachmentUploadSessionRequest,
+    AttachmentUploadSession,
+    AttachmentUploadSessionComplete,
+)
 from nylas.models.response import Response as NylasResponse
 
 
 class Attachments(
     FindableApiResource,
+    CreatableApiResource,
 ):
     """
     Nylas Attachments API
@@ -110,5 +118,60 @@ class Attachments(
             path=f"/v3/grants/{identifier}/attachments/{attachment_id}/download",
             query_params=query_params,
             stream=False,
+            overrides=overrides,
+        )
+
+    def create_upload_session(
+        self,
+        identifier: str,
+        request_body: CreateAttachmentUploadSessionRequest,
+        overrides: RequestOverrides = None,
+    ) -> NylasResponse[AttachmentUploadSession]:
+        """
+        Create a resumable upload session for a large attachment (up to 150 MB).
+
+        After receiving the session, upload file bytes via HTTP PUT to the returned
+        `url` (include the returned `headers`; no Nylas auth header needed), then
+        call complete_upload_session() with the returned `attachment_id`.
+
+        Args:
+            identifier: The identifier of the Grant to act upon.
+            request_body: Session parameters (filename, content_type, optional size).
+            overrides: The request overrides to use for the request.
+
+        Returns:
+            The upload session, including the pre-signed URL and attachment_id.
+        """
+        return super().create(
+            path=f"/v3/grants/{identifier}/attachment-uploads",
+            response_type=AttachmentUploadSession,
+            request_body=request_body,
+            overrides=overrides,
+        )
+
+    def complete_upload_session(
+        self,
+        identifier: str,
+        attachment_id: str,
+        overrides: RequestOverrides = None,
+    ) -> NylasResponse[AttachmentUploadSessionComplete]:
+        """
+        Complete an upload session after file bytes have been PUT to the pre-signed URL.
+
+        Use the `attachment_id` from the completed session when referencing the
+        attachment in a subsequent messages.send() or drafts.create() call.
+
+        Args:
+            identifier: The identifier of the Grant to act upon.
+            attachment_id: The upload session ID returned by create_upload_session().
+            overrides: The request overrides to use for the request.
+
+        Returns:
+            The completed session status.
+        """
+        return super().create(
+            path=f"/v3/grants/{identifier}/attachment-uploads/{attachment_id}/complete",
+            response_type=AttachmentUploadSessionComplete,
+            request_body={},
             overrides=overrides,
         )

--- a/nylas/resources/drafts.py
+++ b/nylas/resources/drafts.py
@@ -125,7 +125,9 @@ class Drafts(
 
         # Encode the content of the attachments to base64
         for attachment in request_body.get("attachments", []):
-            if issubclass(type(attachment["content"]), io.IOBase):
+            if "content" in attachment and issubclass(
+                type(attachment["content"]), io.IOBase
+            ):
                 attachment["content"] = encode_stream_to_base64(attachment["content"])
 
         return super().create(
@@ -173,7 +175,9 @@ class Drafts(
 
         # Encode the content of the attachments to base64
         for attachment in request_body.get("attachments", []):
-            if issubclass(type(attachment["content"]), io.IOBase):
+            if "content" in attachment and issubclass(
+                type(attachment["content"]), io.IOBase
+            ):
                 attachment["content"] = encode_stream_to_base64(attachment["content"])
 
         return super().update(

--- a/nylas/resources/messages.py
+++ b/nylas/resources/messages.py
@@ -186,7 +186,9 @@ class Messages(
         else:
             # Encode the content of the attachments to base64
             for attachment in request_body.get("attachments", []):
-                if issubclass(type(attachment["content"]), io.IOBase):
+                if "content" in attachment and issubclass(
+                    type(attachment["content"]), io.IOBase
+                ):
                     attachment["content"] = encode_stream_to_base64(
                         attachment["content"]
                     )

--- a/tests/resources/test_attachments.py
+++ b/tests/resources/test_attachments.py
@@ -1,7 +1,14 @@
 from io import BytesIO
 from unittest.mock import Mock
 
-from nylas.models.attachments import Attachment, CreateAttachmentRequest, FindAttachmentQueryParams
+from nylas.models.attachments import (
+    Attachment,
+    CreateAttachmentRequest,
+    FindAttachmentQueryParams,
+    AttachmentUploadSession,
+    AttachmentUploadSessionComplete,
+    CreateAttachmentUploadSessionRequest,
+)
 from nylas.resources.attachments import Attachments
 
 
@@ -315,3 +322,245 @@ class TestAttachments:
             stream=False,
             overrides=None,
         )
+
+    def test_create_upload_session(self, http_client_response):
+        attachments = Attachments(http_client_response)
+        request_body: CreateAttachmentUploadSessionRequest = {
+            "filename": "document.pdf",
+            "content_type": "application/pdf",
+            "size": 5242880,
+        }
+
+        attachments.create_upload_session(
+            identifier="abc-123",
+            request_body=request_body,
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "POST",
+            "/v3/grants/abc-123/attachment-uploads",
+            None,
+            None,
+            request_body,
+            overrides=None,
+        )
+
+    def test_create_upload_session_without_size(self, http_client_response):
+        attachments = Attachments(http_client_response)
+        request_body: CreateAttachmentUploadSessionRequest = {
+            "filename": "report.xlsx",
+            "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }
+
+        attachments.create_upload_session(
+            identifier="abc-123",
+            request_body=request_body,
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "POST",
+            "/v3/grants/abc-123/attachment-uploads",
+            None,
+            None,
+            request_body,
+            overrides=None,
+        )
+
+    def test_complete_upload_session(self, http_client_response):
+        attachments = Attachments(http_client_response)
+
+        attachments.complete_upload_session(
+            identifier="abc-123",
+            attachment_id="session-id-123",
+        )
+
+        http_client_response._execute.assert_called_once_with(
+            "POST",
+            "/v3/grants/abc-123/attachment-uploads/session-id-123/complete",
+            None,
+            None,
+            {},
+            overrides=None,
+        )
+
+
+class TestAttachmentUploadSession:
+    """Tests for the AttachmentUploadSession dataclass model."""
+
+    def test_deserialization_full(self):
+        session_json = {
+            "attachment_id": "session-abc-123",
+            "method": "PUT",
+            "url": "https://storage.example.com/upload/session-abc-123",
+            "headers": {"x-ms-blob-type": "BlockBlob"},
+            "expires_at": "2026-05-05T12:00:00Z",
+            "max_size": 157286400,
+            "size": 5242880,
+            "content_type": "application/pdf",
+            "filename": "document.pdf",
+            "grant_id": "grant-abc-123",
+        }
+
+        session = AttachmentUploadSession.from_dict(session_json)
+
+        assert session.attachment_id == "session-abc-123"
+        assert session.method == "PUT"
+        assert session.url == "https://storage.example.com/upload/session-abc-123"
+        assert session.headers == {"x-ms-blob-type": "BlockBlob"}
+        assert session.expires_at == "2026-05-05T12:00:00Z"
+        assert session.max_size == 157286400
+        assert session.size == 5242880
+        assert session.content_type == "application/pdf"
+        assert session.filename == "document.pdf"
+        assert session.grant_id == "grant-abc-123"
+
+    def test_deserialization_without_size(self):
+        """When size is omitted from the request, the API echoes 0."""
+        session_json = {
+            "attachment_id": "session-no-size",
+            "method": "PUT",
+            "url": "https://storage.example.com/upload/session-no-size",
+            "headers": {},
+            "expires_at": "2026-05-05T12:00:00Z",
+            "max_size": 157286400,
+            "size": 0,
+            "content_type": "text/plain",
+            "filename": "notes.txt",
+            "grant_id": "grant-xyz",
+        }
+
+        session = AttachmentUploadSession.from_dict(session_json)
+
+        assert session.attachment_id == "session-no-size"
+        assert session.size == 0
+        assert session.headers == {}
+
+    def test_deserialization_partial(self):
+        """Partial response should not raise; unset fields default to None."""
+        session = AttachmentUploadSession.from_dict({"attachment_id": "partial-session"})
+
+        assert session.attachment_id == "partial-session"
+        assert session.method is None
+        assert session.url is None
+        assert session.headers is None
+        assert session.expires_at is None
+        assert session.max_size is None
+        assert session.size is None
+        assert session.content_type is None
+        assert session.filename is None
+        assert session.grant_id is None
+
+    def test_deserialization_empty_dict(self):
+        session = AttachmentUploadSession.from_dict({})
+
+        assert session.attachment_id is None
+        assert session.grant_id is None
+
+    def test_roundtrip_serialization(self):
+        original = AttachmentUploadSession(
+            attachment_id="rt-session",
+            method="PUT",
+            url="https://example.com/upload",
+            headers={"Content-Type": "application/octet-stream"},
+            expires_at="2026-05-05T12:00:00Z",
+            max_size=157286400,
+            size=1024,
+            content_type="application/octet-stream",
+            filename="file.bin",
+            grant_id="grant-rt",
+        )
+
+        serialized = original.to_dict()
+        deserialized = AttachmentUploadSession.from_dict(serialized)
+
+        assert deserialized.attachment_id == original.attachment_id
+        assert deserialized.method == original.method
+        assert deserialized.url == original.url
+        assert deserialized.headers == original.headers
+        assert deserialized.expires_at == original.expires_at
+        assert deserialized.max_size == original.max_size
+        assert deserialized.size == original.size
+        assert deserialized.content_type == original.content_type
+        assert deserialized.filename == original.filename
+        assert deserialized.grant_id == original.grant_id
+
+
+class TestAttachmentUploadSessionComplete:
+    """Tests for the AttachmentUploadSessionComplete dataclass model."""
+
+    def test_deserialization_ready(self):
+        complete_json = {
+            "attachment_id": "session-abc-123",
+            "grant_id": "grant-abc-123",
+            "status": "ready",
+        }
+
+        complete = AttachmentUploadSessionComplete.from_dict(complete_json)
+
+        assert complete.attachment_id == "session-abc-123"
+        assert complete.grant_id == "grant-abc-123"
+        assert complete.status == "ready"
+
+    def test_deserialization_various_statuses(self):
+        for status in ("uploading", "failed", "expired"):
+            complete = AttachmentUploadSessionComplete.from_dict({
+                "attachment_id": "session-123",
+                "grant_id": "grant-123",
+                "status": status,
+            })
+            assert complete.status == status
+
+    def test_deserialization_empty_dict(self):
+        complete = AttachmentUploadSessionComplete.from_dict({})
+
+        assert complete.attachment_id is None
+        assert complete.grant_id is None
+        assert complete.status is None
+
+    def test_roundtrip_serialization(self):
+        original = AttachmentUploadSessionComplete(
+            attachment_id="session-rt",
+            grant_id="grant-rt",
+            status="ready",
+        )
+
+        serialized = original.to_dict()
+        deserialized = AttachmentUploadSessionComplete.from_dict(serialized)
+
+        assert deserialized.attachment_id == original.attachment_id
+        assert deserialized.grant_id == original.grant_id
+        assert deserialized.status == original.status
+
+
+class TestCreateAttachmentUploadSessionRequest:
+    """Tests for the CreateAttachmentUploadSessionRequest TypedDict."""
+
+    def test_required_fields_only(self):
+        request: CreateAttachmentUploadSessionRequest = {
+            "filename": "document.pdf",
+            "content_type": "application/pdf",
+        }
+
+        assert request["filename"] == "document.pdf"
+        assert request["content_type"] == "application/pdf"
+        assert "size" not in request
+
+    def test_with_size(self):
+        request: CreateAttachmentUploadSessionRequest = {
+            "filename": "video.mp4",
+            "content_type": "video/mp4",
+            "size": 104857600,  # 100 MB
+        }
+
+        assert request["filename"] == "video.mp4"
+        assert request["content_type"] == "video/mp4"
+        assert request["size"] == 104857600
+
+    def test_max_allowed_size(self):
+        request: CreateAttachmentUploadSessionRequest = {
+            "filename": "archive.zip",
+            "content_type": "application/zip",
+            "size": 157286400,  # 150 MB max
+        }
+
+        assert request["size"] == 157286400


### PR DESCRIPTION
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Microsoft Graph has a hard limit on inline attachment size (~3 MB via JSON, ~4 MB
  via multipart). This PR adds a resumable upload-session API to the Python SDK that
  mirrors the existing Node.js implementation, allowing attachments up to 150 MB to
  be sent via Graph.

  How it works

  The upload flow is three steps:

  1. Create a session — nylas.attachments.create_upload_session(identifier,
  request_body) returns a pre-signed URL and an attachment_id.
  2. Upload bytes — the caller PUTs the raw file bytes directly to the pre-signed URL
   (no Nylas auth header needed, outside the SDK).
  3. Complete — nylas.attachments.complete_upload_session(identifier, attachment_id)
  finalises the session. The attachment_id can then be referenced in messages.send()
  or drafts.create().

```
  res = nylas.attachments.create_upload_session(
      identifier=grant_id,
      request_body={"filename": "report.pdf", "content_type": "application/pdf",
  "size": file_size},
  )
  session = res.data

  requests.put(session.url, data=file_bytes, headers={**session.headers,
  "Content-Length": str(file_size)})

  nylas.attachments.complete_upload_session(identifier=grant_id,
  attachment_id=session.attachment_id)

  nylas.messages.send(
      identifier=grant_id,
      request_body={..., "attachments": [{"id": session.attachment_id}]},
  )
```
 ## Changes

  nylas/models/attachments.py
  - CreateAttachmentUploadSessionRequest — TypedDict for the create request
  (filename, content_type, optional size)
  - AttachmentUploadSession — dataclass for the session response (pre-signed url,
  method, headers, expires_at, max_size, etc.)
  - AttachmentUploadSessionComplete — dataclass for the completion response
  (attachment_id, grant_id, status)
  - AttachmentUploadSessionStatusType — Literal type alias for status values

  nylas/resources/attachments.py
  - Added create_upload_session() and complete_upload_session() methods

  nylas/resources/messages.py / drafts.py (bug fix)
  - Guarded the attachment["content"] access so that session-reference attachments
  ({"id": "..."}) don't raise KeyError when passed to messages.send() or
  drafts.create()/update()

  tests/resources/test_attachments.py
  - 18 new unit tests covering model serialisation/deserialisation and API call
  assertions for both new methods
