### PR TITLE
docs: add Nylas banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://www.nylas.com/">
-    <img src="/diagrams/nylas-logo.png" alt="Nylas" height="80" />
+    <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
   </a>
 
   <h1>Nylas Python SDK</h1>


### PR DESCRIPTION
Swaps the small centered logo for the full-width Nylas banner, matching the org profile branding ([nylas/.github#4](https://github.com/nylas/.github/pull/4)).

Nothing else changes — the SDK header, badges, nav links, product row, and Agent Accounts link are all already in place. This is the banner-only delta to bring the SDK READMEs in line with the new house style (wide banner + SDK header).

Banner asset is the same `user-attachments` image used on the org profile, so it renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)