### PR TITLE
Fix JSON Content-Type header for draft and other API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ nylas-python Changelog
 ======================
 Unreleased
 ----------
+* Fix draft and other JSON API requests failing with "only JSON and multipart supported" by sending `Content-Type: application/json` instead of `application/json; charset=utf-8`
 
 v6.15.0
 ----------

--- a/nylas/handler/http_client.py
+++ b/nylas/handler/http_client.py
@@ -209,6 +209,6 @@ class HttpClient:
         if data is not None and data.content_type is not None:
             headers["Content-type"] = data.content_type
         elif response_body is not None:
-            headers["Content-type"] = "application/json; charset=utf-8"
+            headers["Content-type"] = "application/json"
 
         return {**headers, **extra_headers, **override_headers}

--- a/tests/handler/test_http_client.py
+++ b/tests/handler/test_http_client.py
@@ -63,7 +63,7 @@ class TestHttpClient:
             "X-Nylas-API-Wrapper": "python",
             "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
             "Authorization": "Bearer test-key",
-            "Content-type": "application/json; charset=utf-8",
+            "Content-type": "application/json",
         }
 
     def test_build_headers_form_body(self, http_client, patched_version_and_sys):
@@ -200,7 +200,7 @@ class TestHttpClient:
                 "X-Nylas-API-Wrapper": "python",
                 "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
                 "Authorization": "Bearer test-key",
-                "Content-type": "application/json; charset=utf-8",
+                "Content-type": "application/json",
             },
             timeout=60,
             stream=False,
@@ -299,7 +299,7 @@ class TestHttpClient:
                 "X-Nylas-API-Wrapper": "python",
                 "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
                 "Authorization": "Bearer test-key",
-                "Content-type": "application/json; charset=utf-8",
+                "Content-type": "application/json",
                 "test": "header",
             },
             data=b'{"foo": "bar"}',
@@ -332,7 +332,7 @@ class TestHttpClient:
                 "X-Nylas-API-Wrapper": "python",
                 "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
                 "Authorization": "Bearer test-key",
-                "Content-type": "application/json; charset=utf-8",
+                "Content-type": "application/json",
             },
             data=canonical,
             timeout=30,
@@ -347,7 +347,7 @@ class TestHttpClient:
             request_body=None,
             serialized_json_body=b"{}",
         )
-        assert request["headers"]["Content-type"] == "application/json; charset=utf-8"
+        assert request["headers"]["Content-type"] == "application/json"
 
     def test_execute_override_timeout(
         self, http_client, patched_version_and_sys, patched_request
@@ -376,7 +376,7 @@ class TestHttpClient:
                 "X-Nylas-API-Wrapper": "python",
                 "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
                 "Authorization": "Bearer test-key",
-                "Content-type": "application/json; charset=utf-8",
+                "Content-type": "application/json",
                 "test": "header",
             },
             data=b'{"foo": "bar"}',
@@ -466,7 +466,7 @@ class TestHttpClient:
                 "X-Nylas-API-Wrapper": "python",
                 "User-Agent": "Nylas Python SDK 2.0.0 - 1.2.3",
                 "Authorization": "Bearer test-key",
-                "Content-type": "application/json; charset=utf-8",
+                "Content-type": "application/json",
                 "test": "header",
             },
             data=b'{"foo": "bar"}',
@@ -497,6 +497,7 @@ class TestHttpClient:
         assert response_json == {"success": True}
         # Verify that the data is sent as UTF-8 encoded bytes
         call_kwargs = patched_request.call_args[1]
+        assert call_kwargs["headers"]["Content-type"] == "application/json"
         assert "data" in call_kwargs
         sent_data = call_kwargs["data"]
         


### PR DESCRIPTION
Fix draft and other JSON API requests failing with "only JSON and multipart supported" by sending `Content-Type: application/json` instead of `application/json; charset=utf-8`.

The Nylas API rejects requests whose `Content-Type` includes a charset parameter. This change updates `HttpClient._build_headers` to set the header to `application/json` only, updates related test expectations, and adds a CHANGELOG entry under Unreleased.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.