### PR TITLE
[TW-5588] Support callback URIs in application updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 * Aligned Lists create support with the public `POST /v3/lists` schema and added create response/schema coverage
 * Added Manage Domains service-account auth support with canonical signed request bodies, bearer-auth suppression, encoded domain path segments, and `dmarc`/`arc` verification types
 * Added Workspaces resource (`client.workspaces`) with `list`, `find`, `create`, `update` (PATCH), `destroy`, `auto_group`, `manual_assign`, `default`, `policy_id`, and `rule_ids`
+* Corrected Applications `update` to accept `callback_uris` with callback URI IDs for preserving existing callback URIs
 * Corrected RedirectUris `update` to use PATCH instead of PUT; added `deleted_at` to the RedirectUri model and made `platform` optional on create
 * Verified and extended Applications: added `update` (PATCH `/v3/applications`) and public response fields (`idp_settings`, hosted-authentication legal URLs, `domain`, `blocked`, timestamps)
 * Fix draft and other JSON API requests failing with "only JSON and multipart supported" by sending `Content-Type: application/json` instead of `application/json; charset=utf-8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Unreleased
 ----------
 * Aligned Lists create support with the public `POST /v3/lists` schema and added create response/schema coverage
 * Added Manage Domains service-account auth support with canonical signed request bodies, bearer-auth suppression, encoded domain path segments, and `dmarc`/`arc` verification types
-* Added Workspaces resource (`client.workspaces`) with `list`, `find`, `create`, `update` (PATCH), `destroy`, `auto_group`, `manual_assign`, `default`, `policy_id`, and `rule_ids`
+* Added Workspaces resource (`client.workspaces`) with `list`, `find`, `create`, `update` (PATCH), `destroy`, `auto_group`, `manual_assign`, `invalid_also`, `default`, `policy_id`, and `rule_ids`
 * Corrected Applications `update` to accept `callback_uris` with callback URI IDs for preserving existing callback URIs
 * Corrected RedirectUris `update` to use PATCH instead of PUT; added `deleted_at` to the RedirectUri model and made `platform` optional on create
 * Verified and extended Applications: added `update` (PATCH `/v3/applications`) and public response fields (`idp_settings`, hosted-authentication legal URLs, `domain`, `blocked`, timestamps)

--- a/nylas/models/application_details.py
+++ b/nylas/models/application_details.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 from dataclasses_json import dataclass_json
 from typing_extensions import TypedDict, NotRequired
 
-from nylas.models.redirect_uri import RedirectUri
+from nylas.models.redirect_uri import RedirectUri, WritableRedirectUriSettings
 
 Region = str
 """ The Nylas API region (free-form string, e.g. ``us``, ``eu``). """
@@ -196,20 +196,35 @@ class WritableAdditionalSettings(TypedDict):
     allow_query_param_in_redirect_uri: NotRequired[bool]
 
 
+class UpdateApplicationRedirectUriRequest(TypedDict):
+    """
+    Class representing a callback URI provided for an update application call.
+
+    Attributes:
+        id: Existing callback URI ID. Include this when preserving or updating an existing URI.
+        url: Redirect URL.
+        platform: Platform identifier. Optional; defaults to "web" server-side.
+        settings: Optional settings for the redirect URI.
+    """
+
+    id: NotRequired[str]
+    url: str
+    platform: NotRequired[str]
+    settings: NotRequired[WritableRedirectUriSettings]
+
+
 class UpdateApplicationRequest(TypedDict):
     """
     Class representing a request to update a Nylas application.
 
     Note:
-        ``callback_uris`` / ``redirect_uris`` cannot be set via this request; the
-        server silently ignores them. Manage callback URIs via the dedicated
-        redirect-uris endpoints. ``additional_settings`` is write-only and is
-        stripped from the response.
+        ``additional_settings`` is write-only and is stripped from the response.
 
     Attributes:
         branding: Branding details for the application.
         hosted_authentication: Hosted authentication branding details.
         idp_settings: Identity provider settings.
+        callback_uris: List of callback URIs for the application.
         domain: The white-label domain associated with the application.
         additional_settings: Additional (write-only) application settings.
     """
@@ -217,5 +232,6 @@ class UpdateApplicationRequest(TypedDict):
     branding: NotRequired[WritableBranding]
     hosted_authentication: NotRequired[WritableHostedAuthentication]
     idp_settings: NotRequired[WritableIdpSettings]
+    callback_uris: NotRequired[List[UpdateApplicationRedirectUriRequest]]
     domain: NotRequired[str]
     additional_settings: NotRequired[WritableAdditionalSettings]

--- a/nylas/resources/applications.py
+++ b/nylas/resources/applications.py
@@ -51,8 +51,6 @@ class Applications(UpdatablePatchApiResource):
         Update the application information.
 
         Note:
-            ``callback_uris`` / ``redirect_uris`` cannot be updated here; the server
-            silently ignores them. Use the redirect URIs endpoints instead.
             ``additional_settings`` is write-only and is stripped from the response.
 
         Args:

--- a/tests/resources/test_applications.py
+++ b/tests/resources/test_applications.py
@@ -173,6 +173,13 @@ class TestApplications:
             "branding": {"name": "Updated application"},
             "hosted_authentication": {"title": "Welcome"},
             "idp_settings": {"origins": "https://a.com"},
+            "callback_uris": [
+                {
+                    "id": "0556d035-6cb6-4262-a035-6b77e11cf8fc",
+                    "url": "https://example.com/callback",
+                    "platform": "web",
+                }
+            ],
             "domain": "auth.example.com",
             "additional_settings": {"rotate_refresh_token": True},
         }


### PR DESCRIPTION
## Context
Follow-up to the review feedback on nylas-java#327. `PATCH /v3/applications` accepts `callback_uris`, and callers need to include an existing callback URI `id` when preserving or updating entries. The Python SDK typed request model did not expose that shape.

## Summary
- Add `UpdateApplicationRedirectUriRequest` with optional `id`, `platform`, and `settings`.
- Add `callback_uris` to `UpdateApplicationRequest` and remove stale docs saying callback URIs are ignored.
- Cover forwarding a `callback_uris` entry with an existing `id` in the application update test.
- Update the Unreleased changelog for application callback URI preservation and `invalid_also` workspace auto-group support.

## Testing
- `.venv/bin/black --check nylas/models/application_details.py nylas/resources/applications.py tests/resources/test_applications.py`
- `.venv/bin/python -m pytest tests/resources/test_applications.py -q`
- GitHub Actions: passing