### PR TITLE
TDT-2789 Clarify event visibility default is Google-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ nylas-python Changelog
 ======================
 Unreleased
 ----------
+* Clarify that event `default` visibility is Google-only
 
 v6.16.0
 ----------

--- a/nylas/models/events.py
+++ b/nylas/models/events.py
@@ -10,7 +10,13 @@ Status = Literal["confirmed", "tentative", "cancelled"]
 """ Literal representing the status of an Event. """
 
 Visibility = Literal["default", "public", "private"]
-""" Literal representation of visibility of the Event. """
+"""
+Literal representation of visibility of the Event.
+
+`default` is only valid for Google events, where it defers to the calendar's own sharing
+settings. Microsoft and EWS events only support `public` and `private`; sending `default`
+for these providers returns a 400 error.
+"""
 
 ParticipantStatus = Literal["noreply", "yes", "no", "maybe"]
 """ Literal representing the status of an Event participant. """


### PR DESCRIPTION
## What

Updates the docstring for the `Visibility` type in `nylas/models/events.py` to note that `default` only works for Google events. Microsoft and EWS accounts return a 400 error when `default` is sent, but the type hint didn't warn about this.

Jira: TDT-2789 (sub-task of TDT-2765)

🤖 Generated with [Claude Code](https://claude.com/claude-code)