### PR TITLE
Add tentative_as_busy field to GetFreeBusyRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ----------
 * Clarify that event `default` visibility is Google-only
 * Added `resources` field to Event, CreateEventRequest, and UpdateEventRequest models
+* Added tentative_as_busy field to GetFreeBusyRequest
 
 v6.16.0
 ----------

--- a/nylas/models/free_busy.py
+++ b/nylas/models/free_busy.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List, Union
 
 from dataclasses_json import dataclass_json
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, NotRequired
 
 
 @dataclass_json
@@ -64,8 +64,11 @@ class GetFreeBusyRequest(TypedDict):
         start_time: Unix timestamp for the start time to check free/busy for.
         end_time: Unix timestamp for the end time to check free/busy for.
         emails: List of email addresses to check free/busy for.
+        tentative_as_busy: When set to false, treats tentative calendar events as busy:false.
+            Only applicable for Microsoft and EWS calendar providers. Defaults to true.
     """
 
     start_time: int
     end_time: int
     emails: List[str]
+    tentative_as_busy: NotRequired[bool]

--- a/tests/resources/test_calendars.py
+++ b/tests/resources/test_calendars.py
@@ -437,3 +437,27 @@ class TestCalendar:
             overrides=None,
         )
 
+    def test_get_free_busy_with_tentative_as_busy(self, http_client_free_busy):
+        calendars = Calendars(http_client_free_busy)
+        free_busy_request = {
+            "emails": ["test@gmail.com", "test2@gmail.com"],
+            "start_time": 1497916800,
+            "end_time": 1498003200,
+            "tentative_as_busy": False,
+        }
+
+        # Http client is mocked in conftest.py, specific
+        # mock for free busy is configured there
+        calendars.get_free_busy(
+            identifier="abc123", request_body=free_busy_request, overrides=None
+        )
+
+        http_client_free_busy._execute.assert_called_once_with(
+            "POST",
+            "/v3/grants/abc123/calendars/free-busy",
+            None,
+            None,
+            free_busy_request,
+            overrides=None,
+        )
+


### PR DESCRIPTION
## Summary

Adds an optional `tentative_as_busy: NotRequired[bool]` field to the `GetFreeBusyRequest` TypedDict in `nylas/models/free_busy.py`. This field already existed on the Events query params and Availability models, but was missing from the free-busy request.

When set to `false`, tentative calendar events are treated as `busy: false`. Only applicable for Microsoft and EWS calendar providers; defaults to `true`.

## Changes

- `nylas/models/free_busy.py`: import `NotRequired` from `typing_extensions` and add `tentative_as_busy: NotRequired[bool]` to `GetFreeBusyRequest`, with a matching docstring entry.
- `tests/resources/test_calendars.py`: add `test_get_free_busy_with_tentative_as_busy` verifying the field is passed through in the request body.

## Testing

- `python -m pytest tests/resources/test_calendars.py -k "free_busy"` — 2 passed.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.